### PR TITLE
feat: enable navbar rendering on OAuth consent and authorize pages

### DIFF
--- a/internal/handlers/authorization.go
+++ b/internal/handlers/authorization.go
@@ -99,7 +99,12 @@ func (h *AuthorizationHandler) ShowAuthorizePage(c *gin.Context) {
 
 	// Render the consent page
 	templates.RenderTempl(c, http.StatusOK, templates.AuthorizePage(templates.AuthorizePageProps{
-		BaseProps:           templates.BaseProps{CSRFToken: middleware.GetCSRFToken(c)},
+		BaseProps: templates.BaseProps{CSRFToken: middleware.GetCSRFToken(c)},
+		NavbarProps: templates.NavbarProps{
+			Username:   user.Username,
+			IsAdmin:    user.IsAdmin(),
+			ActiveLink: "",
+		},
 		Username:            user.Username,
 		ClientID:            req.Client.ClientID,
 		ClientName:          req.Client.ClientName,

--- a/internal/templates/authorize.templ
+++ b/internal/templates/authorize.templ
@@ -3,7 +3,7 @@ package templates
 import "strings"
 
 templ AuthorizePage(props AuthorizePageProps) {
-	@Layout("Authorize Access", LayoutNoNavbar, nil) {
+	@Layout("Authorize Access", LayoutHasNavbar, &props.NavbarProps) {
 		<link rel="stylesheet" href="/static/css/pages/authorize.css"/>
 		<div class="authorize-container">
 			<div class="authorize-card">

--- a/internal/templates/props.go
+++ b/internal/templates/props.go
@@ -147,6 +147,7 @@ type ClientDetailPageProps struct {
 // AuthorizePageProps contains properties for the OAuth consent page
 type AuthorizePageProps struct {
 	BaseProps
+	NavbarProps
 	Username            string
 	ClientID            string
 	ClientName          string

--- a/internal/templates/static/css/pages/authorize.css
+++ b/internal/templates/static/css/pages/authorize.css
@@ -3,10 +3,11 @@
    Focused, no-distraction consent flow
    ============================================ */
 
-/* Page container: centered, no-navbar layout */
+/* Page container: centered within main-content */
 .authorize-container {
   width: 100%;
   max-width: 480px;
+  margin: 0 auto;
   animation: fadeInUp 0.5s cubic-bezier(0.4, 0, 0.2, 1);
 }
 


### PR DESCRIPTION
- Add NavbarProps to the OAuth consent page to enable rendering of the navigation bar
- Update the authorize page template to display the navbar instead of hiding it
- Pass user information to NavbarProps for proper navbar rendering
- Improve authorize page container CSS to center content within main-content