### PR TITLE
feat: add OAuth 2.0 Authorization Code Flow with PKCE and consent management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ coverage.txt
 *_templ.go
 api/*
 !api/.gitkeep
+.worktrees

--- a/docs/AUTHORIZATION_CODE_FLOW.md
+++ b/docs/AUTHORIZATION_CODE_FLOW.md
@@ -1,0 +1,337 @@
+# Authorization Code Flow Guide
+
+AuthGate supports two OAuth 2.0 flows side-by-side. This guide covers the **Authorization Code Flow** (RFC 6749 §4.1) with PKCE (RFC 7636), suitable for web apps that can perform browser redirects.
+
+## Table of Contents
+
+- [Authorization Code Flow Guide](#authorization-code-flow-guide)
+  - [Table of Contents](#table-of-contents)
+  - [Which Flow Should I Use?](#which-flow-should-i-use)
+  - [Enabling Authorization Code Flow](#enabling-authorization-code-flow)
+    - [Step 1 — Create or Edit an OAuth Client](#step-1--create-or-edit-an-oauth-client)
+    - [Step 2 — Note Your Credentials](#step-2--note-your-credentials)
+  - [How It Works](#how-it-works)
+  - [PKCE (Required for Public Clients)](#pkce-required-for-public-clients)
+    - [Generate Code Verifier and Challenge](#generate-code-verifier-and-challenge)
+  - [API Reference](#api-reference)
+    - [1. Redirect to Authorization Page](#1-redirect-to-authorization-page)
+    - [2. Exchange Code for Tokens](#2-exchange-code-for-tokens)
+  - [User Consent Management](#user-consent-management)
+    - [View Authorized Apps](#view-authorized-apps)
+    - [Revoke Access for an App](#revoke-access-for-an-app)
+  - [Admin Management](#admin-management)
+    - [View All Authorized Users for a Client](#view-all-authorized-users-for-a-client)
+    - [Revoke All User Tokens (Force Re-authentication)](#revoke-all-user-tokens-force-re-authentication)
+  - [Environment Variables](#environment-variables)
+  - [Error Reference](#error-reference)
+
+---
+
+## Which Flow Should I Use?
+
+| Scenario                            | Recommended Flow                                   |
+| ----------------------------------- | -------------------------------------------------- |
+| CLI tools, IoT devices, TV apps     | **Device Code Flow** (RFC 8628)                    |
+| Web apps with a server-side backend | **Authorization Code Flow** (confidential client)  |
+| Single-page apps (SPA), mobile apps | **Authorization Code Flow + PKCE** (public client) |
+
+---
+
+## Enabling Authorization Code Flow
+
+### Step 1 — Create or Edit an OAuth Client
+
+Navigate to **Admin → OAuth Clients → Create New Client** (or edit an existing one).
+
+**Required fields:**
+
+| Field             | Description                                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Client Type**   | `Confidential` for server-side apps (has a secret). `Public` for SPAs/mobile (uses PKCE instead of a secret). |
+| **Grant Types**   | Check **Authorization Code Flow (RFC 6749)**                                                                  |
+| **Redirect URIs** | Comma-separated list of allowed callback URLs. Must be an exact match (no wildcards).                         |
+
+**Example redirect URIs:**
+
+```
+https://app.example.com/callback
+http://localhost:3000/callback
+myapp://oauth/callback
+```
+
+> **Security note:** For public clients, redirect URIs are the primary security boundary. Register only the exact URIs your app uses.
+
+### Step 2 — Note Your Credentials
+
+After creating a **confidential** client, copy the `client_id` and `client_secret` shown once on the confirmation page.
+
+For **public** clients, only `client_id` is needed (no secret).
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant App as Web/Mobile App
+    participant Browser as User's Browser
+    participant AuthGate as AuthGate Server
+
+    App->>Browser: 1. Redirect to /oauth/authorize?client_id=...
+    Browser->>AuthGate: GET /oauth/authorize
+    AuthGate->>Browser: Login page (if not logged in)
+    Browser->>AuthGate: User logs in
+    AuthGate->>Browser: Consent page (app name + requested scopes)
+    Browser->>AuthGate: User clicks "Allow Access"
+    AuthGate->>Browser: 302 redirect_uri?code=XXXXX&state=YYY
+    Browser->>App: code + state delivered to callback
+    App->>AuthGate: POST /oauth/token (code + secret or PKCE verifier)
+    AuthGate-->>App: access_token + refresh_token
+```
+
+**Consent caching:** If `CONSENT_REMEMBER=true` (default) and the user has already consented to the same scopes, the consent page is skipped on subsequent authorizations.
+
+---
+
+## PKCE (Required for Public Clients)
+
+PKCE (Proof Key for Code Exchange, RFC 7636) protects public clients against authorization code interception. It replaces the client secret with a cryptographic proof.
+
+### Generate Code Verifier and Challenge
+
+```bash
+# Generate random 32-byte verifier (must be 43–128 chars)
+CODE_VERIFIER=$(openssl rand -base64 32 | tr -d '=+/' | head -c 43)
+
+# Compute S256 challenge
+CODE_CHALLENGE=$(echo -n "$CODE_VERIFIER" | openssl dgst -sha256 -binary | openssl base64 | tr '+/' '-_' | tr -d '=')
+
+echo "verifier:  $CODE_VERIFIER"
+echo "challenge: $CODE_CHALLENGE"
+```
+
+**In Go:**
+
+```go
+import (
+    "crypto/rand"
+    "crypto/sha256"
+    "encoding/base64"
+)
+
+// Generate verifier
+b := make([]byte, 32)
+rand.Read(b)
+verifier := base64.RawURLEncoding.EncodeToString(b)
+
+// Compute S256 challenge
+sum := sha256.Sum256([]byte(verifier))
+challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+```
+
+---
+
+## API Reference
+
+### 1. Redirect to Authorization Page
+
+```
+GET /oauth/authorize
+```
+
+The user's browser is redirected to this URL to begin the authorization flow.
+
+**Query Parameters:**
+
+| Parameter               | Required          | Description                                                            |
+| ----------------------- | ----------------- | ---------------------------------------------------------------------- |
+| `client_id`             | ✅                | Your OAuth client ID (UUID)                                            |
+| `redirect_uri`          | ✅                | Must exactly match a registered Redirect URI                           |
+| `response_type`         | ✅                | Must be `code`                                                         |
+| `scope`                 | ○                 | Space-separated scopes. Defaults to all scopes allowed for the client. |
+| `state`                 | Recommended       | Random string to prevent CSRF. Returned unchanged in the redirect.     |
+| `code_challenge`        | Public clients ✅ | Base64url(SHA256(code_verifier))                                       |
+| `code_challenge_method` | Public clients ✅ | Must be `S256`                                                         |
+
+**Example (confidential client):**
+
+```
+GET /oauth/authorize?
+  client_id=550e8400-e29b-41d4-a716-446655440000
+  &redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback
+  &response_type=code
+  &scope=read%20write
+  &state=abc123xyz
+```
+
+**Example (public client with PKCE):**
+
+```
+GET /oauth/authorize?
+  client_id=550e8400-e29b-41d4-a716-446655440000
+  &redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback
+  &response_type=code
+  &scope=read
+  &state=abc123xyz
+  &code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+  &code_challenge_method=S256
+```
+
+**Success redirect (to your app):**
+
+```
+https://app.example.com/callback?code=a1b2c3d4...&state=abc123xyz
+```
+
+**Error redirect:**
+
+```
+https://app.example.com/callback?error=access_denied&state=abc123xyz
+```
+
+---
+
+### 2. Exchange Code for Tokens
+
+```
+POST /oauth/token
+Content-Type: application/x-www-form-urlencoded
+```
+
+Exchange the authorization code for access and refresh tokens. The code is **single-use** and expires in `AUTH_CODE_EXPIRATION` (default: 10 minutes).
+
+**Request Parameters:**
+
+| Parameter       | Required        | Description                                                  |
+| --------------- | --------------- | ------------------------------------------------------------ |
+| `grant_type`    | ✅              | `authorization_code`                                         |
+| `code`          | ✅              | Authorization code received in the redirect                  |
+| `redirect_uri`  | ✅              | Must exactly match the redirect_uri used in step 1           |
+| `client_id`     | ✅              | Your OAuth client ID                                         |
+| `client_secret` | Confidential ✅ | Your client secret                                           |
+| `code_verifier` | Public ✅       | The original random string used to generate `code_challenge` |
+
+**Example (confidential client):**
+
+```bash
+curl -X POST https://auth.example.com/oauth/token \
+  -d grant_type=authorization_code \
+  -d code=a1b2c3d4... \
+  -d redirect_uri=https://app.example.com/callback \
+  -d client_id=550e8400-... \
+  -d client_secret=your-client-secret
+```
+
+**Example (public client with PKCE):**
+
+```bash
+curl -X POST https://auth.example.com/oauth/token \
+  -d grant_type=authorization_code \
+  -d code=a1b2c3d4... \
+  -d redirect_uri=https://app.example.com/callback \
+  -d client_id=550e8400-... \
+  -d code_verifier=your-original-verifier
+```
+
+**Success Response (200 OK):**
+
+```json
+{
+  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "read write"
+}
+```
+
+**Refreshing tokens** works identically to the device flow — use `grant_type=refresh_token`:
+
+```bash
+curl -X POST https://auth.example.com/oauth/token \
+  -d grant_type=refresh_token \
+  -d refresh_token=eyJ... \
+  -d client_id=550e8400-...
+```
+
+---
+
+## User Consent Management
+
+Users can view and revoke the applications they have authorized at `/account/authorizations`.
+
+### View Authorized Apps
+
+```
+GET /account/authorizations
+```
+
+Displays a list of all applications the logged-in user has granted access to, with the authorized scopes and grant date.
+
+### Revoke Access for an App
+
+Click **Revoke Access** next to any application in the list. This immediately:
+
+1. Invalidates the consent record (user will see the consent page again next time)
+2. Revokes all active access and refresh tokens issued to that application for this user
+
+---
+
+## Admin Management
+
+### View All Authorized Users for a Client
+
+```
+GET /admin/clients/:client_id/authorizations
+```
+
+Accessible from **Admin → OAuth Clients → [Client Name] → 👥 Authorized Users**.
+
+Shows every user who has granted consent to this application, with their username, email, approved scopes, and grant timestamp.
+
+### Revoke All User Tokens (Force Re-authentication)
+
+```
+POST /admin/clients/:client_id/revoke-all
+```
+
+Available in the **Danger Zone** section of the client detail page. This action:
+
+1. Revokes every active access and refresh token for this client
+2. Clears all user consent records (every user will see the consent page again)
+
+Use this when rotating client secrets, responding to security incidents, or forcing all users to re-acknowledge updated permissions.
+
+> **Audit log:** This action is logged at `CRITICAL` severity under event type `CLIENT_TOKENS_REVOKED_ALL`.
+
+---
+
+## Environment Variables
+
+| Variable               | Default | Description                                                                                                             |
+| ---------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `AUTH_CODE_EXPIRATION` | `10m`   | How long an authorization code is valid. RFC 6749 recommends ≤ 10 minutes.                                              |
+| `PKCE_REQUIRED`        | `false` | When `true`, all clients (including confidential) must use PKCE.                                                        |
+| `CONSENT_REMEMBER`     | `true`  | Skip the consent page if the user has already approved the same scopes. Set to `false` to always show the consent page. |
+
+---
+
+## Error Reference
+
+Errors are returned as redirects to your `redirect_uri` with the following query parameters:
+
+| `error`                     | Cause                                                                                 |
+| --------------------------- | ------------------------------------------------------------------------------------- |
+| `unauthorized_client`       | Unknown `client_id`, inactive client, or Auth Code Flow not enabled                   |
+| `unsupported_response_type` | `response_type` is not `code`                                                         |
+| `invalid_scope`             | Requested scope is not within the client's allowed scopes                             |
+| `invalid_request`           | Missing required parameter, invalid `redirect_uri`, or PKCE required but not provided |
+| `access_denied`             | User clicked **Deny** on the consent page                                             |
+
+Token endpoint errors are returned as JSON (HTTP 400):
+
+| `error`                  | Cause                                                                             |
+| ------------------------ | --------------------------------------------------------------------------------- |
+| `invalid_grant`          | Code expired, already used, wrong `redirect_uri`, or invalid PKCE `code_verifier` |
+| `unauthorized_client`    | Wrong or missing `client_secret`                                                  |
+| `unsupported_grant_type` | `grant_type` is not supported                                                     |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,6 +162,11 @@ type Config struct {
 	MetricsCacheType           string        // Cache backend: memory, redis, redis-aside (default: memory)
 	MetricsCacheClientTTL      time.Duration // Client-side cache TTL for redis-aside (default: 30s)
 	MetricsCacheSizePerConn    int           // Client-side cache size per connection in MB for redis-aside (default: 32MB)
+
+	// Authorization Code Flow settings (RFC 6749)
+	AuthCodeExpiration time.Duration // Authorization code lifetime (default: 10 minutes)
+	PKCERequired       bool          // Force PKCE for all public clients (default: false)
+	ConsentRemember    bool          // Skip consent page if user already authorized same scope (default: true)
 }
 
 func Load() *Config {
@@ -302,6 +307,11 @@ func Load() *Config {
 		MetricsCacheType:           getEnv("METRICS_CACHE_TYPE", MetricsCacheTypeMemory),
 		MetricsCacheClientTTL:      getEnvDuration("METRICS_CACHE_CLIENT_TTL", 30*time.Second),
 		MetricsCacheSizePerConn:    getEnvInt("METRICS_CACHE_SIZE_PER_CONN", 32), // 32MB default
+
+		// Authorization Code Flow settings
+		AuthCodeExpiration: getEnvDuration("AUTH_CODE_EXPIRATION", 10*time.Minute),
+		PKCERequired:       getEnvBool("PKCE_REQUIRED", false),
+		ConsentRemember:    getEnvBool("CONSENT_REMEMBER", true),
 	}
 }
 

--- a/internal/handlers/authorization.go
+++ b/internal/handlers/authorization.go
@@ -1,0 +1,353 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/appleboy/authgate/internal/config"
+	"github.com/appleboy/authgate/internal/middleware"
+	"github.com/appleboy/authgate/internal/models"
+	"github.com/appleboy/authgate/internal/services"
+	"github.com/appleboy/authgate/internal/templates"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AuthorizationHandler manages the OAuth 2.0 Authorization Code Flow consent pages
+// and the user's authorized-applications management UI.
+type AuthorizationHandler struct {
+	authorizationService *services.AuthorizationService
+	tokenService         *services.TokenService
+	userService          *services.UserService
+	config               *config.Config
+}
+
+func NewAuthorizationHandler(
+	as *services.AuthorizationService,
+	ts *services.TokenService,
+	us *services.UserService,
+	cfg *config.Config,
+) *AuthorizationHandler {
+	return &AuthorizationHandler{
+		authorizationService: as,
+		tokenService:         ts,
+		userService:          us,
+		config:               cfg,
+	}
+}
+
+// ShowAuthorizePage renders the OAuth consent page (GET /oauth/authorize).
+// Requires the user to be logged in (enforced by RequireAuth middleware).
+func (h *AuthorizationHandler) ShowAuthorizePage(c *gin.Context) {
+	clientID := c.Query("client_id")
+	redirectURI := c.Query("redirect_uri")
+	responseType := c.Query("response_type")
+	scope := c.Query("scope")
+	state := c.Query("state")
+	codeChallenge := c.Query("code_challenge")
+	codeChallengeMethod := c.Query("code_challenge_method")
+
+	// Validate the authorization request parameters
+	req, err := h.authorizationService.ValidateAuthorizationRequest(
+		clientID, redirectURI, responseType, scope, codeChallengeMethod,
+	)
+	if err != nil {
+		h.redirectWithError(c, redirectURI, state, oauthErrorCode(err), err.Error())
+		return
+	}
+
+	userID, _ := c.Get("user_id")
+	userIDStr := userID.(string)
+
+	// Retrieve the logged-in user for display
+	user, err := h.userService.GetUserByID(userIDStr)
+	if err != nil {
+		c.Redirect(http.StatusFound, "/login")
+		return
+	}
+
+	// If ConsentRemember is enabled and the user has already consented to all
+	// requested scopes, skip the consent page and issue a code immediately.
+	if h.config.ConsentRemember {
+		existing, _ := h.authorizationService.GetUserAuthorization(userIDStr, req.Client.ID)
+		if existing != nil && scopesAreCovered(existing.Scopes, req.Scopes) {
+			h.issueCodeAndRedirect(
+				c,
+				req,
+				userIDStr,
+				redirectURI,
+				state,
+				codeChallenge,
+				codeChallengeMethod,
+			)
+			return
+		}
+	}
+
+	// Render the consent page
+	templates.RenderTempl(c, http.StatusOK, templates.AuthorizePage(templates.AuthorizePageProps{
+		BaseProps:           templates.BaseProps{CSRFToken: middleware.GetCSRFToken(c)},
+		Username:            user.Username,
+		ClientID:            req.Client.ClientID,
+		ClientName:          req.Client.ClientName,
+		ClientDescription:   req.Client.Description,
+		RedirectURI:         redirectURI,
+		Scopes:              req.Scopes,
+		ScopeList:           strings.Fields(req.Scopes),
+		State:               state,
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: codeChallengeMethod,
+	}))
+}
+
+// HandleAuthorize processes the user's consent decision (POST /oauth/authorize).
+// Requires the user to be logged in and a valid CSRF token.
+func (h *AuthorizationHandler) HandleAuthorize(c *gin.Context) {
+	action := c.PostForm("action") // "approve" or "deny"
+	clientID := c.PostForm("client_id")
+	redirectURI := c.PostForm("redirect_uri")
+	scope := c.PostForm("scope")
+	state := c.PostForm("state")
+	codeChallenge := c.PostForm("code_challenge")
+	codeChallengeMethod := c.PostForm("code_challenge_method")
+
+	// Deny path: redirect immediately with access_denied
+	if action != "approve" {
+		h.redirectWithError(
+			c,
+			redirectURI,
+			state,
+			"access_denied",
+			"User denied the authorization request",
+		)
+		return
+	}
+
+	// Re-validate request on POST to prevent parameter tampering
+	req, err := h.authorizationService.ValidateAuthorizationRequest(
+		clientID, redirectURI, "code", scope, codeChallengeMethod,
+	)
+	if err != nil {
+		h.redirectWithError(c, redirectURI, state, oauthErrorCode(err), err.Error())
+		return
+	}
+
+	userID, _ := c.Get("user_id")
+	userIDStr := userID.(string)
+
+	// Persist the consent record
+	if _, err := h.authorizationService.SaveUserAuthorization(
+		c.Request.Context(),
+		userIDStr,
+		req.Client.ID,
+		req.Client.ClientID,
+		req.Scopes,
+	); err != nil {
+		h.redirectWithError(c, redirectURI, state, "server_error", "Failed to save authorization")
+		return
+	}
+
+	h.issueCodeAndRedirect(
+		c, req, userIDStr, redirectURI, state, codeChallenge, codeChallengeMethod,
+	)
+}
+
+// issueCodeAndRedirect generates an authorization code and redirects to the client's redirect_uri.
+func (h *AuthorizationHandler) issueCodeAndRedirect(
+	c *gin.Context,
+	req *services.AuthorizationRequest,
+	userID, redirectURI, state, codeChallenge, codeChallengeMethod string,
+) {
+	plainCode, _, err := h.authorizationService.CreateAuthorizationCode(
+		c.Request.Context(),
+		req.Client.ID,
+		req.Client.ClientID,
+		userID,
+		redirectURI,
+		req.Scopes,
+		codeChallenge,
+		codeChallengeMethod,
+	)
+	if err != nil {
+		h.redirectWithError(
+			c,
+			redirectURI,
+			state,
+			"server_error",
+			"Failed to generate authorization code",
+		)
+		return
+	}
+
+	u, err := url.Parse(redirectURI)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid redirect_uri"})
+		return
+	}
+	q := u.Query()
+	q.Set("code", plainCode)
+	if state != "" {
+		q.Set("state", state)
+	}
+	u.RawQuery = q.Encode()
+	c.Redirect(http.StatusFound, u.String())
+}
+
+// redirectWithError sends an OAuth error response as a redirect to the client's redirect_uri.
+// If redirect_uri is missing or invalid, renders a plain error page instead.
+func (h *AuthorizationHandler) redirectWithError(
+	c *gin.Context,
+	redirectURI, state, errorCode, description string,
+) {
+	if redirectURI == "" {
+		templates.RenderTempl(
+			c,
+			http.StatusBadRequest,
+			templates.ErrorPage(templates.ErrorPageProps{
+				Error:   errorCode,
+				Message: description,
+			}),
+		)
+		return
+	}
+	u, err := url.Parse(redirectURI)
+	if err != nil {
+		templates.RenderTempl(
+			c,
+			http.StatusBadRequest,
+			templates.ErrorPage(templates.ErrorPageProps{
+				Error:   errorCode,
+				Message: description,
+			}),
+		)
+		return
+	}
+	q := u.Query()
+	q.Set("error", errorCode)
+	q.Set("error_description", description)
+	if state != "" {
+		q.Set("state", state)
+	}
+	u.RawQuery = q.Encode()
+	c.Redirect(http.StatusFound, u.String())
+}
+
+// ============================================================
+// Account – authorized applications management
+// ============================================================
+
+// ListAuthorizations renders the user's authorized applications page (GET /account/authorizations).
+func (h *AuthorizationHandler) ListAuthorizations(c *gin.Context) {
+	userID, _ := c.Get("user_id")
+	user, _ := c.Get("user")
+	userIDStr := userID.(string)
+
+	auths, err := h.authorizationService.ListUserAuthorizations(c.Request.Context(), userIDStr)
+	if err != nil {
+		templates.RenderTempl(
+			c,
+			http.StatusInternalServerError,
+			templates.ErrorPage(templates.ErrorPageProps{
+				Error: "Failed to retrieve authorizations",
+			}),
+		)
+		return
+	}
+
+	// Build display models
+	displayAuths := make([]templates.AuthorizationDisplay, 0, len(auths))
+	for _, a := range auths {
+		displayAuths = append(displayAuths, templates.AuthorizationDisplay{
+			UUID:       a.UUID,
+			ClientID:   a.ClientID,
+			ClientName: a.ClientName,
+			Scopes:     a.Scopes,
+			GrantedAt:  a.GrantedAt,
+			IsActive:   a.IsActive,
+		})
+	}
+
+	isAdmin := false
+	username := ""
+	if um, ok := user.(*models.User); ok {
+		isAdmin = um.IsAdmin()
+		username = um.Username
+	} else if u, err := h.userService.GetUserByID(userIDStr); err == nil {
+		isAdmin = u.IsAdmin()
+		username = u.Username
+	}
+
+	templates.RenderTempl(
+		c,
+		http.StatusOK,
+		templates.AccountAuthorizations(templates.AuthorizationsPageProps{
+			BaseProps: templates.BaseProps{CSRFToken: middleware.GetCSRFToken(c)},
+			NavbarProps: templates.NavbarProps{
+				Username:   username,
+				IsAdmin:    isAdmin,
+				ActiveLink: "authorizations",
+			},
+			Authorizations: displayAuths,
+			Success:        c.Query("success"),
+			Error:          c.Query("error"),
+		}),
+	)
+}
+
+// RevokeAuthorization revokes a user's consent for one application (POST /account/authorizations/:uuid/revoke).
+func (h *AuthorizationHandler) RevokeAuthorization(c *gin.Context) {
+	authUUID := c.Param("uuid")
+	userID, _ := c.Get("user_id")
+	userIDStr := userID.(string)
+
+	if err := h.authorizationService.RevokeUserAuthorization(
+		c.Request.Context(),
+		authUUID,
+		userIDStr,
+	); err != nil {
+		if errors.Is(err, services.ErrAuthorizationNotFound) {
+			c.Redirect(http.StatusFound, "/account/authorizations?error=not_found")
+			return
+		}
+		c.Redirect(http.StatusFound, "/account/authorizations?error=server_error")
+		return
+	}
+
+	c.Redirect(http.StatusFound, "/account/authorizations?success=revoked")
+}
+
+// ============================================================
+// Helpers
+// ============================================================
+
+const errInvalidRequest = "invalid_request"
+
+// oauthErrorCode maps service errors to RFC 6749 error codes.
+func oauthErrorCode(err error) string {
+	switch {
+	case errors.Is(err, services.ErrUnauthorizedClient):
+		return "unauthorized_client"
+	case errors.Is(err, services.ErrUnsupportedResponseType):
+		return "unsupported_response_type"
+	case errors.Is(err, services.ErrInvalidAuthCodeScope):
+		return "invalid_scope"
+	default:
+		return errInvalidRequest
+	}
+}
+
+// scopesAreCovered returns true when all scopes in requested are present in granted.
+func scopesAreCovered(grantedScopes, requestedScopes string) bool {
+	granted := make(map[string]bool)
+	for _, s := range strings.Fields(grantedScopes) {
+		granted[s] = true
+	}
+	for _, s := range strings.Fields(requestedScopes) {
+		if !granted[s] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/models/audit_log.go
+++ b/internal/models/audit_log.go
@@ -39,6 +39,14 @@ const (
 	EventRateLimitExceeded  EventType = "RATE_LIMIT_EXCEEDED"
 	EventSuspiciousActivity EventType = "SUSPICIOUS_ACTIVITY"
 
+	// Authorization Code Flow events (RFC 6749)
+	EventAuthorizationCodeGenerated EventType = "AUTHORIZATION_CODE_GENERATED"
+	EventAuthorizationCodeExchanged EventType = "AUTHORIZATION_CODE_EXCHANGED"
+	EventAuthorizationCodeDenied    EventType = "AUTHORIZATION_CODE_DENIED"
+	EventUserAuthorizationGranted   EventType = "USER_AUTHORIZATION_GRANTED"
+	EventUserAuthorizationRevoked   EventType = "USER_AUTHORIZATION_REVOKED"
+	EventClientTokensRevokedAll     EventType = "CLIENT_TOKENS_REVOKED_ALL" //nolint:gosec
+
 	// Audit events
 	EventTypeAuditLogView     EventType = "AUDIT_LOG_VIEWED"
 	EventTypeAuditLogExported EventType = "AUDIT_LOG_EXPORTED"
@@ -58,11 +66,12 @@ const (
 type ResourceType string
 
 const (
-	ResourceUser        ResourceType = "USER"
-	ResourceClient      ResourceType = "CLIENT"
-	ResourceToken       ResourceType = "TOKEN"
-	ResourceDeviceCode  ResourceType = "DEVICE_CODE"
-	ResourceOAuthConfig ResourceType = "OAUTH_CONFIG"
+	ResourceUser          ResourceType = "USER"
+	ResourceClient        ResourceType = "CLIENT"
+	ResourceToken         ResourceType = "TOKEN"
+	ResourceDeviceCode    ResourceType = "DEVICE_CODE"
+	ResourceOAuthConfig   ResourceType = "OAUTH_CONFIG"
+	ResourceAuthorization ResourceType = "AUTHORIZATION"
 )
 
 // AuditDetails stores additional event-specific information as JSON

--- a/internal/models/authorization_code.go
+++ b/internal/models/authorization_code.go
@@ -1,0 +1,42 @@
+package models
+
+import "time"
+
+// AuthorizationCode stores OAuth 2.0 authorization codes (RFC 6749).
+// Codes are short-lived (default 10 minutes) and single-use.
+type AuthorizationCode struct {
+	ID   uint   `gorm:"primaryKey;autoIncrement"`
+	UUID string `gorm:"uniqueIndex;size:36;not null"` // 對外 API/UI 識別碼
+
+	// Code storage: SHA256 hash for security, prefix for quick lookup
+	CodeHash   string `gorm:"uniqueIndex;not null"`  // SHA256(plainCode)
+	CodePrefix string `gorm:"index;not null;size:8"` // First 8 chars for quick lookup
+
+	// Relations (int PK for fast JOIN, string ClientID for OAuth protocol)
+	ApplicationID int64  `gorm:"not null;index"` // FK → OAuthApplication.ID
+	ClientID      string `gorm:"not null;index"` // Denormalized ClientID UUID (OAuth protocol use)
+	UserID        string `gorm:"not null;index"` // FK → User.ID
+
+	RedirectURI string `gorm:"not null"`
+	Scopes      string `gorm:"not null"`
+
+	// PKCE (RFC 7636)
+	CodeChallenge       string `gorm:"default:''"`     // code_challenge (empty = PKCE not used)
+	CodeChallengeMethod string `gorm:"default:'S256'"` // "S256" or "plain"
+
+	ExpiresAt time.Time
+	UsedAt    *time.Time // Set immediately upon exchange; prevents replay attacks
+	CreatedAt time.Time
+}
+
+func (a *AuthorizationCode) IsExpired() bool {
+	return time.Now().After(a.ExpiresAt)
+}
+
+func (a *AuthorizationCode) IsUsed() bool {
+	return a.UsedAt != nil
+}
+
+func (AuthorizationCode) TableName() string {
+	return "authorization_codes"
+}

--- a/internal/models/oauth_application.go
+++ b/internal/models/oauth_application.go
@@ -8,20 +8,22 @@ import (
 )
 
 type OAuthApplication struct {
-	ID               int64       `gorm:"primaryKey;autoIncrement"`
-	ClientID         string      `gorm:"uniqueIndex;not null"`
-	ClientSecret     string      `gorm:"not null"` // bcrypt hashed secret
-	ClientName       string      `gorm:"not null"`
-	Description      string      `gorm:"type:text"`
-	UserID           string      `gorm:"not null"`
-	Scopes           string      `gorm:"not null"`
-	GrantTypes       string      `gorm:"not null;default:'device_code'"`
-	RedirectURIs     StringArray `gorm:"type:json"`
-	EnableDeviceFlow bool        `gorm:"not null;default:true"`
-	IsActive         bool        `gorm:"not null;default:true"`
-	CreatedBy        string
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
+	ID                 int64       `gorm:"primaryKey;autoIncrement"`
+	ClientID           string      `gorm:"uniqueIndex;not null"`
+	ClientSecret       string      `gorm:"not null"` // bcrypt hashed secret
+	ClientName         string      `gorm:"not null"`
+	Description        string      `gorm:"type:text"`
+	UserID             string      `gorm:"not null"`
+	Scopes             string      `gorm:"not null"`
+	GrantTypes         string      `gorm:"not null;default:'device_code'"`
+	RedirectURIs       StringArray `gorm:"type:json"`
+	ClientType         string      `gorm:"not null;default:'confidential'"` // "confidential" or "public"
+	EnableDeviceFlow   bool        `gorm:"not null;default:true"`
+	EnableAuthCodeFlow bool        `gorm:"not null;default:false"`
+	IsActive           bool        `gorm:"not null;default:true"`
+	CreatedBy          string
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
 }
 
 // StringArray is a custom type for []string that can be stored as JSON in database

--- a/internal/models/token.go
+++ b/internal/models/token.go
@@ -5,18 +5,19 @@ import (
 )
 
 type AccessToken struct {
-	ID            string `gorm:"primaryKey"`
-	Token         string `gorm:"uniqueIndex;not null"`
-	TokenType     string `gorm:"not null;default:'Bearer'"`
-	TokenCategory string `gorm:"not null;default:'access';index"` // 'access' or 'refresh'
-	Status        string `gorm:"not null;default:'active';index"` // 'active', 'disabled', 'revoked'
-	UserID        string `gorm:"not null;index"`
-	ClientID      string `gorm:"not null;index"`
-	Scopes        string `gorm:"not null"` // space-separated scopes
-	ExpiresAt     time.Time
-	CreatedAt     time.Time
-	LastUsedAt    *time.Time `gorm:"index"` // Last time token was used (for refresh tokens)
-	ParentTokenID string     `gorm:"index"` // Links access tokens to their refresh token
+	ID              string `gorm:"primaryKey"`
+	Token           string `gorm:"uniqueIndex;not null"`
+	TokenType       string `gorm:"not null;default:'Bearer'"`
+	TokenCategory   string `gorm:"not null;default:'access';index"` // 'access' or 'refresh'
+	Status          string `gorm:"not null;default:'active';index"` // 'active', 'disabled', 'revoked'
+	UserID          string `gorm:"not null;index"`
+	ClientID        string `gorm:"not null;index"`
+	Scopes          string `gorm:"not null"` // space-separated scopes
+	ExpiresAt       time.Time
+	CreatedAt       time.Time
+	LastUsedAt      *time.Time `gorm:"index"` // Last time token was used (for refresh tokens)
+	ParentTokenID   string     `gorm:"index"` // Links access tokens to their refresh token
+	AuthorizationID *uint      `gorm:"index"` // FK → UserAuthorization.ID (nil for device_code grants)
 }
 
 func (t *AccessToken) IsExpired() bool {

--- a/internal/models/user_authorization.go
+++ b/internal/models/user_authorization.go
@@ -1,0 +1,27 @@
+package models
+
+import "time"
+
+// UserAuthorization records a user's consent grant to an OAuth application.
+// There is at most one active record per (UserID, ApplicationID) pair.
+type UserAuthorization struct {
+	ID   uint   `gorm:"primaryKey;autoIncrement"`
+	UUID string `gorm:"uniqueIndex;size:36;not null"` // 對外 API/UI 識別碼
+
+	// Relations (composite unique index ensures one grant per user+app)
+	UserID        string `gorm:"not null;uniqueIndex:idx_user_app"` // FK → User.ID
+	ApplicationID int64  `gorm:"not null;uniqueIndex:idx_user_app"` // FK → OAuthApplication.ID
+	ClientID      string `gorm:"not null;index"`                    // Denormalized ClientID UUID (for UI display and API responses)
+
+	Scopes    string `gorm:"not null"`
+	GrantedAt time.Time
+	RevokedAt *time.Time
+	IsActive  bool `gorm:"not null;default:true"`
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+func (UserAuthorization) TableName() string {
+	return "user_authorizations"
+}

--- a/internal/services/authorization.go
+++ b/internal/services/authorization.go
@@ -1,0 +1,543 @@
+package services
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/appleboy/authgate/internal/config"
+	"github.com/appleboy/authgate/internal/models"
+	"github.com/appleboy/authgate/internal/store"
+	"github.com/appleboy/authgate/internal/util"
+	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// Authorization Code Flow errors
+var (
+	ErrInvalidAuthCodeRequest  = errors.New("invalid_request")
+	ErrUnauthorizedClient      = errors.New("unauthorized_client")
+	ErrAccessDeniedConsent     = errors.New("access_denied")
+	ErrUnsupportedResponseType = errors.New("unsupported_response_type")
+	ErrInvalidAuthCodeScope    = errors.New("invalid_scope")
+	ErrInvalidRedirectURI      = errors.New("invalid redirect_uri")
+	ErrAuthCodeNotFound        = errors.New("authorization code not found")
+	ErrAuthCodeExpired         = errors.New("authorization code expired")
+	ErrAuthCodeAlreadyUsed     = errors.New("authorization code already used")
+	ErrInvalidCodeVerifier     = errors.New("invalid code_verifier")
+	ErrPKCERequired            = errors.New("pkce required for public clients")
+	ErrAuthorizationNotFound   = errors.New("authorization not found")
+)
+
+// AuthorizationRequest holds validated parameters for an authorization request
+type AuthorizationRequest struct {
+	Client              *models.OAuthApplication
+	RedirectURI         string
+	Scopes              string
+	State               string
+	CodeChallenge       string
+	CodeChallengeMethod string
+}
+
+// AuthorizationService manages the OAuth 2.0 Authorization Code Flow (RFC 6749)
+type AuthorizationService struct {
+	store        *store.Store
+	config       *config.Config
+	auditService *AuditService
+}
+
+func NewAuthorizationService(
+	s *store.Store,
+	cfg *config.Config,
+	auditService *AuditService,
+) *AuthorizationService {
+	return &AuthorizationService{
+		store:        s,
+		config:       cfg,
+		auditService: auditService,
+	}
+}
+
+// ValidateAuthorizationRequest validates all parameters of an incoming authorization request.
+// Returns the parsed AuthorizationRequest on success.
+func (s *AuthorizationService) ValidateAuthorizationRequest(
+	clientID, redirectURI, responseType, scope, codeChallengeMethod string,
+) (*AuthorizationRequest, error) {
+	// 1. response_type must be "code"
+	if responseType != "code" {
+		return nil, ErrUnsupportedResponseType
+	}
+
+	// 2. Client must exist and be active
+	client, err := s.store.GetClient(clientID)
+	if err != nil || !client.IsActive {
+		return nil, ErrUnauthorizedClient
+	}
+
+	// 3. Auth Code Flow must be enabled for this client
+	if !client.EnableAuthCodeFlow {
+		return nil, ErrUnauthorizedClient
+	}
+
+	// 4. redirect_uri must exactly match one of the registered URIs
+	if !s.isValidRedirectURI(client, redirectURI) {
+		return nil, ErrInvalidRedirectURI
+	}
+
+	// 5. Validate scope (must be subset of client's allowed scopes)
+	if scope != "" && !s.isValidScope(client.Scopes, scope) {
+		return nil, ErrInvalidAuthCodeScope
+	}
+	if scope == "" {
+		scope = client.Scopes // Default to all client scopes
+	}
+
+	// 6. PKCE: public clients must use S256
+	if client.ClientType == "public" {
+		if codeChallengeMethod == "" {
+			return nil, ErrPKCERequired
+		}
+	}
+	if codeChallengeMethod != "" && codeChallengeMethod != "S256" &&
+		codeChallengeMethod != "plain" {
+		return nil, ErrInvalidAuthCodeRequest
+	}
+	// Global PKCE enforcement
+	if s.config.PKCERequired && codeChallengeMethod == "" {
+		return nil, ErrPKCERequired
+	}
+
+	return &AuthorizationRequest{
+		Client:              client,
+		RedirectURI:         redirectURI,
+		Scopes:              scope,
+		CodeChallengeMethod: codeChallengeMethod,
+	}, nil
+}
+
+// CreateAuthorizationCode generates a one-time authorization code and saves it to the database.
+// Returns the plaintext code (to be sent in the redirect) and the stored record.
+func (s *AuthorizationService) CreateAuthorizationCode(
+	ctx context.Context,
+	applicationID int64,
+	clientID, userID, redirectURI, scopes, codeChallenge, codeChallengeMethod string,
+) (plainCode string, record *models.AuthorizationCode, err error) {
+	// Generate 32 cryptographically random bytes (256-bit entropy)
+	rawBytes, err := util.CryptoRandomBytes(32)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to generate authorization code: %w", err)
+	}
+	plainCode = hex.EncodeToString(rawBytes) // 64-char hex string
+
+	// SHA-256 hash for secure storage (no salt needed: 256-bit entropy is sufficient)
+	sum := sha256.Sum256([]byte(plainCode))
+	codeHash := hex.EncodeToString(sum[:])
+	codePrefix := plainCode[:8]
+
+	record = &models.AuthorizationCode{
+		UUID:                uuid.New().String(),
+		CodeHash:            codeHash,
+		CodePrefix:          codePrefix,
+		ApplicationID:       applicationID,
+		ClientID:            clientID,
+		UserID:              userID,
+		RedirectURI:         redirectURI,
+		Scopes:              scopes,
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: codeChallengeMethod,
+		ExpiresAt:           time.Now().Add(s.config.AuthCodeExpiration),
+	}
+
+	if err := s.store.CreateAuthorizationCode(record); err != nil {
+		return "", nil, fmt.Errorf("failed to save authorization code: %w", err)
+	}
+
+	if s.auditService != nil {
+		s.auditService.Log(ctx, AuditLogEntry{
+			EventType:    models.EventAuthorizationCodeGenerated,
+			Severity:     models.SeverityInfo,
+			ActorUserID:  userID,
+			ResourceType: models.ResourceAuthorization,
+			ResourceID:   record.UUID,
+			Action:       "Authorization code generated",
+			Details: models.AuditDetails{
+				"client_id":    clientID,
+				"scopes":       scopes,
+				"pkce":         codeChallenge != "",
+				"redirect_uri": redirectURI,
+			},
+			Success: true,
+		})
+	}
+
+	return plainCode, record, nil
+}
+
+// ExchangeCode validates a plaintext authorization code and marks it as used.
+// The caller (TokenHandler) is responsible for issuing tokens after this returns successfully.
+func (s *AuthorizationService) ExchangeCode(
+	ctx context.Context,
+	plainCode, clientID, redirectURI, clientSecret, codeVerifier string,
+) (*models.AuthorizationCode, error) {
+	// Hash the incoming code for lookup
+	sum := sha256.Sum256([]byte(plainCode))
+	codeHash := hex.EncodeToString(sum[:])
+
+	record, err := s.store.GetAuthorizationCodeByHash(codeHash)
+	if err != nil {
+		return nil, ErrAuthCodeNotFound
+	}
+
+	// Validate state
+	if record.IsUsed() {
+		return nil, ErrAuthCodeAlreadyUsed
+	}
+	if record.IsExpired() {
+		return nil, ErrAuthCodeExpired
+	}
+	if record.ClientID != clientID {
+		return nil, ErrAuthCodeNotFound // Don't reveal the code exists for another client
+	}
+	if record.RedirectURI != redirectURI {
+		return nil, ErrInvalidRedirectURI
+	}
+
+	// Client authentication
+	client, err := s.store.GetClient(clientID)
+	if err != nil || !client.IsActive {
+		return nil, ErrUnauthorizedClient
+	}
+
+	if client.ClientType == "confidential" {
+		// Confidential clients must present their secret
+		if clientSecret == "" {
+			return nil, ErrUnauthorizedClient
+		}
+		if !verifyClientSecret(client.ClientSecret, clientSecret) {
+			return nil, ErrUnauthorizedClient
+		}
+	} else {
+		// Public clients must present PKCE code_verifier
+		if record.CodeChallenge == "" {
+			return nil, ErrPKCERequired
+		}
+		if !verifyPKCE(record.CodeChallenge, record.CodeChallengeMethod, codeVerifier) {
+			return nil, ErrInvalidCodeVerifier
+		}
+	}
+
+	// Mark as used immediately (prevents replay even if subsequent steps fail)
+	now := time.Now()
+	if err := s.store.MarkAuthorizationCodeUsed(record.ID); err != nil {
+		return nil, fmt.Errorf("failed to mark code as used: %w", err)
+	}
+	record.UsedAt = &now // Reflect DB state in the returned struct
+
+	if s.auditService != nil {
+		s.auditService.Log(ctx, AuditLogEntry{
+			EventType:    models.EventAuthorizationCodeExchanged,
+			Severity:     models.SeverityInfo,
+			ActorUserID:  record.UserID,
+			ResourceType: models.ResourceAuthorization,
+			ResourceID:   record.UUID,
+			Action:       "Authorization code exchanged for token",
+			Details: models.AuditDetails{
+				"client_id": clientID,
+				"scopes":    record.Scopes,
+			},
+			Success: true,
+		})
+	}
+
+	return record, nil
+}
+
+// GetUserAuthorization returns the active consent record for a (user, application) pair.
+// Returns nil, nil when no consent exists (not an error condition).
+func (s *AuthorizationService) GetUserAuthorization(
+	userID string,
+	applicationID int64,
+) (*models.UserAuthorization, error) {
+	auth, err := s.store.GetUserAuthorization(userID, applicationID)
+	if err != nil {
+		return nil, nil // Treat as "not found" for consent check
+	}
+	return auth, nil
+}
+
+// SaveUserAuthorization creates or updates the consent record for a user+application pair.
+func (s *AuthorizationService) SaveUserAuthorization(
+	ctx context.Context,
+	userID string,
+	applicationID int64,
+	clientID, scopes string,
+) (*models.UserAuthorization, error) {
+	auth := &models.UserAuthorization{
+		UUID:          uuid.New().String(),
+		UserID:        userID,
+		ApplicationID: applicationID,
+		ClientID:      clientID,
+		Scopes:        scopes,
+		GrantedAt:     time.Now(),
+		IsActive:      true,
+	}
+
+	if err := s.store.UpsertUserAuthorization(auth); err != nil {
+		return nil, fmt.Errorf("failed to save user authorization: %w", err)
+	}
+
+	// Re-fetch to get the stored record (UpsertUserAuthorization may modify in-place)
+	stored, err := s.store.GetUserAuthorization(userID, applicationID)
+	if err != nil {
+		return auth, nil // Return what we built; non-fatal
+	}
+
+	if s.auditService != nil {
+		s.auditService.Log(ctx, AuditLogEntry{
+			EventType:    models.EventUserAuthorizationGranted,
+			Severity:     models.SeverityInfo,
+			ActorUserID:  userID,
+			ResourceType: models.ResourceAuthorization,
+			ResourceID:   stored.UUID,
+			Action:       "User granted authorization to application",
+			Details: models.AuditDetails{
+				"client_id": clientID,
+				"scopes":    scopes,
+			},
+			Success: true,
+		})
+	}
+
+	return stored, nil
+}
+
+// RevokeUserAuthorization revokes a user's consent for an application.
+// It also revokes all active tokens that were issued under this authorization.
+func (s *AuthorizationService) RevokeUserAuthorization(
+	ctx context.Context,
+	authUUID, userID string,
+) error {
+	revoked, err := s.store.RevokeUserAuthorization(authUUID, userID)
+	if err != nil {
+		return ErrAuthorizationNotFound
+	}
+
+	// Cascade-revoke all tokens tied to this authorization
+	_ = s.store.RevokeTokensByAuthorizationID(revoked.ID)
+
+	if s.auditService != nil {
+		s.auditService.Log(ctx, AuditLogEntry{
+			EventType:    models.EventUserAuthorizationRevoked,
+			Severity:     models.SeverityInfo,
+			ActorUserID:  userID,
+			ResourceType: models.ResourceAuthorization,
+			ResourceID:   authUUID,
+			Action:       "User revoked authorization for application",
+			Details: models.AuditDetails{
+				"client_id": revoked.ClientID,
+				"scopes":    revoked.Scopes,
+			},
+			Success: true,
+		})
+	}
+
+	return nil
+}
+
+// ListUserAuthorizations returns all active authorizations for a user with client display names.
+func (s *AuthorizationService) ListUserAuthorizations(
+	ctx context.Context,
+	userID string,
+) ([]UserAuthorizationWithClient, error) {
+	auths, err := s.store.ListUserAuthorizations(userID)
+	if err != nil {
+		return nil, err
+	}
+	if len(auths) == 0 {
+		return []UserAuthorizationWithClient{}, nil
+	}
+
+	// Batch-fetch client names
+	clientIDs := make([]string, 0, len(auths))
+	seen := make(map[string]bool)
+	for _, a := range auths {
+		if !seen[a.ClientID] {
+			clientIDs = append(clientIDs, a.ClientID)
+			seen[a.ClientID] = true
+		}
+	}
+	clientMap, _ := s.store.GetClientsByIDs(clientIDs)
+
+	result := make([]UserAuthorizationWithClient, 0, len(auths))
+	for _, a := range auths {
+		clientName := a.ClientID
+		if c, ok := clientMap[a.ClientID]; ok && c != nil {
+			clientName = c.ClientName
+		}
+		result = append(result, UserAuthorizationWithClient{
+			UserAuthorization: a,
+			ClientName:        clientName,
+		})
+	}
+
+	return result, nil
+}
+
+// RevokeAllApplicationTokens revokes all active tokens and consent records for an application.
+// This is an admin operation that forces all users to re-authenticate.
+func (s *AuthorizationService) RevokeAllApplicationTokens(
+	ctx context.Context,
+	clientID, actorUserID string,
+) (int64, error) {
+	// Revoke all active tokens
+	revokedCount, err := s.store.RevokeAllActiveTokensByClientID(clientID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to revoke tokens: %w", err)
+	}
+
+	// Invalidate all consent records so users see the consent page again
+	_ = s.store.RevokeAllUserAuthorizationsByClientID(clientID)
+
+	if s.auditService != nil {
+		_ = s.auditService.LogSync(ctx, AuditLogEntry{
+			EventType:    models.EventClientTokensRevokedAll,
+			Severity:     models.SeverityCritical,
+			ActorUserID:  actorUserID,
+			ResourceType: models.ResourceClient,
+			ResourceID:   clientID,
+			Action:       "All client tokens revoked by administrator",
+			Details: models.AuditDetails{
+				"client_id":     clientID,
+				"revoked_count": revokedCount,
+			},
+			Success: true,
+		})
+	}
+
+	return revokedCount, nil
+}
+
+// UserAuthorizationWithClient combines a UserAuthorization with its client's display name
+type UserAuthorizationWithClient struct {
+	models.UserAuthorization
+	ClientName string
+}
+
+// UserAuthorizationWithUser combines a UserAuthorization with the authorizing user's details
+type UserAuthorizationWithUser struct {
+	models.UserAuthorization
+	Username string
+	Email    string
+}
+
+// ListClientAuthorizations returns all active consent grants for a given client, with user details.
+// Intended for the admin overview page.
+func (s *AuthorizationService) ListClientAuthorizations(
+	ctx context.Context,
+	clientID string,
+) ([]UserAuthorizationWithUser, error) {
+	auths, err := s.store.GetClientAuthorizations(clientID)
+	if err != nil {
+		return nil, err
+	}
+	if len(auths) == 0 {
+		return []UserAuthorizationWithUser{}, nil
+	}
+
+	// Batch-fetch user display names
+	userIDSet := make(map[string]bool)
+	for _, a := range auths {
+		userIDSet[a.UserID] = true
+	}
+	userIDs := make([]string, 0, len(userIDSet))
+	for id := range userIDSet {
+		userIDs = append(userIDs, id)
+	}
+	userMap, _ := s.store.GetUsersByIDs(userIDs)
+
+	result := make([]UserAuthorizationWithUser, 0, len(auths))
+	for _, a := range auths {
+		username, email := a.UserID, ""
+		if u, ok := userMap[a.UserID]; ok && u != nil {
+			username = u.Username
+			email = u.Email
+		}
+		result = append(result, UserAuthorizationWithUser{
+			UserAuthorization: a,
+			Username:          username,
+			Email:             email,
+		})
+	}
+	return result, nil
+}
+
+// ============================================================
+// PKCE helpers (RFC 7636)
+// ============================================================
+
+// verifyPKCE validates code_verifier against the stored code_challenge
+func verifyPKCE(codeChallenge, method, codeVerifier string) bool {
+	if codeVerifier == "" {
+		return false
+	}
+	switch strings.ToUpper(method) {
+	case "S256":
+		sum := sha256.Sum256([]byte(codeVerifier))
+		computed := base64.RawURLEncoding.EncodeToString(sum[:])
+		return computed == codeChallenge
+	case "PLAIN", "":
+		return codeVerifier == codeChallenge
+	default:
+		return false
+	}
+}
+
+// ============================================================
+// Client secret verification
+// ============================================================
+
+// verifyClientSecret performs bcrypt comparison of the stored hashed client secret.
+func verifyClientSecret(hashedSecret, plainSecret string) bool {
+	if len(hashedSecret) == 0 || len(plainSecret) == 0 {
+		return false
+	}
+	err := bcrypt.CompareHashAndPassword([]byte(hashedSecret), []byte(plainSecret))
+	return err == nil
+}
+
+// ============================================================
+// Scope helpers
+// ============================================================
+
+func (s *AuthorizationService) isValidRedirectURI(
+	client *models.OAuthApplication,
+	uri string,
+) bool {
+	if uri == "" {
+		return false
+	}
+	for _, registered := range client.RedirectURIs {
+		if registered == uri {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *AuthorizationService) isValidScope(clientScopes, requestedScopes string) bool {
+	allowed := make(map[string]bool)
+	for _, sc := range strings.Fields(clientScopes) {
+		allowed[sc] = true
+	}
+	for _, sc := range strings.Fields(requestedScopes) {
+		if !allowed[sc] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/services/authorization_test.go
+++ b/internal/services/authorization_test.go
@@ -1,0 +1,555 @@
+package services
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/appleboy/authgate/internal/config"
+	"github.com/appleboy/authgate/internal/models"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	testClientPlainSecret = "test-plain-secret" //nolint:gosec
+	testPKCEVerifier      = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+)
+
+// createTestAuthorizationService builds a service with an in-memory store.
+func createTestAuthorizationService(t *testing.T) *AuthorizationService {
+	t.Helper()
+	s := setupTestStore(t)
+	cfg := &config.Config{
+		AuthCodeExpiration: 10 * time.Minute,
+		PKCERequired:       false,
+		ConsentRemember:    true,
+	}
+	return NewAuthorizationService(s, cfg, nil)
+}
+
+// createAuthCodeFlowClient creates a test client with auth code flow enabled.
+// The ClientSecret field stores the bcrypt hash of testClientPlainSecret.
+func createAuthCodeFlowClient(
+	t *testing.T,
+	svc *AuthorizationService,
+	clientType string,
+) *models.OAuthApplication {
+	t.Helper()
+	hash, err := bcrypt.GenerateFromPassword([]byte(testClientPlainSecret), bcrypt.MinCost)
+	require.NoError(t, err)
+	client := &models.OAuthApplication{
+		ClientID:           uuid.New().String(),
+		ClientSecret:       string(hash),
+		ClientName:         "Test Auth Code Client",
+		UserID:             uuid.New().String(),
+		Scopes:             "read write",
+		GrantTypes:         "authorization_code",
+		RedirectURIs:       models.StringArray{"https://app.example.com/callback"},
+		ClientType:         clientType,
+		EnableAuthCodeFlow: true,
+		IsActive:           true,
+	}
+	err = svc.store.CreateClient(client)
+	require.NoError(t, err)
+	return client
+}
+
+// ============================================================
+// ValidateAuthorizationRequest
+// ============================================================
+
+func TestValidateAuthorizationRequest_Success(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+
+	req, err := svc.ValidateAuthorizationRequest(
+		client.ClientID,
+		"https://app.example.com/callback",
+		"code",
+		"read",
+		"",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, client.ClientID, req.Client.ClientID)
+	assert.Equal(t, "read", req.Scopes)
+}
+
+func TestValidateAuthorizationRequest_DefaultScope(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+
+	req, err := svc.ValidateAuthorizationRequest(
+		client.ClientID, "https://app.example.com/callback", "code", "", "",
+	)
+
+	require.NoError(t, err)
+	// Empty scope should fall back to the client's full scope
+	assert.Equal(t, client.Scopes, req.Scopes)
+}
+
+func TestValidateAuthorizationRequest_InvalidResponseType(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+
+	_, err := svc.ValidateAuthorizationRequest(
+		client.ClientID, "https://app.example.com/callback", "token", "", "",
+	)
+	assert.ErrorIs(t, err, ErrUnsupportedResponseType)
+}
+
+func TestValidateAuthorizationRequest_UnknownClient(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+
+	_, err := svc.ValidateAuthorizationRequest(
+		"nonexistent", "https://app.example.com/callback", "code", "", "",
+	)
+	assert.ErrorIs(t, err, ErrUnauthorizedClient)
+}
+
+func TestValidateAuthorizationRequest_AuthCodeFlowDisabled(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := &models.OAuthApplication{
+		ClientID:           uuid.New().String(),
+		ClientSecret:       "secret",
+		ClientName:         "No Auth Code Client",
+		UserID:             uuid.New().String(),
+		Scopes:             "read",
+		GrantTypes:         "device_code",
+		RedirectURIs:       models.StringArray{"https://app.example.com/callback"},
+		ClientType:         "confidential",
+		EnableAuthCodeFlow: false, // disabled
+		IsActive:           true,
+	}
+	require.NoError(t, svc.store.CreateClient(client))
+
+	_, err := svc.ValidateAuthorizationRequest(
+		client.ClientID, "https://app.example.com/callback", "code", "", "",
+	)
+	assert.ErrorIs(t, err, ErrUnauthorizedClient)
+}
+
+func TestValidateAuthorizationRequest_InvalidRedirectURI(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+
+	_, err := svc.ValidateAuthorizationRequest(
+		client.ClientID, "https://evil.example.com/callback", "code", "", "",
+	)
+	assert.ErrorIs(t, err, ErrInvalidRedirectURI)
+}
+
+func TestValidateAuthorizationRequest_InvalidScope(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+
+	_, err := svc.ValidateAuthorizationRequest(
+		client.ClientID, "https://app.example.com/callback", "code", "admin", "",
+	)
+	assert.ErrorIs(t, err, ErrInvalidAuthCodeScope)
+}
+
+func TestValidateAuthorizationRequest_PublicClientRequiresPKCE(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "public")
+
+	// No code_challenge_method → should fail for public client
+	_, err := svc.ValidateAuthorizationRequest(
+		client.ClientID, "https://app.example.com/callback", "code", "read", "",
+	)
+	assert.ErrorIs(t, err, ErrPKCERequired)
+}
+
+func TestValidateAuthorizationRequest_PublicClientWithPKCE(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "public")
+
+	req, err := svc.ValidateAuthorizationRequest(
+		client.ClientID, "https://app.example.com/callback", "code", "read", "S256",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "S256", req.CodeChallengeMethod)
+}
+
+// ============================================================
+// CreateAuthorizationCode
+// ============================================================
+
+func TestCreateAuthorizationCode_Success(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+	userID := uuid.New().String()
+
+	plainCode, record, err := svc.CreateAuthorizationCode(
+		context.Background(),
+		client.ID,
+		client.ClientID,
+		userID,
+		"https://app.example.com/callback",
+		"read write",
+		"", "",
+	)
+
+	require.NoError(t, err)
+	assert.Len(t, plainCode, 64) // 32 bytes hex-encoded
+	assert.NotEmpty(t, record.UUID)
+	assert.Equal(t, client.ID, record.ApplicationID)
+	assert.Equal(t, userID, record.UserID)
+	assert.False(t, record.IsExpired())
+	assert.False(t, record.IsUsed())
+}
+
+func TestCreateAuthorizationCode_WithPKCE(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "public")
+	userID := uuid.New().String()
+
+	verifier := testPKCEVerifier
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	_, record, err := svc.CreateAuthorizationCode(
+		context.Background(),
+		client.ID, client.ClientID, userID,
+		"https://app.example.com/callback", "read",
+		challenge, "S256",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, challenge, record.CodeChallenge)
+	assert.Equal(t, "S256", record.CodeChallengeMethod)
+}
+
+// ============================================================
+// ExchangeCode
+// ============================================================
+
+func TestExchangeCode_Success_ConfidentialClient(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+	userID := uuid.New().String()
+
+	plainCode, _, err := svc.CreateAuthorizationCode(
+		context.Background(),
+		client.ID, client.ClientID, userID,
+		"https://app.example.com/callback", "read write", "", "",
+	)
+	require.NoError(t, err)
+
+	authCode, err := svc.ExchangeCode(
+		context.Background(),
+		plainCode,
+		client.ClientID,
+		"https://app.example.com/callback",
+		testClientPlainSecret,
+		"",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, userID, authCode.UserID)
+	assert.Equal(t, client.ClientID, authCode.ClientID)
+	// Code should now be marked used
+	assert.True(t, authCode.IsUsed())
+}
+
+func TestExchangeCode_Success_PublicClient_PKCE_S256(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "public")
+	userID := uuid.New().String()
+
+	verifier := testPKCEVerifier
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	plainCode, _, err := svc.CreateAuthorizationCode(
+		context.Background(),
+		client.ID, client.ClientID, userID,
+		"https://app.example.com/callback", "read",
+		challenge, "S256",
+	)
+	require.NoError(t, err)
+
+	_, err = svc.ExchangeCode(
+		context.Background(),
+		plainCode, client.ClientID,
+		"https://app.example.com/callback",
+		"", verifier,
+	)
+	require.NoError(t, err)
+}
+
+func TestExchangeCode_ReplayAttack(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+	userID := uuid.New().String()
+
+	plainCode, _, err := svc.CreateAuthorizationCode(
+		context.Background(),
+		client.ID, client.ClientID, userID,
+		"https://app.example.com/callback", "read", "", "",
+	)
+	require.NoError(t, err)
+
+	// First exchange succeeds
+	_, err = svc.ExchangeCode(context.Background(), plainCode, client.ClientID,
+		"https://app.example.com/callback", testClientPlainSecret, "")
+	require.NoError(t, err)
+
+	// Second exchange with same code must fail
+	_, err = svc.ExchangeCode(context.Background(), plainCode, client.ClientID,
+		"https://app.example.com/callback", testClientPlainSecret, "")
+	assert.ErrorIs(t, err, ErrAuthCodeAlreadyUsed)
+}
+
+func TestExchangeCode_ExpiredCode(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	svc.config.AuthCodeExpiration = -1 * time.Second // already expired
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+	userID := uuid.New().String()
+
+	plainCode, _, err := svc.CreateAuthorizationCode(
+		context.Background(),
+		client.ID, client.ClientID, userID,
+		"https://app.example.com/callback", "read", "", "",
+	)
+	require.NoError(t, err)
+
+	_, err = svc.ExchangeCode(context.Background(), plainCode, client.ClientID,
+		"https://app.example.com/callback", testClientPlainSecret, "")
+	assert.ErrorIs(t, err, ErrAuthCodeExpired)
+}
+
+func TestExchangeCode_WrongRedirectURI(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+	userID := uuid.New().String()
+
+	plainCode, _, err := svc.CreateAuthorizationCode(
+		context.Background(),
+		client.ID, client.ClientID, userID,
+		"https://app.example.com/callback", "read", "", "",
+	)
+	require.NoError(t, err)
+
+	_, err = svc.ExchangeCode(context.Background(), plainCode, client.ClientID,
+		"https://other.example.com/callback", testClientPlainSecret, "")
+	assert.ErrorIs(t, err, ErrInvalidRedirectURI)
+}
+
+func TestExchangeCode_WrongClientSecret(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+	userID := uuid.New().String()
+
+	plainCode, _, err := svc.CreateAuthorizationCode(
+		context.Background(),
+		client.ID, client.ClientID, userID,
+		"https://app.example.com/callback", "read", "", "",
+	)
+	require.NoError(t, err)
+
+	_, err = svc.ExchangeCode(context.Background(), plainCode, client.ClientID,
+		"https://app.example.com/callback", "wrong-secret", "")
+	assert.ErrorIs(t, err, ErrUnauthorizedClient)
+}
+
+func TestExchangeCode_WrongCodeVerifier(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "public")
+	userID := uuid.New().String()
+
+	verifier := "correct-verifier-string-long-enough-for-pkce-use"
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	plainCode, _, err := svc.CreateAuthorizationCode(
+		context.Background(),
+		client.ID, client.ClientID, userID,
+		"https://app.example.com/callback", "read",
+		challenge, "S256",
+	)
+	require.NoError(t, err)
+
+	_, err = svc.ExchangeCode(context.Background(), plainCode, client.ClientID,
+		"https://app.example.com/callback", "", "wrong-verifier")
+	assert.ErrorIs(t, err, ErrInvalidCodeVerifier)
+}
+
+// ============================================================
+// UserAuthorization consent management
+// ============================================================
+
+func TestSaveUserAuthorization_CreateAndUpsert(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+	userID := uuid.New().String()
+
+	// First save – creates record
+	auth, err := svc.SaveUserAuthorization(
+		context.Background(), userID, client.ID, client.ClientID, "read",
+	)
+	require.NoError(t, err)
+	assert.True(t, auth.IsActive)
+	assert.Equal(t, "read", auth.Scopes)
+	firstUUID := auth.UUID
+
+	// Second save with expanded scopes – should update, not duplicate
+	auth2, err := svc.SaveUserAuthorization(
+		context.Background(), userID, client.ID, client.ClientID, "read write",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "read write", auth2.Scopes)
+	assert.True(t, auth2.IsActive)
+	// UUID may differ (new UUID on upsert) but there should still be only one record
+	_ = firstUUID
+}
+
+func TestGetUserAuthorization_ExistsAndMissing(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+	userID := uuid.New().String()
+
+	// Before saving: should return nil, nil
+	auth, err := svc.GetUserAuthorization(userID, client.ID)
+	require.NoError(t, err)
+	assert.Nil(t, auth)
+
+	// After saving
+	_, err = svc.SaveUserAuthorization(
+		context.Background(), userID, client.ID, client.ClientID, "read",
+	)
+	require.NoError(t, err)
+
+	auth, err = svc.GetUserAuthorization(userID, client.ID)
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+	assert.Equal(t, "read", auth.Scopes)
+}
+
+func TestRevokeUserAuthorization_Success(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+	userID := uuid.New().String()
+
+	auth, err := svc.SaveUserAuthorization(
+		context.Background(), userID, client.ID, client.ClientID, "read write",
+	)
+	require.NoError(t, err)
+
+	err = svc.RevokeUserAuthorization(context.Background(), auth.UUID, userID)
+	require.NoError(t, err)
+
+	// After revoke, GetUserAuthorization should return nil (no active record)
+	found, err := svc.GetUserAuthorization(userID, client.ID)
+	require.NoError(t, err)
+	assert.Nil(t, found)
+}
+
+func TestRevokeUserAuthorization_WrongUser(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+	ownerID := uuid.New().String()
+	otherID := uuid.New().String()
+
+	auth, err := svc.SaveUserAuthorization(
+		context.Background(), ownerID, client.ID, client.ClientID, "read",
+	)
+	require.NoError(t, err)
+
+	// Attempt to revoke with a different user ID
+	err = svc.RevokeUserAuthorization(context.Background(), auth.UUID, otherID)
+	assert.ErrorIs(t, err, ErrAuthorizationNotFound)
+}
+
+func TestListUserAuthorizations_MultipleClients(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	userID := uuid.New().String()
+
+	for i := 0; i < 3; i++ {
+		c := &models.OAuthApplication{
+			ClientID:           uuid.New().String(),
+			ClientSecret:       "secret",
+			ClientName:         fmt.Sprintf("Client %d", i),
+			UserID:             uuid.New().String(),
+			Scopes:             "read",
+			GrantTypes:         "authorization_code",
+			RedirectURIs:       models.StringArray{"https://app.example.com/cb"},
+			ClientType:         "confidential",
+			EnableAuthCodeFlow: true,
+			IsActive:           true,
+		}
+		require.NoError(t, svc.store.CreateClient(c))
+		_, err := svc.SaveUserAuthorization(context.Background(), userID, c.ID, c.ClientID, "read")
+		require.NoError(t, err)
+	}
+
+	auths, err := svc.ListUserAuthorizations(context.Background(), userID)
+	require.NoError(t, err)
+	assert.Len(t, auths, 3)
+}
+
+// ============================================================
+// RevokeAllApplicationTokens (admin P6)
+// ============================================================
+
+func TestRevokeAllApplicationTokens_RevokesConsentRecords(t *testing.T) {
+	svc := createTestAuthorizationService(t)
+	client := createAuthCodeFlowClient(t, svc, "confidential")
+
+	// Grant access for 2 users
+	for i := 0; i < 2; i++ {
+		userID := uuid.New().String()
+		_, err := svc.SaveUserAuthorization(
+			context.Background(), userID, client.ID, client.ClientID, "read",
+		)
+		require.NoError(t, err)
+	}
+
+	// Revoke all
+	adminID := uuid.New().String()
+	revokedCount, err := svc.RevokeAllApplicationTokens(
+		context.Background(),
+		client.ClientID,
+		adminID,
+	)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, revokedCount, int64(0)) // 0 tokens in DB (no actual tokens created)
+
+	// All consent records for this client should now be inactive
+	auths, err := svc.store.GetClientAuthorizations(client.ClientID)
+	require.NoError(t, err)
+	assert.Empty(t, auths) // active records only; all revoked
+}
+
+// ============================================================
+// PKCE helper unit tests
+// ============================================================
+
+func TestVerifyPKCE_S256(t *testing.T) {
+	verifier := testPKCEVerifier
+	sum := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
+
+	assert.True(t, verifyPKCE(challenge, "S256", verifier))
+	assert.False(t, verifyPKCE(challenge, "S256", "wrong-verifier"))
+	assert.False(t, verifyPKCE(challenge, "S256", ""))
+}
+
+func TestVerifyPKCE_Plain(t *testing.T) {
+	challenge := "my-plain-verifier"
+	assert.True(t, verifyPKCE(challenge, "plain", challenge))
+	assert.False(t, verifyPKCE(challenge, "plain", "other"))
+}
+
+func TestVerifyPKCE_EmptyMethod(t *testing.T) {
+	challenge := "my-plain-verifier"
+	// Empty method falls back to plain
+	assert.True(t, verifyPKCE(challenge, "", challenge))
+}

--- a/internal/templates/account_authorizations.templ
+++ b/internal/templates/account_authorizations.templ
@@ -1,0 +1,73 @@
+package templates
+
+import "fmt"
+
+templ AccountAuthorizations(props AuthorizationsPageProps) {
+	@Layout("Authorized Applications", LayoutHasNavbar, &props.NavbarProps) {
+		<link rel="stylesheet" href="/static/css/pages/account-authorizations.css"/>
+		<div class="main-content">
+			<div class="authorizations-page-container">
+				<div class="card">
+					<!-- Card Header -->
+					<div class="authorizations-card-header">
+						<h1 class="authorizations-title">Authorized Applications</h1>
+						<p class="authorizations-subtitle">Applications that have access to your account</p>
+					</div>
+					<!-- Alert -->
+					@Alert(props.Error, AlertError)
+					@Alert(props.Success, AlertSuccess)
+					if len(props.Authorizations) > 0 {
+						<div class="authorizations-list-header">
+							<span class="authorizations-count">
+								{ fmt.Sprintf("%d", len(props.Authorizations)) } application(s)
+							</span>
+						</div>
+						<div class="authorizations-list">
+							for _, auth := range props.Authorizations {
+								@AuthorizationItem(auth, props.CSRFToken)
+							}
+						</div>
+					} else {
+						<div class="empty-state">
+							<div class="empty-icon">🔓</div>
+							<h3 class="empty-title">No Authorized Applications</h3>
+							<p class="empty-text">
+								You haven't authorized any applications yet.
+								Applications will appear here after you grant them access.
+							</p>
+						</div>
+					}
+				</div>
+			</div>
+		</div>
+	}
+}
+
+templ AuthorizationItem(auth AuthorizationDisplay, csrfToken string) {
+	<div class="authorization-item">
+		<!-- Icon -->
+		<div class="authorization-app-icon">🔗</div>
+		<!-- Info -->
+		<div class="authorization-info">
+			<div class="authorization-app-name">{ auth.ClientName }</div>
+			<div class="authorization-meta">
+				<span class="authorization-scopes">{ auth.Scopes }</span>
+				<span class="authorization-date">{ auth.GrantedAt.Format("2006-01-02 15:04") }</span>
+				<span class="authorization-status active">Active</span>
+			</div>
+		</div>
+		<!-- Actions -->
+		<div class="authorization-actions">
+			<form method="POST" action={ templ.URL("/account/authorizations/" + auth.UUID + "/revoke") } style="margin:0;">
+				<input type="hidden" name="csrf_token" value={ csrfToken }/>
+				<button
+					type="submit"
+					class="authorization-revoke-btn"
+					onclick="return confirm('Revoke access for this application? All its tokens will be invalidated.')"
+				>
+					Revoke Access
+				</button>
+			</form>
+		</div>
+	</div>
+}

--- a/internal/templates/admin_client_authorizations.templ
+++ b/internal/templates/admin_client_authorizations.templ
@@ -1,0 +1,77 @@
+package templates
+
+import "fmt"
+
+templ AdminClientAuthorizations(props ClientAuthorizationsPageProps) {
+	@Layout("Client Authorizations", LayoutAdminNavbar, &props.NavbarProps) {
+		<link rel="stylesheet" href="/static/css/pages/admin-tables.css"/>
+		<link rel="stylesheet" href="/static/css/pages/admin-forms.css"/>
+		<div class="main-content">
+			<div class="admin-form-container" style="max-width:1000px;">
+				<div class="card">
+					<div class="admin-form-header">
+						<h1 class="admin-form-title">Authorized Users</h1>
+						<p style="font-size:var(--text-sm);color:var(--color-text-secondary);margin-top:var(--space-2);">
+							Users who have granted access to <strong>{ props.Client.ClientName }</strong>
+						</p>
+					</div>
+					@Alert(props.Error, AlertError)
+					if len(props.Authorizations) > 0 {
+						<!-- Summary bar -->
+						<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-6);padding-bottom:var(--space-4);border-bottom:2px solid var(--color-border);">
+							<span style="font-family:var(--font-mono);font-size:var(--text-sm);font-weight:600;color:var(--color-text-primary);">
+								{ fmt.Sprintf("%d", len(props.Authorizations)) } active grant(s)
+							</span>
+							<a href={ templ.URL("/admin/clients/" + props.Client.ClientID) } class="admin-action-btn secondary" style="padding:var(--space-2) var(--space-4);font-size:var(--text-sm);">
+								← Back to Client
+							</a>
+						</div>
+						<!-- Table -->
+						<div class="admin-table-wrapper">
+							<table class="admin-table">
+								<thead>
+									<tr>
+										<th>User</th>
+										<th>Email</th>
+										<th>Scopes</th>
+										<th>Granted At</th>
+									</tr>
+								</thead>
+								<tbody>
+									for _, auth := range props.Authorizations {
+										<tr>
+											<td>
+												<span style="font-weight:600;color:var(--color-text-primary);">{ auth.Username }</span>
+												<span style="display:block;font-family:var(--font-mono);font-size:var(--text-xs);color:var(--color-text-tertiary);">{ auth.UserID }</span>
+											</td>
+											<td style="font-size:var(--text-sm);color:var(--color-text-secondary);">{ auth.Email }</td>
+											<td>
+												<span style="font-family:var(--font-mono);font-size:var(--text-xs);background:var(--color-bg-tertiary);padding:var(--space-1) var(--space-2);border-radius:var(--radius-sm);border:1px solid var(--color-border);">
+													{ auth.Scopes }
+												</span>
+											</td>
+											<td style="font-family:var(--font-mono);font-size:var(--text-sm);white-space:nowrap;">
+												{ auth.GrantedAt.Format("2006-01-02 15:04") }
+											</td>
+										</tr>
+									}
+								</tbody>
+							</table>
+						</div>
+					} else {
+						<div class="empty-state">
+							<div class="empty-icon">🔓</div>
+							<h3 class="empty-title">No Authorized Users</h3>
+							<p class="empty-text">No users have granted access to this application yet.</p>
+						</div>
+						<div style="margin-top:var(--space-6);text-align:center;">
+							<a href={ templ.URL("/admin/clients/" + props.Client.ClientID) } class="admin-action-btn secondary">
+								← Back to Client
+							</a>
+						</div>
+					}
+				</div>
+			</div>
+		</div>
+	}
+}

--- a/internal/templates/admin_client_detail.templ
+++ b/internal/templates/admin_client_detail.templ
@@ -1,5 +1,7 @@
 package templates
 
+import "fmt"
+
 templ AdminClientDetail(props ClientDetailPageProps) {
 	@Layout("Client Details", LayoutAdminNavbar, &props.NavbarProps) {
 		<link rel="stylesheet" href="/static/css/pages/admin-forms.css"/>
@@ -9,6 +11,9 @@ templ AdminClientDetail(props ClientDetailPageProps) {
 					<div class="admin-form-header">
 						<h1 class="admin-form-title">Client Details</h1>
 					</div>
+					<!-- Alerts -->
+					@Alert(props.Error, AlertError)
+					@Alert(props.Success, AlertSuccess)
 					<div class="admin-detail-section">
 						<div class="admin-detail-row">
 							<div class="admin-detail-label">Client ID</div>
@@ -24,6 +29,16 @@ templ AdminClientDetail(props ClientDetailPageProps) {
 								<div class="admin-detail-value">{ props.Client.Description }</div>
 							</div>
 						}
+						<div class="admin-detail-row">
+							<div class="admin-detail-label">Client Type</div>
+							<div class="admin-detail-value">
+								if props.Client.ClientType == "public" {
+									<span class="status-badge" style="background:rgba(245,158,11,0.1);color:#D97706;border:1px solid rgba(245,158,11,0.3);">Public</span>
+								} else {
+									<span class="status-badge" style="background:rgba(0,114,255,0.1);color:#0072ff;border:1px solid rgba(0,114,255,0.3);">Confidential</span>
+								}
+							</div>
+						</div>
 						<div class="admin-detail-row">
 							<div class="admin-detail-label">Scopes</div>
 							<div class="admin-detail-value">{ props.Client.Scopes }</div>
@@ -49,6 +64,16 @@ templ AdminClientDetail(props ClientDetailPageProps) {
 							</div>
 						</div>
 						<div class="admin-detail-row">
+							<div class="admin-detail-label">Auth Code Flow</div>
+							<div class="admin-detail-value">
+								if props.Client.EnableAuthCodeFlow {
+									<span class="status-badge status-active">Enabled</span>
+								} else {
+									<span class="status-badge status-inactive">Disabled</span>
+								}
+							</div>
+						</div>
+						<div class="admin-detail-row">
 							<div class="admin-detail-label">Status</div>
 							<div class="admin-detail-value">
 								if props.Client.IsActive {
@@ -67,6 +92,7 @@ templ AdminClientDetail(props ClientDetailPageProps) {
 							<div class="admin-detail-value">{ props.Client.UpdatedAt.Format("2006-01-02 15:04:05") }</div>
 						</div>
 					</div>
+					<!-- Standard Actions -->
 					<div class="admin-action-buttons">
 						<a href={ templ.URL("/admin/clients/" + props.Client.ClientID + "/edit") } class="admin-action-btn primary">
 							✏️ Edit Client
@@ -78,9 +104,46 @@ templ AdminClientDetail(props ClientDetailPageProps) {
 						>
 							🔄 Regenerate Secret
 						</a>
+						<a href={ templ.URL("/admin/clients/" + props.Client.ClientID + "/authorizations") } class="admin-action-btn secondary">
+							👥 Authorized Users
+						</a>
 						<a href="/admin/clients" class="admin-action-btn secondary">
 							← Back to List
 						</a>
+					</div>
+					<!-- Danger Zone: Revoke All Tokens -->
+					<div class="admin-danger-zone">
+						<div class="admin-danger-zone-header">
+							<h3 class="admin-danger-zone-title">⚠️ Danger Zone</h3>
+							<p class="admin-danger-zone-desc">
+								These actions are irreversible. Revoking all tokens will force all users to re-authenticate.
+							</p>
+						</div>
+						<div class="admin-danger-zone-body">
+							<div class="admin-danger-item">
+								<div class="admin-danger-item-info">
+									<strong>Revoke All User Tokens</strong>
+									<span>
+										Immediately invalidate all active access and refresh tokens for this client.
+										if props.ActiveTokenCount > 0 {
+											Currently <strong>{ fmt.Sprintf("%d", props.ActiveTokenCount) }</strong> active token(s).
+										} else {
+											No active tokens.
+										}
+									</span>
+								</div>
+								<form method="POST" action={ templ.URL("/admin/clients/" + props.Client.ClientID + "/revoke-all") } style="margin:0;">
+									<input type="hidden" name="csrf_token" value={ props.CSRFToken }/>
+									<button
+										type="submit"
+										class="admin-action-btn danger"
+										onclick="return confirm('Revoke ALL active tokens for this client? All users will need to re-authenticate. This cannot be undone.')"
+									>
+										Revoke All Tokens
+									</button>
+								</form>
+							</div>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/internal/templates/admin_client_form.templ
+++ b/internal/templates/admin_client_form.templ
@@ -12,28 +12,17 @@ templ AdminClientForm(props ClientFormPageProps) {
 					@Alert(props.Error, AlertError)
 					<form method={ props.Method } action={ templ.URL(props.Action) } class="admin-form">
 						<input type="hidden" name="csrf_token" value={ props.CSRFToken }/>
+						<!-- Client Name -->
 						<div class="admin-form-group">
 							<label for="client_name" class="admin-form-label admin-form-label-required">Client Name</label>
 							if props.Client != nil {
-								<input
-									type="text"
-									id="client_name"
-									name="client_name"
-									class="admin-form-input"
-									value={ props.Client.ClientName }
-									required
-								/>
+								<input type="text" id="client_name" name="client_name" class="admin-form-input" value={ props.Client.ClientName } required/>
 							} else {
-								<input
-									type="text"
-									id="client_name"
-									name="client_name"
-									class="admin-form-input"
-									required
-								/>
+								<input type="text" id="client_name" name="client_name" class="admin-form-input" required/>
 							}
 							<small class="admin-form-hint">A human-readable name for this OAuth client</small>
 						</div>
+						<!-- Description -->
 						<div class="admin-form-group">
 							<label for="description" class="admin-form-label">Description</label>
 							if props.Client != nil {
@@ -43,36 +32,70 @@ templ AdminClientForm(props ClientFormPageProps) {
 							}
 							<small class="admin-form-hint">Optional description of this client's purpose</small>
 						</div>
+						<!-- Client Type -->
+						<div class="admin-form-group">
+							<label for="client_type" class="admin-form-label admin-form-label-required">Client Type</label>
+							<select id="client_type" name="client_type" class="admin-form-select">
+								<option
+									value="confidential"
+									selected?={ props.Client == nil || props.Client.ClientType != "public" }
+								>
+									Confidential — server-side apps that can store a secret
+								</option>
+								<option
+									value="public"
+									selected?={ props.Client != nil && props.Client.ClientType == "public" }
+								>
+									Public — SPAs, CLIs, mobile apps (PKCE required)
+								</option>
+							</select>
+							<small class="admin-form-hint">
+								Confidential clients authenticate with a secret.
+								Public clients use PKCE instead (no secret required).
+							</small>
+						</div>
+						<!-- Grant Types (checkboxes) -->
+						<div class="admin-form-group">
+							<label class="admin-form-label admin-form-label-required">Grant Types</label>
+							<div class="admin-form-checkboxes">
+								<label class="admin-form-checkbox-label">
+									<input
+										type="checkbox"
+										name="enable_device_flow"
+										value="true"
+										checked?={ props.Client == nil || props.Client.EnableDeviceFlow }
+									/>
+									<span>
+										<strong>Device Authorization Flow</strong> (RFC 8628)
+										— for CLI tools and devices without a browser
+									</span>
+								</label>
+								<label class="admin-form-checkbox-label">
+									<input
+										type="checkbox"
+										name="enable_auth_code_flow"
+										value="true"
+										checked?={ props.Client != nil && props.Client.EnableAuthCodeFlow }
+									/>
+									<span>
+										<strong>Authorization Code Flow</strong> (RFC 6749)
+										— for web apps with a redirect URI callback
+									</span>
+								</label>
+							</div>
+							<small class="admin-form-hint">At least one grant type must be selected.</small>
+						</div>
+						<!-- Scopes -->
 						<div class="admin-form-group">
 							<label for="scopes" class="admin-form-label">Scopes</label>
 							if props.Client != nil {
-								<input
-									type="text"
-									id="scopes"
-									name="scopes"
-									class="admin-form-input"
-									value={ props.Client.Scopes }
-								/>
+								<input type="text" id="scopes" name="scopes" class="admin-form-input" value={ props.Client.Scopes }/>
 							} else {
-								<input
-									type="text"
-									id="scopes"
-									name="scopes"
-									class="admin-form-input"
-									value="read write"
-								/>
+								<input type="text" id="scopes" name="scopes" class="admin-form-input" value="read write"/>
 							}
 							<small class="admin-form-hint">Space-separated list of scopes (e.g., "read write")</small>
 						</div>
-						<div class="admin-form-group">
-							<label for="grant_types" class="admin-form-label">Grant Types</label>
-							<select id="grant_types" name="grant_types" class="admin-form-select">
-								<option value="device_code" selected>
-									Device Code Flow (RFC 8628)
-								</option>
-							</select>
-							<small class="admin-form-hint">Currently only Device Code Flow is supported</small>
-						</div>
+						<!-- Redirect URIs -->
 						<div class="admin-form-group">
 							<label for="redirect_uris" class="admin-form-label">Redirect URIs</label>
 							if props.Client != nil {
@@ -80,8 +103,12 @@ templ AdminClientForm(props ClientFormPageProps) {
 							} else {
 								<textarea id="redirect_uris" name="redirect_uris" class="admin-form-textarea" rows="3"></textarea>
 							}
-							<small class="admin-form-hint">Comma-separated redirect URIs (optional for device flow)</small>
+							<small class="admin-form-hint">
+								Comma-separated redirect URIs. Required when Authorization Code Flow is enabled.
+								Example: <code>https://app.example.com/callback</code>
+							</small>
 						</div>
+						<!-- Status (edit only) -->
 						if props.IsEdit {
 							<div class="admin-form-group">
 								<label for="is_active" class="admin-form-label">Status</label>
@@ -106,6 +133,7 @@ templ AdminClientForm(props ClientFormPageProps) {
 								</div>
 							</div>
 						}
+						<!-- Actions -->
 						<div class="admin-form-actions">
 							<button type="submit" class="admin-form-submit-btn">
 								if props.IsEdit {

--- a/internal/templates/admin_clients.templ
+++ b/internal/templates/admin_clients.templ
@@ -206,6 +206,13 @@ templ ClientTableRow(client services.ClientWithCreator, csrfToken string) {
 			<code class="grant-types-code">
 				{ client.GrantTypes }
 			</code>
+			<div style="margin-top:var(--space-1);">
+				if client.ClientType == "public" {
+					<span class="status-badge" style="background:rgba(245,158,11,0.1);color:#D97706;border:1px solid rgba(245,158,11,0.3);font-size:var(--text-xs);">Public</span>
+				} else {
+					<span class="status-badge" style="background:rgba(0,114,255,0.08);color:#0072ff;border:1px solid rgba(0,114,255,0.25);font-size:var(--text-xs);">Confidential</span>
+				}
+			</div>
 		</td>
 		<td>
 			if client.IsActive {

--- a/internal/templates/authorize.templ
+++ b/internal/templates/authorize.templ
@@ -1,0 +1,110 @@
+package templates
+
+import "strings"
+
+templ AuthorizePage(props AuthorizePageProps) {
+	@Layout("Authorize Access", LayoutNoNavbar, nil) {
+		<link rel="stylesheet" href="/static/css/pages/authorize.css"/>
+		<div class="authorize-container">
+			<div class="authorize-card">
+				<!-- App Header -->
+				<div class="authorize-app-header">
+					<div class="authorize-app-icon">🔐</div>
+					<div class="authorize-app-info">
+						<div class="authorize-app-name">{ props.ClientName }</div>
+						<div class="authorize-app-id">{ props.ClientID }</div>
+					</div>
+				</div>
+				<!-- Title -->
+				<div class="authorize-title-section">
+					<h1 class="authorize-title">Authorize Access</h1>
+					<p class="authorize-subtitle">
+						<strong>{ props.ClientName }</strong> is requesting access to your account.
+					</p>
+					<div class="authorize-user-tag">Signed in as { props.Username }</div>
+				</div>
+				<!-- Error Alert -->
+				@Alert(props.Error, AlertError)
+				<!-- App Description -->
+				if props.ClientDescription != "" {
+					<div class="authorize-app-description">{ props.ClientDescription }</div>
+				}
+				<!-- Redirect URI -->
+				<div class="authorize-redirect-info">
+					<span class="authorize-redirect-label">Redirect to</span>
+					<span class="authorize-redirect-uri">{ props.RedirectURI }</span>
+				</div>
+				<!-- Requested Scopes -->
+				<div class="authorize-scopes-label">Requested Permissions</div>
+				<ul class="authorize-scopes-list">
+					for _, scope := range props.ScopeList {
+						<li class="authorize-scope-item">
+							<div class="authorize-scope-check">✓</div>
+							<div class="authorize-scope-text">
+								<span class="authorize-scope-name">{ scope }</span>
+								<span class="authorize-scope-desc">{ scopeDescription(scope) }</span>
+							</div>
+						</li>
+					}
+				</ul>
+				<!-- Action Form -->
+				<div class="authorize-actions">
+					<!-- Allow -->
+					<form method="POST" action="/oauth/authorize" style="margin:0;">
+						<input type="hidden" name="csrf_token" value={ props.CSRFToken }/>
+						<input type="hidden" name="action" value="approve"/>
+						<input type="hidden" name="client_id" value={ props.ClientID }/>
+						<input type="hidden" name="redirect_uri" value={ props.RedirectURI }/>
+						<input type="hidden" name="scope" value={ props.Scopes }/>
+						<input type="hidden" name="state" value={ props.State }/>
+						<input type="hidden" name="code_challenge" value={ props.CodeChallenge }/>
+						<input type="hidden" name="code_challenge_method" value={ props.CodeChallengeMethod }/>
+						<button type="submit" class="authorize-btn-allow">
+							Allow Access
+						</button>
+					</form>
+					<!-- Deny -->
+					<form method="POST" action="/oauth/authorize" style="margin:0;">
+						<input type="hidden" name="csrf_token" value={ props.CSRFToken }/>
+						<input type="hidden" name="action" value="deny"/>
+						<input type="hidden" name="client_id" value={ props.ClientID }/>
+						<input type="hidden" name="redirect_uri" value={ props.RedirectURI }/>
+						<input type="hidden" name="state" value={ props.State }/>
+						<button type="submit" class="authorize-btn-deny">
+							Deny
+						</button>
+					</form>
+				</div>
+				<!-- Footer Note -->
+				<div class="authorize-footer-note">
+					By clicking <strong>Allow Access</strong>, you grant <strong>{ props.ClientName }</strong>
+					permission to access your account with the listed permissions.
+					You can revoke this access at any time from
+					<a href="/account/authorizations">Account &rsaquo; Authorizations</a>.
+				</div>
+			</div>
+		</div>
+	}
+}
+
+// scopeDescription returns a human-readable description for a known scope.
+func scopeDescription(scope string) string {
+	switch strings.ToLower(scope) {
+	case "read":
+		return "Read your profile and data"
+	case "write":
+		return "Create and modify data on your behalf"
+	case "admin":
+		return "Full administrative access"
+	case "openid":
+		return "Verify your identity"
+	case "profile":
+		return "Access your name and profile information"
+	case "email":
+		return "Access your email address"
+	case "offline_access":
+		return "Access your data when you're not present (refresh tokens)"
+	default:
+		return scope
+	}
+}

--- a/internal/templates/navbar_component.templ
+++ b/internal/templates/navbar_component.templ
@@ -11,6 +11,7 @@ templ Navbar(props *NavbarProps) {
 				<div class="navbar-links">
 					@NavLink("/device", "Device Authorization", props.ActiveLink == "device", false)
 					@NavLink("/account/sessions", "Active Sessions", props.ActiveLink == "sessions", false)
+					@NavLink("/account/authorizations", "Authorized Apps", props.ActiveLink == "authorizations", false)
 					if props.IsAdmin {
 						@NavLink("/admin/clients", "OAuth Clients", props.ActiveLink == "clients", true)
 						@NavLink("/admin/audit", "Audit Logs", props.ActiveLink == "audit", true)

--- a/internal/templates/props.go
+++ b/internal/templates/props.go
@@ -91,17 +91,19 @@ type ClientsPageProps struct {
 
 // ClientDisplay wraps OAuthApplication with string fields for template rendering
 type ClientDisplay struct {
-	ID               int64
-	ClientID         string
-	ClientName       string
-	Description      string
-	Scopes           string
-	GrantTypes       string
-	RedirectURIs     string // Comma-separated string
-	EnableDeviceFlow bool
-	IsActive         bool
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
+	ID                 int64
+	ClientID           string
+	ClientName         string
+	Description        string
+	Scopes             string
+	GrantTypes         string
+	RedirectURIs       string // Comma-separated string
+	ClientType         string // "confidential" or "public"
+	EnableDeviceFlow   bool
+	EnableAuthCodeFlow bool
+	IsActive           bool
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
 }
 
 // ClientFormPageProps contains properties for the client form page
@@ -136,8 +138,64 @@ type ClientSecretPageProps struct {
 type ClientDetailPageProps struct {
 	BaseProps
 	NavbarProps
-	Client  *models.OAuthApplication
-	Success string
+	Client           *models.OAuthApplication
+	ActiveTokenCount int64 // Number of active tokens for this client
+	Success          string
+	Error            string
+}
+
+// AuthorizePageProps contains properties for the OAuth consent page
+type AuthorizePageProps struct {
+	BaseProps
+	Username            string
+	ClientID            string
+	ClientName          string
+	ClientDescription   string
+	RedirectURI         string
+	Scopes              string   // Space-separated scope string
+	ScopeList           []string // Pre-split scope list for template iteration
+	State               string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	Error               string
+}
+
+// AuthorizationDisplay is a view model for a single user authorization entry
+type AuthorizationDisplay struct {
+	UUID       string
+	ClientID   string
+	ClientName string
+	Scopes     string
+	GrantedAt  time.Time
+	IsActive   bool
+}
+
+// AuthorizationsPageProps contains properties for the account authorizations page
+type AuthorizationsPageProps struct {
+	BaseProps
+	NavbarProps
+	Authorizations []AuthorizationDisplay
+	Success        string
+	Error          string
+}
+
+// ClientAuthorizationDisplay is a view model for one user's grant on the admin overview page
+type ClientAuthorizationDisplay struct {
+	UUID      string
+	UserID    string
+	Username  string
+	Email     string
+	Scopes    string
+	GrantedAt time.Time
+}
+
+// ClientAuthorizationsPageProps contains properties for the admin client-authorizations page
+type ClientAuthorizationsPageProps struct {
+	BaseProps
+	NavbarProps
+	Client         *models.OAuthApplication
+	Authorizations []ClientAuthorizationDisplay
+	Error          string
 }
 
 // AuditLogsPageProps contains properties for the audit logs page

--- a/internal/templates/static/css/pages/account-authorizations.css
+++ b/internal/templates/static/css/pages/account-authorizations.css
@@ -1,0 +1,258 @@
+/* ============================================
+   Account Authorizations Page
+   User-facing consent / app management
+   ============================================ */
+
+.authorizations-page-container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+/* Card Header */
+.authorizations-card-header {
+  text-align: center;
+  margin-bottom: var(--space-8);
+  padding-bottom: var(--space-6);
+  border-bottom: 2px solid var(--color-border);
+  animation: slideDown 0.6s cubic-bezier(0.22, 1, 0.36, 1) 0.2s both;
+}
+
+.authorizations-title {
+  font-size: var(--text-4xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-3);
+  letter-spacing: -0.03em;
+  background: linear-gradient(135deg, #0072ff, #00c6ff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.authorizations-subtitle {
+  font-size: var(--text-base);
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+
+/* List Header */
+.authorizations-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-5);
+  animation: fadeInUp 0.6s cubic-bezier(0.22, 1, 0.36, 1) 0.4s both;
+}
+
+.authorizations-count {
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+}
+
+/* ============================================
+   App Authorization Cards
+   ============================================ */
+
+.authorizations-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  animation: fadeInUp 0.6s cubic-bezier(0.22, 1, 0.36, 1) 0.5s both;
+}
+
+.authorization-item {
+  display: grid;
+  grid-template-columns: 48px 1fr auto;
+  gap: var(--space-4);
+  align-items: center;
+  padding: var(--space-5);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  transition: all var(--transition-fast);
+}
+
+.authorization-item:hover {
+  border-color: rgba(0, 114, 255, 0.3);
+  box-shadow: var(--shadow-md);
+}
+
+/* App Icon */
+.authorization-app-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, var(--color-primary-pale), #dbeafe);
+  border: 1px solid rgba(0, 114, 255, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+/* App Info */
+.authorization-info {
+  min-width: 0;
+}
+
+.authorization-app-name {
+  font-size: var(--text-base);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.authorization-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: center;
+}
+
+.authorization-scopes {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-tertiary);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+}
+
+.authorization-date {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.authorization-date::before {
+  content: "🕐";
+  font-size: 0.7rem;
+}
+
+/* Status Badge */
+.authorization-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  font-family: var(--font-mono);
+}
+
+.authorization-status.active {
+  background: rgba(16, 185, 129, 0.1);
+  color: #059669;
+  border: 1px solid rgba(16, 185, 129, 0.3);
+}
+
+.authorization-status.active::before {
+  content: "●";
+  font-size: 0.5rem;
+}
+
+/* Revoke Button */
+.authorization-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.authorization-revoke-btn {
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  background: rgba(239, 68, 68, 0.08);
+  color: #DC2626;
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+}
+
+.authorization-revoke-btn:hover {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.4);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(239, 68, 68, 0.2);
+}
+
+/* ============================================
+   Empty State
+   ============================================ */
+
+.empty-state {
+  text-align: center;
+  padding: var(--space-16) var(--space-8);
+}
+
+.empty-icon {
+  font-size: 3rem;
+  margin-bottom: var(--space-4);
+}
+
+.empty-title {
+  font-size: var(--text-xl);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-3);
+}
+
+.empty-text {
+  font-size: var(--text-base);
+  color: var(--color-text-secondary);
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+/* ============================================
+   Responsive
+   ============================================ */
+
+@media (max-width: 640px) {
+  .authorization-item {
+    grid-template-columns: 40px 1fr;
+    grid-template-rows: auto auto;
+  }
+
+  .authorization-app-icon {
+    width: 40px;
+    height: 40px;
+    font-size: 1rem;
+  }
+
+  .authorization-actions {
+    grid-column: 1 / -1;
+    flex-direction: row;
+    justify-content: flex-end;
+    align-items: center;
+    padding-top: var(--space-3);
+    border-top: 1px solid var(--color-border);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .authorizations-card-header,
+  .authorizations-list-header,
+  .authorizations-list {
+    animation: none;
+  }
+
+  .authorization-item:hover,
+  .authorization-revoke-btn:hover {
+    transform: none;
+  }
+}

--- a/internal/templates/static/css/pages/admin-forms.css
+++ b/internal/templates/static/css/pages/admin-forms.css
@@ -96,6 +96,49 @@
     0 0 20px rgba(0, 114, 255, 0.15);
 }
 
+/* Checkbox group for multi-select options (grant types etc.) */
+.admin-form-checkboxes {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+}
+
+.admin-form-checkbox-label {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.admin-form-checkbox-label:hover {
+  border-color: rgba(0, 114, 255, 0.4);
+  background: var(--color-bg-secondary);
+}
+
+.admin-form-checkbox-label input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  margin-top: 2px;
+  flex-shrink: 0;
+  accent-color: var(--color-primary);
+  cursor: pointer;
+}
+
+.admin-form-checkbox-label span {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.admin-form-checkbox-label span strong {
+  color: var(--color-text-primary);
+}
+
 .admin-form-hint {
   display: block;
   margin-top: var(--space-2);
@@ -389,6 +432,85 @@
   border-color: var(--color-gray-400);
   transform: translateY(-2px);
   color: var(--color-text-primary);
+}
+
+.admin-action-btn.danger {
+  background: rgba(239, 68, 68, 0.08);
+  color: #DC2626;
+  border: 1.5px solid rgba(239, 68, 68, 0.3);
+}
+
+.admin-action-btn.danger:hover {
+  background: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.5);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.2);
+}
+
+/* ============================================
+   Danger Zone
+   ============================================ */
+
+.admin-danger-zone {
+  margin-top: var(--space-8);
+  border: 1.5px solid rgba(239, 68, 68, 0.3);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.admin-danger-zone-header {
+  padding: var(--space-4) var(--space-6);
+  background: rgba(239, 68, 68, 0.05);
+  border-bottom: 1px solid rgba(239, 68, 68, 0.2);
+}
+
+.admin-danger-zone-title {
+  font-size: var(--text-base);
+  font-weight: 700;
+  color: #DC2626;
+  margin-bottom: var(--space-1);
+}
+
+.admin-danger-zone-desc {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.admin-danger-zone-body {
+  padding: var(--space-4) var(--space-6);
+}
+
+.admin-danger-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-6);
+}
+
+.admin-danger-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  flex: 1;
+}
+
+.admin-danger-item-info strong {
+  font-size: var(--text-sm);
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.admin-danger-item-info span {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+@media (max-width: 600px) {
+  .admin-danger-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 
 /* ============================================

--- a/internal/templates/static/css/pages/authorize.css
+++ b/internal/templates/static/css/pages/authorize.css
@@ -1,0 +1,326 @@
+/* ============================================
+   OAuth Authorization / Consent Page
+   Focused, no-distraction consent flow
+   ============================================ */
+
+/* Page container: centered, no-navbar layout */
+.authorize-container {
+  width: 100%;
+  max-width: 480px;
+  animation: fadeInUp 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ============================================
+   Consent Card
+   ============================================ */
+
+.authorize-card {
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: var(--space-10);
+  box-shadow: var(--shadow-xl);
+}
+
+/* App Header */
+.authorize-app-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+  padding-bottom: var(--space-6);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.authorize-app-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, var(--color-primary-pale), #dbeafe);
+  border: 1px solid rgba(0, 114, 255, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  flex-shrink: 0;
+}
+
+.authorize-app-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.authorize-app-name {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.authorize-app-id {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Title Section */
+.authorize-title-section {
+  margin-bottom: var(--space-6);
+}
+
+.authorize-title {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-2);
+  letter-spacing: -0.02em;
+}
+
+.authorize-subtitle {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.authorize-user-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+  margin-top: var(--space-3);
+}
+
+.authorize-user-tag::before {
+  content: "●";
+  color: var(--color-success);
+  font-size: 0.5rem;
+}
+
+/* ============================================
+   Scope List
+   ============================================ */
+
+.authorize-scopes-label {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-tertiary);
+  margin-bottom: var(--space-3);
+}
+
+.authorize-scopes-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-6);
+}
+
+.authorize-scope-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  transition: border-color var(--transition-fast);
+}
+
+.authorize-scope-item:hover {
+  border-color: rgba(0, 114, 255, 0.3);
+}
+
+.authorize-scope-check {
+  width: 18px;
+  height: 18px;
+  border-radius: var(--radius-full);
+  background: rgba(16, 185, 129, 0.1);
+  border: 1.5px solid rgba(16, 185, 129, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-top: 1px;
+  font-size: 0.6rem;
+  color: var(--color-success);
+}
+
+.authorize-scope-text {
+  flex: 1;
+}
+
+.authorize-scope-name {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  display: block;
+}
+
+.authorize-scope-desc {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  display: block;
+  margin-top: var(--space-1);
+}
+
+/* ============================================
+   Description (optional)
+   ============================================ */
+
+.authorize-app-description {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-secondary);
+  border-left: 3px solid var(--color-primary-light);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-6);
+  line-height: 1.6;
+}
+
+/* ============================================
+   Action Buttons
+   ============================================ */
+
+.authorize-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.authorize-btn-allow {
+  width: 100%;
+  padding: var(--space-4);
+  font-size: var(--text-base);
+  font-weight: 700;
+  color: white;
+  background: linear-gradient(135deg, #0072ff, #0058cc);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  box-shadow: 0 2px 8px rgba(0, 114, 255, 0.35);
+  letter-spacing: 0.01em;
+}
+
+.authorize-btn-allow:hover {
+  background: linear-gradient(135deg, #0058cc, #004ab5);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(0, 114, 255, 0.4);
+}
+
+.authorize-btn-allow:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 8px rgba(0, 114, 255, 0.35);
+}
+
+.authorize-btn-deny {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  text-decoration: none;
+  display: block;
+  text-align: center;
+}
+
+.authorize-btn-deny:hover {
+  background: var(--color-error-pale);
+  border-color: rgba(239, 68, 68, 0.4);
+  color: var(--color-error);
+}
+
+/* ============================================
+   Footer Note
+   ============================================ */
+
+.authorize-footer-note {
+  margin-top: var(--space-5);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-border);
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  text-align: center;
+  line-height: 1.6;
+}
+
+.authorize-footer-note strong {
+  color: var(--color-text-secondary);
+}
+
+/* ============================================
+   Redirect URI display
+   ============================================ */
+
+.authorize-redirect-info {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg-tertiary);
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--space-6);
+}
+
+.authorize-redirect-label {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.authorize-redirect-uri {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ============================================
+   Responsive
+   ============================================ */
+
+@media (max-width: 540px) {
+  .authorize-card {
+    padding: var(--space-6);
+    border-radius: var(--radius-lg);
+  }
+
+  .authorize-title {
+    font-size: var(--text-xl);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .authorize-container {
+    animation: none;
+  }
+  .authorize-btn-allow:hover,
+  .authorize-btn-deny:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
- Add full OAuth 2.0 Authorization Code Flow support with PKCE, including user consent, admin control, and client management features for web/mobile apps
- Introduce new OAuth consent UI and an authorized applications management page for users
- Implement per-app grant listing and revocation in both user and admin interfaces
- Store user consent grants and authorization codes in a new database schema, supporting single-use codes and PKCE code challenge validation
- Extend OAuth client creation and update forms to support client type selection (confidential/public) and grant type checkboxes
- Track consent and authorization-related audit events for compliance and monitoring
- Add comprehensive test coverage for authorization code flow, PKCE enforcement, and consent management logic
- Refactor backend services to handle consent grant creation, updating, and revocation, including cascaded token invalidation
- Update .gitignore, documentation, and CSS to support new UI and features