### PR TITLE
feat: strengthen device code security and switch to hash-based storage

### DIFF
--- a/internal/models/device_code.go
+++ b/internal/models/device_code.go
@@ -5,17 +5,21 @@ import (
 )
 
 type DeviceCode struct {
-	DeviceCode   string `gorm:"primaryKey"`
-	UserCode     string `gorm:"uniqueIndex;not null"`
-	ClientID     string `gorm:"not null;index"`
-	Scopes       string `gorm:"not null"` // space-separated scopes
-	ExpiresAt    time.Time
-	Interval     int    // polling interval in seconds
-	UserID       string // filled after authorization
-	Authorized   bool   `gorm:"default:false"`
-	AuthorizedAt time.Time
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	ID             int64  `gorm:"primaryKey;autoIncrement"`
+	DeviceCode     string `gorm:"-"`                    // Not stored in DB, only for in-memory use
+	DeviceCodeHash string `gorm:"uniqueIndex;not null"` // PBKDF2 hash of device code
+	DeviceCodeSalt string `gorm:"not null"`             // Random salt for hashing
+	DeviceCodeID   string `gorm:"index;not null"`       // Last 8 chars for quick lookup
+	UserCode       string `gorm:"uniqueIndex;not null"`
+	ClientID       string `gorm:"not null;index"`
+	Scopes         string `gorm:"not null"` // space-separated scopes
+	ExpiresAt      time.Time
+	Interval       int    // polling interval in seconds
+	UserID         string // filled after authorization
+	Authorized     bool   `gorm:"default:false"`
+	AuthorizedAt   time.Time
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 func (d *DeviceCode) IsExpired() bool {

--- a/internal/services/device_security_test.go
+++ b/internal/services/device_security_test.go
@@ -1,0 +1,243 @@
+package services
+
+import (
+	"crypto/subtle"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/appleboy/authgate/internal/config"
+	"github.com/appleboy/authgate/internal/models"
+	"github.com/appleboy/authgate/internal/store"
+	"github.com/appleboy/authgate/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestService(t *testing.T) (*DeviceService, *models.OAuthClient) {
+	st, err := store.New("sqlite", ":memory:")
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		DeviceCodeExpiration: 30 * time.Minute,
+		PollingInterval:      5,
+	}
+	service := NewDeviceService(st, cfg)
+
+	// Create test client
+	client := &models.OAuthClient{
+		ClientID:   "test-client-id",
+		ClientName: "Test Client",
+		IsActive:   true,
+	}
+	err = st.CreateClient(client)
+	require.NoError(t, err)
+
+	return service, client
+}
+
+func TestDeviceCodeHashing(t *testing.T) {
+	service, client := setupTestService(t)
+
+	t.Run("DeviceCode field not stored in database", func(t *testing.T) {
+		dc, err := service.GenerateDeviceCode(client.ClientID, "read")
+		require.NoError(t, err)
+		assert.NotEmpty(t, dc.DeviceCode, "DeviceCode field should be populated")
+		assert.Len(t, dc.DeviceCode, 40, "DeviceCode should be 40 hex chars")
+
+		// Query database directly - should not find plaintext
+		var dbRecord models.DeviceCode
+		err = service.store.DB().Where("device_code_id = ?", dc.DeviceCodeID).First(&dbRecord).Error
+		require.NoError(t, err)
+		assert.Empty(t, dbRecord.DeviceCode, "DeviceCode should not exist in database")
+		assert.NotEmpty(t, dbRecord.DeviceCodeHash, "Hash should exist")
+		assert.NotEmpty(t, dbRecord.DeviceCodeSalt, "Salt should exist")
+	})
+
+	t.Run("Valid device code passes verification", func(t *testing.T) {
+		dc, err := service.GenerateDeviceCode(client.ClientID, "read")
+		require.NoError(t, err)
+		plaintext := dc.DeviceCode
+
+		// Verify
+		retrieved, err := service.GetDeviceCode(plaintext)
+		require.NoError(t, err)
+		assert.Equal(t, dc.UserCode, retrieved.UserCode)
+		assert.Equal(t, plaintext, retrieved.DeviceCode)
+	})
+
+	t.Run("Invalid device code fails verification", func(t *testing.T) {
+		dc, err := service.GenerateDeviceCode(client.ClientID, "read")
+		require.NoError(t, err)
+
+		// Try with wrong code (same suffix, different prefix)
+		wrongCode := "0000000000000000000000000000000" + dc.DeviceCodeID
+		_, err = service.GetDeviceCode(wrongCode)
+		assert.Equal(t, ErrDeviceCodeNotFound, err)
+	})
+
+	t.Run("Hash collision does not grant access", func(t *testing.T) {
+		// Generate two codes
+		dc1, err := service.GenerateDeviceCode(client.ClientID, "read")
+		require.NoError(t, err)
+
+		dc2, err := service.GenerateDeviceCode(client.ClientID, "read")
+		require.NoError(t, err)
+
+		// Try to use dc1's prefix with dc2's suffix
+		fakeCode := dc1.DeviceCode[:32] + dc2.DeviceCodeID
+		_, err = service.GetDeviceCode(fakeCode)
+		assert.Error(t, err)
+	})
+}
+
+func TestDeviceCodeInputValidation(t *testing.T) {
+	service, client := setupTestService(t)
+
+	t.Run("Valid 40-char hex code passes", func(t *testing.T) {
+		dc, err := service.GenerateDeviceCode(client.ClientID, "read")
+		require.NoError(t, err)
+
+		retrieved, err := service.GetDeviceCode(dc.DeviceCode)
+		require.NoError(t, err)
+		assert.NotNil(t, retrieved)
+	})
+
+	t.Run("Invalid length rejected", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			code string
+		}{
+			{"Empty", ""},
+			{"Too short", "abc"},
+			{"39 chars", "0123456789abcdef0123456789abcdef01234"},
+			{"41 chars", "0123456789abcdef0123456789abcdef012345"},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := service.GetDeviceCode(tc.code)
+				assert.Equal(t, ErrDeviceCodeNotFound, err)
+			})
+		}
+	})
+
+	t.Run("Non-hex characters rejected", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			code string
+		}{
+			{"Uppercase", "0123456789ABCDEF0123456789ABCDEF01234567"},
+			{"Invalid char 'g'", "0123456789abcdefg123456789abcdef01234567"},
+			{"Space", "0123456789abcdef 123456789abcdef01234567"},
+			{"Dash", "0123456789abcdef-123456789abcdef01234567"},
+			{"Special chars", "<script>alert('xss')</script>0000000000"},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := service.GetDeviceCode(tc.code)
+				assert.Equal(t, ErrDeviceCodeNotFound, err)
+			})
+		}
+	})
+}
+
+func TestConstantTimeComparison(t *testing.T) {
+	const testHash = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd"
+
+	t.Run("Constant-time comparison correctness", func(t *testing.T) {
+		hash1 := testHash
+		hash2 := testHash
+		hash3 := "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+		// Same hashes should match
+		result1 := subtle.ConstantTimeCompare([]byte(hash1), []byte(hash2))
+		assert.Equal(t, 1, result1, "Identical hashes should match")
+
+		// Different hashes should not match
+		result2 := subtle.ConstantTimeCompare([]byte(hash1), []byte(hash3))
+		assert.Equal(t, 0, result2, "Different hashes should not match")
+	})
+
+	t.Run("Timing consistency check", func(t *testing.T) {
+		// This is a basic sanity check - real timing attack analysis requires
+		// statistical analysis over many iterations with proper benchmarking setup
+		hash := testHash
+		almostMatch := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef123456789000000000000000000000000000000000000"
+		noMatch := "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+		iterations := 100000 // More iterations for better averaging
+
+		// Warm up
+		for i := 0; i < 1000; i++ {
+			subtle.ConstantTimeCompare([]byte(hash), []byte(almostMatch))
+		}
+
+		start1 := time.Now()
+		for i := 0; i < iterations; i++ {
+			subtle.ConstantTimeCompare([]byte(hash), []byte(almostMatch))
+		}
+		duration1 := time.Since(start1)
+
+		start2 := time.Now()
+		for i := 0; i < iterations; i++ {
+			subtle.ConstantTimeCompare([]byte(hash), []byte(noMatch))
+		}
+		duration2 := time.Since(start2)
+
+		// Both operations should complete (this is more of a smoke test)
+		// We mainly trust Go's crypto/subtle package's constant-time guarantees
+		assert.Greater(t, duration1, time.Duration(0))
+		assert.Greater(t, duration2, time.Duration(0))
+
+		// Log the timing for informational purposes
+		t.Logf("Timing info: almostMatch=%v, noMatch=%v", duration1, duration2)
+	})
+}
+
+func TestDeviceCodeGeneration(t *testing.T) {
+	service, client := setupTestService(t)
+
+	t.Run("Generated codes are unique", func(t *testing.T) {
+		codes := make(map[string]bool)
+
+		for i := 0; i < 100; i++ {
+			dc, err := service.GenerateDeviceCode(client.ClientID, "read")
+			require.NoError(t, err)
+
+			assert.False(t, codes[dc.DeviceCode], "Duplicate device code generated")
+			codes[dc.DeviceCode] = true
+		}
+	})
+
+	t.Run("Generated codes have correct format", func(t *testing.T) {
+		dc, err := service.GenerateDeviceCode(client.ClientID, "read")
+		require.NoError(t, err)
+
+		// Check length
+		assert.Len(t, dc.DeviceCode, 40)
+
+		// Check hex format
+		_, err = hex.DecodeString(dc.DeviceCode)
+		assert.NoError(t, err, "DeviceCode should be valid hex")
+
+		// Check DeviceCodeID is last 8 chars
+		assert.Equal(t, dc.DeviceCode[32:], dc.DeviceCodeID)
+	})
+
+	t.Run("Hash and salt are properly generated", func(t *testing.T) {
+		dc, err := service.GenerateDeviceCode(client.ClientID, "read")
+		require.NoError(t, err)
+
+		// Check hash length (50 bytes = 100 hex chars)
+		assert.Len(t, dc.DeviceCodeHash, 100)
+
+		// Check salt length (20 chars)
+		assert.Len(t, dc.DeviceCodeSalt, 20)
+
+		// Verify hash can be reproduced
+		expectedHash := util.HashToken(dc.DeviceCode, dc.DeviceCodeSalt)
+		assert.Equal(t, expectedHash, dc.DeviceCodeHash)
+	})
+}

--- a/internal/services/device_test.go
+++ b/internal/services/device_test.go
@@ -197,6 +197,8 @@ func TestUserCodeNormalization(t *testing.T) {
 
 	assert.NoError(t, err1)
 	assert.NoError(t, err2)
-	assert.Equal(t, dc.DeviceCode, dc1.DeviceCode)
-	assert.Equal(t, dc.DeviceCode, dc2.DeviceCode)
+	// Compare by UserCode since DeviceCode field is not stored in DB (gorm:"-")
+	assert.Equal(t, dc.UserCode, dc1.UserCode)
+	assert.Equal(t, dc.UserCode, dc2.UserCode)
+	assert.Equal(t, dc1.ID, dc2.ID)
 }

--- a/internal/services/token_test.go
+++ b/internal/services/token_test.go
@@ -16,8 +16,9 @@ import (
 )
 
 func createTestTokenService(s *store.Store, cfg *config.Config) *TokenService {
+	deviceService := NewDeviceService(s, cfg)
 	localProvider := token.NewLocalTokenProvider(cfg)
-	return NewTokenService(s, cfg, localProvider, nil, "local")
+	return NewTokenService(s, cfg, deviceService, localProvider, nil, "local")
 }
 
 func createAuthorizedDeviceCode(t *testing.T, s *store.Store, clientID string) *models.DeviceCode {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -275,18 +275,23 @@ func (s *Store) DeleteClient(clientID string) error {
 }
 
 // Device Code operations
+
+// CreateDeviceCode creates a new device code
 func (s *Store) CreateDeviceCode(dc *models.DeviceCode) error {
 	return s.db.Create(dc).Error
 }
 
-func (s *Store) GetDeviceCode(deviceCode string) (*models.DeviceCode, error) {
-	var dc models.DeviceCode
-	if err := s.db.Where("device_code = ?", deviceCode).First(&dc).Error; err != nil {
+// GetDeviceCodesByID retrieves all device codes with matching ID suffix
+// Used for hash verification during token exchange
+func (s *Store) GetDeviceCodesByID(deviceCodeID string) ([]*models.DeviceCode, error) {
+	var dcs []*models.DeviceCode
+	if err := s.db.Where("device_code_id = ?", deviceCodeID).Find(&dcs).Error; err != nil {
 		return nil, err
 	}
-	return &dc, nil
+	return dcs, nil
 }
 
+// GetDeviceCodeByUserCode retrieves a device code by user code
 func (s *Store) GetDeviceCodeByUserCode(userCode string) (*models.DeviceCode, error) {
 	var dc models.DeviceCode
 	if err := s.db.Where("user_code = ?", userCode).First(&dc).Error; err != nil {
@@ -295,12 +300,14 @@ func (s *Store) GetDeviceCodeByUserCode(userCode string) (*models.DeviceCode, er
 	return &dc, nil
 }
 
+// UpdateDeviceCode updates a device code
 func (s *Store) UpdateDeviceCode(dc *models.DeviceCode) error {
 	return s.db.Save(dc).Error
 }
 
-func (s *Store) DeleteDeviceCode(deviceCode string) error {
-	return s.db.Where("device_code = ?", deviceCode).Delete(&models.DeviceCode{}).Error
+// DeleteDeviceCodeByID deletes device code by ID (primary key)
+func (s *Store) DeleteDeviceCodeByID(id int64) error {
+	return s.db.Delete(&models.DeviceCode{}, id).Error
 }
 
 // Access Token operations

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// CryptoRandomBytes generates cryptographically secure random bytes
+func CryptoRandomBytes(length int64) ([]byte, error) {
+	buf := make([]byte, length)
+	_, err := rand.Read(buf)
+	return buf, err
+}
+
+// CryptoRandomString generates a random hex string for salts
+func CryptoRandomString(length int) (string, error) {
+	bytes, err := CryptoRandomBytes(int64((length + 1) / 2))
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes)[:length], nil
+}
+
+// HashToken returns PBKDF2 hash of token with salt
+// Parameters match Gitea's implementation for security consistency
+func HashToken(token, salt string) string {
+	hash := pbkdf2.Key([]byte(token), []byte(salt), 10000, 50, sha256.New)
+	return hex.EncodeToString(hash)
+}

--- a/internal/util/crypto_test.go
+++ b/internal/util/crypto_test.go
@@ -1,0 +1,79 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCryptoRandomBytes(t *testing.T) {
+	t.Run("Generate correct length", func(t *testing.T) {
+		bytes, err := CryptoRandomBytes(20)
+		require.NoError(t, err)
+		assert.Len(t, bytes, 20)
+	})
+
+	t.Run("Generate unique values", func(t *testing.T) {
+		bytes1, err := CryptoRandomBytes(20)
+		require.NoError(t, err)
+
+		bytes2, err := CryptoRandomBytes(20)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, bytes1, bytes2, "Random bytes should not be identical")
+	})
+}
+
+func TestCryptoRandomString(t *testing.T) {
+	t.Run("Generate correct length", func(t *testing.T) {
+		str, err := CryptoRandomString(20)
+		require.NoError(t, err)
+		assert.Len(t, str, 20)
+	})
+
+	t.Run("Generate hex characters only", func(t *testing.T) {
+		str, err := CryptoRandomString(20)
+		require.NoError(t, err)
+
+		for _, c := range str {
+			assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),
+				"Character '%c' is not a valid hex digit", c)
+		}
+	})
+}
+
+func TestHashToken(t *testing.T) {
+	t.Run("Same input produces same hash", func(t *testing.T) {
+		token := "test-device-code-12345"
+		salt := "random-salt-abc"
+
+		hash1 := HashToken(token, salt)
+		hash2 := HashToken(token, salt)
+
+		assert.Equal(t, hash1, hash2)
+		assert.Len(t, hash1, 100) // 50 bytes = 100 hex chars
+	})
+
+	t.Run("Different salt produces different hash", func(t *testing.T) {
+		token := "test-device-code-12345"
+		salt1 := "salt1"
+		salt2 := "salt2"
+
+		hash1 := HashToken(token, salt1)
+		hash2 := HashToken(token, salt2)
+
+		assert.NotEqual(t, hash1, hash2)
+	})
+
+	t.Run("Different token produces different hash", func(t *testing.T) {
+		token1 := "device-code-1"
+		token2 := "device-code-2" //nolint:gosec // test value, not a credential
+		salt := "same-salt"
+
+		hash1 := HashToken(token1, salt)
+		hash2 := HashToken(token2, salt)
+
+		assert.NotEqual(t, hash1, hash2)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -156,6 +156,7 @@ func runServer() {
 	tokenService := services.NewTokenService(
 		db,
 		cfg,
+		deviceService,
 		localTokenProvider,
 		httpTokenProvider,
 		cfg.TokenProviderMode,


### PR DESCRIPTION
- Refactor device code handling to use secure random generation, PBKDF2 hashing, a unique salt, and suffix-based indexing for quick lookup
- Remove storage of plaintext device codes in the database; only the hash, salt, and suffix ID are saved
- Add constant-time hash comparison to prevent timing attacks during device code verification
- Implement input validation for device code length and character set to enhance security
- Update store layer to use suffix-based searching and deletion by primary key instead of plaintext device code
- Replace device code lookup logic in service and token layers with new hash-based verification and expiry checks
- Introduce dedicated crypto utilities for random byte/string generation and token hashing
- Add comprehensive unit tests for random generation, hashing, input validation, constant-time comparison, and device code security scenarios
- Update affected tests to verify the new model and store logic, including device code creation, retrieval, and deletion semantics