### PR TITLE
feat: refactor navbar to add dropdowns and improve mobile usability

### DIFF
--- a/internal/templates/navbar_component.templ
+++ b/internal/templates/navbar_component.templ
@@ -10,11 +10,23 @@ templ Navbar(props *NavbarProps) {
 			<div class="navbar-menu" id="navbarMenu">
 				<div class="navbar-links">
 					@NavLink("/device", "Device Authorization", props.ActiveLink == "device", false)
-					@NavLink("/account/sessions", "Active Sessions", props.ActiveLink == "sessions", false)
-					@NavLink("/account/authorizations", "Authorized Apps", props.ActiveLink == "authorizations", false)
+					@NavDropdown(
+						"Account",
+						props.ActiveLink == "sessions" || props.ActiveLink == "authorizations",
+						false,
+					) {
+						@NavDropdownItem("/account/sessions", "Active Sessions", props.ActiveLink == "sessions", false)
+						@NavDropdownItem("/account/authorizations", "Authorized Apps", props.ActiveLink == "authorizations", false)
+					}
+					@NavDropdown("API Docs", props.ActiveLink == "apidocs", false) {
+						@NavDropdownItem("/swagger/index.html", "Swagger UI", props.ActiveLink == "apidocs", false)
+					}
 					if props.IsAdmin {
-						@NavLink("/admin/clients", "OAuth Clients", props.ActiveLink == "clients", true)
-						@NavLink("/admin/audit", "Audit Logs", props.ActiveLink == "audit", true)
+						<div class="navbar-admin-divider" aria-hidden="true"></div>
+						@NavAdminDropdown(props.ActiveLink == "clients" || props.ActiveLink == "audit") {
+							@NavDropdownItem("/admin/clients", "OAuth Clients", props.ActiveLink == "clients", true)
+							@NavDropdownItem("/admin/audit", "Audit Logs", props.ActiveLink == "audit", true)
+						}
 					}
 				</div>
 				<div class="navbar-user">
@@ -30,6 +42,65 @@ templ NavLink(href, label string, isActive bool, isAdmin bool) {
 	<a
 		href={ templ.URL(href) }
 		class={ templ.Classes("navbar-link", templ.KV("active", isActive), templ.KV("admin", isAdmin)) }
+	>
+		{ label }
+	</a>
+}
+
+templ NavDropdown(label string, isActive bool, isAdmin bool) {
+	<div class={ templ.Classes("navbar-dropdown", templ.KV("active", isActive), templ.KV("admin", isAdmin)) }>
+		<button
+			class={ templ.Classes("navbar-link", "navbar-dropdown-trigger", templ.KV("active", isActive), templ.KV("admin", isAdmin)) }
+			aria-haspopup="true"
+			aria-expanded="false"
+			onclick="toggleDropdown(this)"
+		>
+			{ label }
+			<span class="navbar-dropdown-arrow" aria-hidden="true">
+				<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<path d="M2 4L6 8L10 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+				</svg>
+			</span>
+		</button>
+		<div class="navbar-dropdown-menu" role="menu">
+			{ children... }
+		</div>
+	</div>
+}
+
+templ NavAdminDropdown(isActive bool) {
+	<div class={ templ.Classes("navbar-dropdown", "navbar-dropdown--admin", templ.KV("active", isActive)) }>
+		<button
+			class={ templ.Classes("navbar-link", "navbar-dropdown-trigger", "navbar-dropdown-trigger--admin", templ.KV("active", isActive)) }
+			aria-haspopup="true"
+			aria-expanded="false"
+			onclick="toggleDropdown(this)"
+		>
+			<span class="navbar-admin-icon" aria-hidden="true">
+				<svg width="13" height="13" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<rect x="3" y="11" width="18" height="11" rx="2" stroke="currentColor" stroke-width="2"></rect>
+					<path d="M7 11V7a5 5 0 0 1 10 0v4" stroke="currentColor" stroke-width="2" stroke-linecap="round"></path>
+				</svg>
+			</span>
+			Admin
+			<span class="navbar-admin-badge">ADMIN</span>
+			<span class="navbar-dropdown-arrow" aria-hidden="true">
+				<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<path d="M2 4L6 8L10 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
+				</svg>
+			</span>
+		</button>
+		<div class="navbar-dropdown-menu navbar-dropdown-menu--admin" role="menu">
+			{ children... }
+		</div>
+	</div>
+}
+
+templ NavDropdownItem(href, label string, isActive bool, isAdmin bool) {
+	<a
+		href={ templ.URL(href) }
+		class={ templ.Classes("navbar-dropdown-item", templ.KV("active", isActive), templ.KV("admin", isAdmin)) }
+		role="menuitem"
 	>
 		{ label }
 	</a>

--- a/internal/templates/static/css/components/navbar.css
+++ b/internal/templates/static/css/components/navbar.css
@@ -207,17 +207,279 @@
   }
 }
 
-/* Admin-specific navbar styling */
-.navbar-link.admin {
+/* ============================================
+   Admin Divider
+   ============================================ */
+
+.navbar-admin-divider {
+  width: 1px;
+  height: 20px;
+  background: var(--color-border);
+  margin: 0 var(--space-1);
+  flex-shrink: 0;
+}
+
+/* ============================================
+   Admin Dropdown — Amber "Restricted" Theme
+   ============================================ */
+
+/* Resting state: subtle amber tint to signal elevated access */
+.navbar-dropdown-trigger--admin {
+  color: var(--color-warning);
+  background: rgba(245, 158, 11, 0.06);
+  border-color: rgba(245, 158, 11, 0.18);
+}
+
+.navbar-dropdown-trigger--admin:hover,
+.navbar-dropdown-trigger--admin.active {
+  color: #b45309;
+  background: var(--color-warning-pale);
+  border-color: rgba(245, 158, 11, 0.35);
+}
+
+/* Lock icon */
+.navbar-admin-icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+
+/* ADMIN badge chip */
+.navbar-admin-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 5px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: #92400e;
+  background: rgba(245, 158, 11, 0.18);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: var(--radius-full);
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+/* Admin dropdown panel: amber accent top border */
+.navbar-dropdown-menu--admin {
+  border-top: 3px solid var(--color-warning);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+}
+
+/* Admin dropdown items */
+.navbar-dropdown-item.admin {
+  color: var(--color-text-secondary);
+}
+
+.navbar-dropdown-item.admin:hover {
+  color: #b45309;
+  background: var(--color-warning-pale);
+}
+
+.navbar-dropdown-item.admin.active {
+  color: #b45309;
+  background: var(--color-warning-pale);
+  font-weight: 700;
+}
+
+/* Hover trigger for admin dropdown (desktop) */
+@media (hover: hover) {
+  .navbar-dropdown--admin:hover .navbar-dropdown-trigger--admin {
+    color: #b45309;
+    background: var(--color-warning-pale);
+    border-color: rgba(245, 158, 11, 0.35);
+  }
+}
+
+/* Mobile: admin divider becomes horizontal */
+@media (max-width: 768px) {
+  .navbar-admin-divider {
+    width: 100%;
+    height: 1px;
+    margin: var(--space-2) 0;
+  }
+}
+
+/* ============================================
+   Dropdown Menu
+   ============================================ */
+
+.navbar-dropdown {
+  position: relative;
+}
+
+.navbar-dropdown-trigger {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  background: none;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.navbar-dropdown-arrow {
+  display: flex;
+  align-items: center;
+  transition: transform var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.navbar-dropdown-trigger[aria-expanded="true"] .navbar-dropdown-arrow {
+  transform: rotate(180deg);
+}
+
+.navbar-dropdown-menu {
+  position: absolute;
+  top: calc(100% + var(--space-2));
+  left: 0;
+  min-width: 180px;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-1);
+  z-index: calc(var(--z-sticky) + 1);
+  /* Hidden by default */
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-6px);
+  transition:
+    opacity var(--transition-fast),
+    visibility var(--transition-fast),
+    transform var(--transition-fast);
+  pointer-events: none;
+}
+
+/* Invisible bridge that fills the gap between trigger and menu,
+   preventing hover loss when the mouse moves through the gap */
+.navbar-dropdown-menu::before {
+  content: '';
+  position: absolute;
+  top: calc(-1 * var(--space-2) - 2px);
+  left: 0;
+  right: 0;
+  height: calc(var(--space-2) + 2px);
+}
+
+/* Open state via JS (aria-expanded) */
+.navbar-dropdown-trigger[aria-expanded="true"] + .navbar-dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+/* Also open on hover for desktop */
+@media (hover: hover) {
+  .navbar-dropdown:hover .navbar-dropdown-menu {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .navbar-dropdown:hover .navbar-dropdown-trigger {
+    color: var(--color-primary);
+    background: var(--color-primary-pale);
+    border-color: rgba(0, 114, 255, 0.2);
+  }
+
+  .navbar-dropdown--admin:hover .navbar-dropdown-trigger--admin {
+    color: #b45309;
+    background: var(--color-warning-pale);
+    border-color: rgba(245, 158, 11, 0.35);
+  }
+}
+
+.navbar-dropdown-item {
+  display: flex;
+  align-items: center;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  border-radius: var(--radius-md);
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+}
+
+.navbar-dropdown-item:hover {
+  color: var(--color-primary);
+  background: var(--color-primary-pale);
+}
+
+.navbar-dropdown-item.active {
+  color: var(--color-primary);
+  background: var(--color-primary-pale);
+  font-weight: 700;
+}
+
+.navbar-dropdown-item.admin {
   color: var(--color-success);
 }
 
-.navbar-link.admin:hover {
+.navbar-dropdown-item.admin:hover {
   background: var(--color-success-pale);
-  border-color: rgba(16, 185, 129, 0.2);
 }
 
-.navbar-link.admin.active {
+.navbar-dropdown-item.admin.active {
   background: var(--color-success-pale);
-  border-color: rgba(16, 185, 129, 0.3);
+  font-weight: 700;
+}
+
+/* Mobile dropdown: accordion style */
+@media (max-width: 768px) {
+  .navbar-dropdown {
+    width: 100%;
+  }
+
+  .navbar-dropdown-menu {
+    position: static;
+    box-shadow: none;
+    border: none;
+    border-radius: 0;
+    padding: 0;
+    margin-left: var(--space-4);
+    min-width: 0;
+    background: transparent;
+    /* Override hover-open; mobile uses JS only */
+    opacity: 0;
+    visibility: hidden;
+    transform: none;
+    max-height: 0;
+    overflow: hidden;
+    transition:
+      opacity var(--transition-fast),
+      visibility var(--transition-fast),
+      max-height var(--transition-base);
+  }
+
+  .navbar-dropdown-trigger[aria-expanded="true"] + .navbar-dropdown-menu {
+    opacity: 1;
+    visibility: visible;
+    max-height: 300px;
+  }
+
+  /* Disable hover-open on mobile */
+  .navbar-dropdown:hover .navbar-dropdown-menu {
+    opacity: 0;
+    visibility: hidden;
+    transform: none;
+    max-height: 0;
+    pointer-events: none;
+  }
+
+  .navbar-dropdown-trigger[aria-expanded="true"] + .navbar-dropdown-menu {
+    opacity: 1 !important;
+    visibility: visible !important;
+    max-height: 300px !important;
+    pointer-events: auto !important;
+  }
+
+  .navbar-dropdown-item {
+    padding: var(--space-2) var(--space-4);
+    border-radius: 0;
+    width: 100%;
+  }
 }

--- a/internal/templates/static/js/navbar.js
+++ b/internal/templates/static/js/navbar.js
@@ -8,6 +8,23 @@ function toggleMenu() {
   }
 }
 
+/**
+ * Toggle dropdown open/closed (used on mobile and as click fallback)
+ * @param {HTMLElement} trigger - The dropdown trigger button
+ */
+function toggleDropdown(trigger) {
+  const isExpanded = trigger.getAttribute('aria-expanded') === 'true';
+
+  // Close all other dropdowns first
+  document.querySelectorAll('.navbar-dropdown-trigger[aria-expanded="true"]').forEach(function(btn) {
+    if (btn !== trigger) {
+      btn.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  trigger.setAttribute('aria-expanded', isExpanded ? 'false' : 'true');
+}
+
 // Close mobile menu when clicking outside
 document.addEventListener('DOMContentLoaded', function() {
   const navbar = document.querySelector('.navbar');
@@ -18,14 +35,20 @@ document.addEventListener('DOMContentLoaded', function() {
     document.addEventListener('click', function(event) {
       const isClickInside = navbar.contains(event.target);
 
-      if (!isClickInside && navbarMenu.classList.contains('active')) {
-        navbarMenu.classList.remove('active');
+      if (!isClickInside) {
+        if (navbarMenu.classList.contains('active')) {
+          navbarMenu.classList.remove('active');
+        }
+        // Close all dropdowns
+        document.querySelectorAll('.navbar-dropdown-trigger[aria-expanded="true"]').forEach(function(btn) {
+          btn.setAttribute('aria-expanded', 'false');
+        });
       }
     });
 
-    // Close menu when clicking on a link
-    const navLinks = navbarMenu.querySelectorAll('.navbar-link');
-    navLinks.forEach(link => {
+    // Close menu when clicking on a link (not a dropdown trigger)
+    const navLinks = navbarMenu.querySelectorAll('.navbar-link:not(.navbar-dropdown-trigger), .navbar-dropdown-item');
+    navLinks.forEach(function(link) {
       link.addEventListener('click', function() {
         if (window.innerWidth <= 768) {
           navbarMenu.classList.remove('active');


### PR DESCRIPTION
- Replace "Active Sessions" and "Authorized Apps" navbar links with an "Account" dropdown containing these options.
- Add an "API Docs" dropdown to the navbar for Swagger UI.
- Group admin links ("OAuth Clients", "Audit Logs") into an admin dropdown with a divider and visual enhancements.
- Implement reusable dropdown, admin dropdown, and dropdown item navbar components.
- Significantly expand navbar CSS to support dropdown menus and admin theming, including mobile-optimized accordion dropdown menus.
- Add JavaScript to handle opening and closing navbar dropdowns, including exclusive open state and click-outside behavior.
- Update click handlers so that clicking any menu item or dropdown item on mobile closes the navbar.