### PR TITLE
feat: add user-facing token and session management features

### DIFF
--- a/internal/handlers/session.go
+++ b/internal/handlers/session.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/appleboy/authgate/internal/services"
+
+	"github.com/gin-gonic/gin"
+)
+
+type SessionHandler struct {
+	tokenService *services.TokenService
+}
+
+func NewSessionHandler(ts *services.TokenService) *SessionHandler {
+	return &SessionHandler{tokenService: ts}
+}
+
+// ListSessions shows all active sessions (tokens) for the current user
+func (h *SessionHandler) ListSessions(c *gin.Context) {
+	userID, exists := c.Get("user_id")
+	if !exists {
+		c.HTML(http.StatusUnauthorized, "error.html", gin.H{
+			"Error": "User not authenticated",
+		})
+		return
+	}
+
+	tokens, err := h.tokenService.GetUserTokensWithClient(userID.(string))
+	if err != nil {
+		c.HTML(http.StatusInternalServerError, "error.html", gin.H{
+			"Error": "Failed to retrieve sessions",
+		})
+		return
+	}
+
+	// Get CSRF token from context (set by middleware)
+	csrfToken, _ := c.Get("csrf_token")
+
+	c.HTML(http.StatusOK, "account/sessions.html", gin.H{
+		"Sessions":   tokens,
+		"csrf_token": csrfToken,
+	})
+}
+
+// RevokeSession revokes a specific session by token ID
+func (h *SessionHandler) RevokeSession(c *gin.Context) {
+	userID, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error": "User not authenticated",
+		})
+		return
+	}
+
+	tokenID := c.Param("id")
+	if tokenID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Token ID is required",
+		})
+		return
+	}
+
+	// Verify that this token belongs to the current user
+	tokens, err := h.tokenService.GetUserTokens(userID.(string))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Failed to retrieve sessions",
+		})
+		return
+	}
+
+	found := false
+	for _, token := range tokens {
+		if token.ID == tokenID {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": "You don't have permission to revoke this token",
+		})
+		return
+	}
+
+	// Revoke the token
+	if err := h.tokenService.RevokeTokenByID(tokenID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Failed to revoke session",
+		})
+		return
+	}
+
+	c.Redirect(http.StatusFound, "/account/sessions")
+}
+
+// RevokeAllSessions revokes all sessions for the current user
+func (h *SessionHandler) RevokeAllSessions(c *gin.Context) {
+	userID, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error": "User not authenticated",
+		})
+		return
+	}
+
+	if err := h.tokenService.RevokeAllUserTokens(userID.(string)); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Failed to revoke all sessions",
+		})
+		return
+	}
+
+	c.Redirect(http.StatusFound, "/account/sessions")
+}

--- a/internal/services/token_test.go
+++ b/internal/services/token_test.go
@@ -260,3 +260,271 @@ func TestValidateToken_WrongSecret(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, claims)
 }
+
+func TestRevokeToken_Success(t *testing.T) {
+	s := setupTestStore(t)
+	cfg := &config.Config{
+		DeviceCodeExpiration: 30 * time.Minute,
+		PollingInterval:      5,
+		JWTExpiration:        1 * time.Hour,
+		JWTSecret:            "test-secret",
+		BaseURL:              "http://localhost:8080",
+	}
+	tokenService := NewTokenService(s, cfg)
+
+	// Create an active client and get a token
+	client := createTestClient(t, s, true)
+	dc := createAuthorizedDeviceCode(t, s, client.ClientID)
+	token, err := tokenService.ExchangeDeviceCode(dc.DeviceCode, client.ClientID)
+	require.NoError(t, err)
+
+	// Revoke the token
+	err = tokenService.RevokeToken(token.Token)
+
+	// Assert
+	assert.NoError(t, err)
+
+	// Verify token is removed from database
+	_, err = s.GetAccessToken(token.Token)
+	assert.Error(t, err) // Should not be found
+}
+
+func TestRevokeToken_InvalidToken(t *testing.T) {
+	s := setupTestStore(t)
+	cfg := &config.Config{
+		JWTSecret: "test-secret",
+	}
+	tokenService := NewTokenService(s, cfg)
+
+	// Try to revoke a non-existent token
+	err := tokenService.RevokeToken("non-existent-token")
+
+	// Assert
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "token not found")
+}
+
+func TestRevokeTokenByID_Success(t *testing.T) {
+	s := setupTestStore(t)
+	cfg := &config.Config{
+		DeviceCodeExpiration: 30 * time.Minute,
+		PollingInterval:      5,
+		JWTExpiration:        1 * time.Hour,
+		JWTSecret:            "test-secret",
+		BaseURL:              "http://localhost:8080",
+	}
+	tokenService := NewTokenService(s, cfg)
+
+	// Create an active client and get a token
+	client := createTestClient(t, s, true)
+	dc := createAuthorizedDeviceCode(t, s, client.ClientID)
+	token, err := tokenService.ExchangeDeviceCode(dc.DeviceCode, client.ClientID)
+	require.NoError(t, err)
+
+	// Revoke the token by ID
+	err = tokenService.RevokeTokenByID(token.ID)
+
+	// Assert
+	assert.NoError(t, err)
+
+	// Verify token is removed from database
+	_, err = s.GetAccessTokenByID(token.ID)
+	assert.Error(t, err) // Should not be found
+}
+
+func TestGetUserTokens_Success(t *testing.T) {
+	s := setupTestStore(t)
+	cfg := &config.Config{
+		DeviceCodeExpiration: 30 * time.Minute,
+		PollingInterval:      5,
+		JWTExpiration:        1 * time.Hour,
+		JWTSecret:            "test-secret",
+		BaseURL:              "http://localhost:8080",
+	}
+	tokenService := NewTokenService(s, cfg)
+	deviceService := NewDeviceService(s, cfg)
+
+	// Create an active client
+	client := createTestClient(t, s, true)
+	userID := uuid.New().String()
+
+	// Generate and authorize multiple device codes
+	dc1, err := deviceService.GenerateDeviceCode(client.ClientID, "read")
+	require.NoError(t, err)
+	err = deviceService.AuthorizeDeviceCode(dc1.UserCode, userID)
+	require.NoError(t, err)
+
+	dc2, err := deviceService.GenerateDeviceCode(client.ClientID, "write")
+	require.NoError(t, err)
+	err = deviceService.AuthorizeDeviceCode(dc2.UserCode, userID)
+	require.NoError(t, err)
+
+	// Exchange for tokens
+	token1, err := tokenService.ExchangeDeviceCode(dc1.DeviceCode, client.ClientID)
+	require.NoError(t, err)
+	token2, err := tokenService.ExchangeDeviceCode(dc2.DeviceCode, client.ClientID)
+	require.NoError(t, err)
+
+	// Get user tokens
+	tokens, err := tokenService.GetUserTokens(userID)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Len(t, tokens, 2)
+	assert.Contains(t, []string{token1.ID, token2.ID}, tokens[0].ID)
+	assert.Contains(t, []string{token1.ID, token2.ID}, tokens[1].ID)
+}
+
+func TestRevokeAllUserTokens_Success(t *testing.T) {
+	s := setupTestStore(t)
+	cfg := &config.Config{
+		DeviceCodeExpiration: 30 * time.Minute,
+		PollingInterval:      5,
+		JWTExpiration:        1 * time.Hour,
+		JWTSecret:            "test-secret",
+		BaseURL:              "http://localhost:8080",
+	}
+	tokenService := NewTokenService(s, cfg)
+	deviceService := NewDeviceService(s, cfg)
+
+	// Create an active client
+	client := createTestClient(t, s, true)
+	userID := uuid.New().String()
+
+	// Generate and authorize multiple device codes
+	dc1, err := deviceService.GenerateDeviceCode(client.ClientID, "read")
+	require.NoError(t, err)
+	err = deviceService.AuthorizeDeviceCode(dc1.UserCode, userID)
+	require.NoError(t, err)
+
+	dc2, err := deviceService.GenerateDeviceCode(client.ClientID, "write")
+	require.NoError(t, err)
+	err = deviceService.AuthorizeDeviceCode(dc2.UserCode, userID)
+	require.NoError(t, err)
+
+	// Exchange for tokens
+	_, err = tokenService.ExchangeDeviceCode(dc1.DeviceCode, client.ClientID)
+	require.NoError(t, err)
+	_, err = tokenService.ExchangeDeviceCode(dc2.DeviceCode, client.ClientID)
+	require.NoError(t, err)
+
+	// Revoke all user tokens
+	err = tokenService.RevokeAllUserTokens(userID)
+	assert.NoError(t, err)
+
+	// Verify all tokens are removed
+	tokens, err := tokenService.GetUserTokens(userID)
+	assert.NoError(t, err)
+	assert.Len(t, tokens, 0)
+}
+
+func TestGetUserTokensWithClient_Success(t *testing.T) {
+	s := setupTestStore(t)
+	cfg := &config.Config{
+		DeviceCodeExpiration: 30 * time.Minute,
+		PollingInterval:      5,
+		JWTExpiration:        1 * time.Hour,
+		JWTSecret:            "test-secret",
+		BaseURL:              "http://localhost:8080",
+	}
+	tokenService := NewTokenService(s, cfg)
+	deviceService := NewDeviceService(s, cfg)
+
+	// Create an active client
+	client := createTestClient(t, s, true)
+	userID := uuid.New().String()
+
+	// Generate and authorize device code
+	dc, err := deviceService.GenerateDeviceCode(client.ClientID, "read write")
+	require.NoError(t, err)
+	err = deviceService.AuthorizeDeviceCode(dc.UserCode, userID)
+	require.NoError(t, err)
+
+	// Exchange for token
+	token, err := tokenService.ExchangeDeviceCode(dc.DeviceCode, client.ClientID)
+	require.NoError(t, err)
+
+	// Get user tokens with client info
+	tokensWithClient, err := tokenService.GetUserTokensWithClient(userID)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Len(t, tokensWithClient, 1)
+	assert.Equal(t, token.ID, tokensWithClient[0].ID)
+	assert.Equal(t, client.ClientName, tokensWithClient[0].ClientName)
+	assert.Equal(t, "read write", tokensWithClient[0].Scopes)
+}
+
+func TestGetUserTokensWithClient_MultipleClients(t *testing.T) {
+	s := setupTestStore(t)
+	cfg := &config.Config{
+		DeviceCodeExpiration: 30 * time.Minute,
+		PollingInterval:      5,
+		JWTExpiration:        1 * time.Hour,
+		JWTSecret:            "test-secret",
+		BaseURL:              "http://localhost:8080",
+	}
+	tokenService := NewTokenService(s, cfg)
+	deviceService := NewDeviceService(s, cfg)
+
+	// Create two different clients
+	client1 := createTestClient(t, s, true)
+	client2 := createTestClient(t, s, true)
+	userID := uuid.New().String()
+
+	// Generate and authorize tokens for both clients
+	dc1, err := deviceService.GenerateDeviceCode(client1.ClientID, "read")
+	require.NoError(t, err)
+	err = deviceService.AuthorizeDeviceCode(dc1.UserCode, userID)
+	require.NoError(t, err)
+
+	dc2, err := deviceService.GenerateDeviceCode(client2.ClientID, "write")
+	require.NoError(t, err)
+	err = deviceService.AuthorizeDeviceCode(dc2.UserCode, userID)
+	require.NoError(t, err)
+
+	// Exchange for tokens
+	token1, err := tokenService.ExchangeDeviceCode(dc1.DeviceCode, client1.ClientID)
+	require.NoError(t, err)
+	token2, err := tokenService.ExchangeDeviceCode(dc2.DeviceCode, client2.ClientID)
+	require.NoError(t, err)
+
+	// Get user tokens with client info (should use WHERE IN for batch query)
+	tokensWithClient, err := tokenService.GetUserTokensWithClient(userID)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Len(t, tokensWithClient, 2)
+
+	// Create maps for easier verification
+	tokenMap := make(map[string]TokenWithClient)
+	for _, twc := range tokensWithClient {
+		tokenMap[twc.ID] = twc
+	}
+
+	// Verify token 1
+	assert.Contains(t, tokenMap, token1.ID)
+	assert.Equal(t, client1.ClientName, tokenMap[token1.ID].ClientName)
+	assert.Equal(t, "read", tokenMap[token1.ID].Scopes)
+
+	// Verify token 2
+	assert.Contains(t, tokenMap, token2.ID)
+	assert.Equal(t, client2.ClientName, tokenMap[token2.ID].ClientName)
+	assert.Equal(t, "write", tokenMap[token2.ID].Scopes)
+}
+
+func TestGetUserTokensWithClient_EmptyResult(t *testing.T) {
+	s := setupTestStore(t)
+	cfg := &config.Config{
+		JWTSecret: "test-secret",
+	}
+	tokenService := NewTokenService(s, cfg)
+
+	// Get tokens for non-existent user
+	tokensWithClient, err := tokenService.GetUserTokensWithClient("non-existent-user")
+
+	// Assert
+	assert.NoError(t, err)
+	assert.NotNil(t, tokensWithClient)
+	assert.Len(t, tokensWithClient, 0)
+}

--- a/internal/static/style.css
+++ b/internal/static/style.css
@@ -68,13 +68,15 @@ h1 {
     color: #333;
 }
 
-.logout-link {
+.logout-link,
+.sessions-link {
     color: #667eea;
     text-decoration: none;
     margin-left: 8px;
 }
 
-.logout-link:hover {
+.logout-link:hover,
+.sessions-link:hover {
     text-decoration: underline;
 }
 

--- a/internal/templates/account/sessions.html
+++ b/internal/templates/account/sessions.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Active Sessions - OAuth Device Flow</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <div class="container">
+        <div class="card">
+            <div class="header">
+                <h1>Active Sessions</h1>
+                <div class="header-actions">
+                    <a href="/device" class="btn btn-secondary">Back to Device Authorization</a>
+                    <a href="/logout" class="btn btn-secondary">Logout</a>
+                </div>
+            </div>
+
+            <p class="subtitle">Manage devices that have access to your account</p>
+
+            {{if .Sessions}}
+            <div class="sessions-list">
+                <div class="sessions-header">
+                    <h3>Authorized Devices</h3>
+                    <form method="POST" action="/account/sessions/revoke-all" style="display: inline;">
+                        <input type="hidden" name="csrf_token" value="{{.csrf_token}}">
+                        <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm('Are you sure you want to revoke all sessions? This will log out all your devices.')">
+                            Revoke All
+                        </button>
+                    </form>
+                </div>
+
+                <div class="sessions-grid">
+                    {{range .Sessions}}
+                    <div class="session-item">
+                        <div class="session-info">
+                            <div class="session-client">
+                                <strong>Client:</strong> <span class="client-name">{{.ClientName}}</span>
+                            </div>
+                            <div class="session-client-id">
+                                <strong>Client ID:</strong> <span class="client-id-text">{{.ClientID}}</span>
+                            </div>
+                            <div class="session-scopes">
+                                <strong>Scopes:</strong> <span class="badge">{{.Scopes}}</span>
+                            </div>
+                            <div class="session-dates">
+                                <div><strong>Created:</strong> {{.CreatedAt.Format "2006-01-02 15:04:05"}}</div>
+                                <div><strong>Expires:</strong> {{.ExpiresAt.Format "2006-01-02 15:04:05"}}</div>
+                            </div>
+                            {{if .IsExpired}}
+                            <div class="session-status expired">Expired</div>
+                            {{else}}
+                            <div class="session-status active">Active</div>
+                            {{end}}
+                        </div>
+                        <div class="session-actions">
+                            <form method="POST" action="/account/sessions/{{.ID}}/revoke">
+                                <input type="hidden" name="csrf_token" value="{{$.csrf_token}}">
+                                <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm('Are you sure you want to revoke this session?')">
+                                    Revoke
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                    {{end}}
+                </div>
+            </div>
+            {{else}}
+            <div class="alert alert-info">
+                You don't have any active sessions. Authorize a device to see it here.
+            </div>
+            {{end}}
+        </div>
+    </div>
+
+    <style>
+        .sessions-list {
+            margin-top: 2rem;
+        }
+
+        .sessions-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 1.5rem;
+            padding-bottom: 1rem;
+            border-bottom: 2px solid #e5e7eb;
+        }
+
+        .sessions-header h3 {
+            margin: 0;
+            color: #1f2937;
+        }
+
+        .sessions-grid {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .session-item {
+            border: 1px solid #e5e7eb;
+            border-radius: 8px;
+            padding: 1.5rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            background: #fafafa;
+            transition: box-shadow 0.2s;
+        }
+
+        .session-item:hover {
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .session-info {
+            flex: 1;
+        }
+
+        .session-client,
+        .session-client-id,
+        .session-scopes,
+        .session-dates {
+            margin-bottom: 0.75rem;
+        }
+
+        .client-name {
+            color: #667eea;
+            font-weight: 600;
+            font-size: 1.1rem;
+        }
+
+        .client-id-text {
+            font-family: 'Monaco', 'Menlo', monospace;
+            font-size: 0.875rem;
+            color: #6b7280;
+        }
+
+        .session-dates {
+            display: flex;
+            gap: 2rem;
+            font-size: 0.875rem;
+            color: #6b7280;
+        }
+
+        .session-status {
+            display: inline-block;
+            padding: 0.25rem 0.75rem;
+            border-radius: 12px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .session-status.active {
+            background-color: #d1fae5;
+            color: #065f46;
+        }
+
+        .session-status.expired {
+            background-color: #fee2e2;
+            color: #991b1b;
+        }
+
+        .badge {
+            display: inline-block;
+            padding: 0.25rem 0.5rem;
+            background-color: #dbeafe;
+            color: #1e40af;
+            border-radius: 4px;
+            font-size: 0.875rem;
+        }
+
+        .header-actions {
+            display: flex;
+            gap: 0.5rem;
+        }
+
+        .btn-sm {
+            padding: 0.5rem 1rem;
+            font-size: 0.875rem;
+        }
+
+        .btn-danger {
+            background-color: #dc2626;
+            color: white;
+        }
+
+        .btn-danger:hover {
+            background-color: #b91c1c;
+        }
+    </style>
+</body>
+</html>

--- a/internal/templates/device.html
+++ b/internal/templates/device.html
@@ -14,6 +14,7 @@
                 {{if .username}}
                 <div class="user-info">
                     Logged in as <strong>{{.username}}</strong>
+                    <a href="/account/sessions" class="sessions-link">Active Sessions</a>
                     <a href="/logout" class="logout-link">Logout</a>
                 </div>
                 {{if .is_admin}}


### PR DESCRIPTION
- Add RFC 7009-compliant token revocation endpoint and logic
- Implement user session management: view, revoke individual, and revoke all active sessions
- Create session management web UI for users to manage device authorizations
- Add backend support for batch querying client info for user tokens to avoid N+1 queries
- Extend database layer with token and session revocation methods
- Update styles and navigation to support session management features
- Add comprehensive tests for token revocation and session listing functions
- Update documentation to describe token revocation and session management workflows