### PR TITLE
refactor: unify types and modernize code and test style across the repo

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,29 +1,89 @@
 version: "2"
+output:
+  sort-order:
+    - file
 linters:
   default: none
   enable:
+    - bidichk
     - bodyclose
-    - dogsled
-    - dupl
+    - depguard
     - errcheck
-    - exhaustive
-    - goconst
+    - forbidigo
+    - gocheckcompilerdirectives
     - gocritic
-    - gocyclo
-    - goprintffuncname
-    - gosec
     - govet
     - ineffassign
-    - misspell
+    - mirror
+    - modernize
     - nakedret
-    - noctx
+    - nilnil
     - nolintlint
-    - rowserrcheck
+    - perfsprint
+    - revive
     - staticcheck
+    - testifylint
     - unconvert
     - unparam
     - unused
-    - whitespace
+    - usestdlibvars
+    - usetesting
+    - wastedassign
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: io/ioutil
+              desc: use os or io instead
+            - pkg: golang.org/x/exp
+              desc: it's experimental and unreliable
+            - pkg: github.com/pkg/errors
+              desc: use builtin errors package instead
+    nolintlint:
+      allow-unused: false
+      require-explanation: true
+      require-specific: true
+    gocritic:
+      enabled-checks:
+        - equalFold
+      disabled-checks: []
+    revive:
+      severity: error
+      rules:
+        - name: blank-imports
+        - name: constant-logical-expr
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: empty-lines
+        - name: error-return
+        - name: error-strings
+        - name: exported
+        - name: identical-branches
+        - name: if-return
+        - name: increment-decrement
+        - name: modifies-value-receiver
+        - name: package-comments
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-return
+        - name: var-declaration
+        - name: var-naming
+          disabled: true
+    staticcheck:
+      checks:
+        - all
+    testifylint: {}
+    usetesting:
+      os-temp-dir: true
+    perfsprint:
+      concat-loop: false
+    govet:
+      enable:
+        - nilness
+        - unusedwrite
   exclusions:
     generated: lax
     presets:
@@ -31,19 +91,24 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+    rules:
+      - linters:
+          - errcheck
+          - staticcheck
+          - unparam
+        path: _test\.go
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 formatters:
   enable:
     - gofmt
     - gofumpt
-    - goimports
     - golines
+  settings:
+    gofumpt:
+      extra-rules: true
   exclusions:
     generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
+run:
+  timeout: 10m

--- a/internal/auth/http_api.go
+++ b/internal/auth/http_api.go
@@ -45,7 +45,7 @@ type APIAuthResponse struct {
 func (p *HTTPAPIAuthProvider) Authenticate(
 	ctx context.Context,
 	username, password string,
-) (*AuthResult, error) {
+) (*Result, error) {
 	reqBody := APIAuthRequest{
 		Username: username,
 		Password: password,
@@ -119,7 +119,7 @@ func (p *HTTPAPIAuthProvider) Authenticate(
 		)
 	}
 
-	return &AuthResult{
+	return &Result{
 		Username:   username,
 		ExternalID: authResp.UserID,
 		Email:      authResp.Email,

--- a/internal/auth/http_api_test.go
+++ b/internal/auth/http_api_test.go
@@ -353,7 +353,7 @@ func TestHTTPAPIAuthProvider_HMACAuth_ValidSignature(t *testing.T) {
 		}
 
 		// Compute expected signature: HMAC-SHA256(timestamp + method + path + body)
-		message := fmt.Sprintf("%s%s%s%s", timestamp, r.Method, r.URL.Path, string(body))
+		message := timestamp + r.Method + r.URL.Path + string(body)
 		h := hmac.New(sha256.New, []byte(testSecret))
 		h.Write([]byte(message))
 		expectedSignature := hex.EncodeToString(h.Sum(nil))
@@ -502,7 +502,7 @@ func TestHTTPAPIAuthProvider_SimpleAuth_Unauthorized(t *testing.T) {
 	provider := createTestProvider(cfg)
 	result, err := provider.Authenticate(context.Background(), "testuser", "password123")
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "401")
 }

--- a/internal/auth/local.go
+++ b/internal/auth/local.go
@@ -22,7 +22,7 @@ func NewLocalAuthProvider(s *store.Store) *LocalAuthProvider {
 func (p *LocalAuthProvider) Authenticate(
 	ctx context.Context,
 	username, password string,
-) (*AuthResult, error) {
+) (*Result, error) {
 	user, err := p.store.GetUserByUsername(username)
 	if err != nil {
 		return nil, ErrInvalidCredentials
@@ -35,7 +35,7 @@ func (p *LocalAuthProvider) Authenticate(
 		return nil, ErrInvalidCredentials
 	}
 
-	return &AuthResult{
+	return &Result{
 		Username:   user.Username,
 		ExternalID: "", // Local users don't have external IDs
 		Email:      user.Email,

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -1,7 +1,7 @@
 package auth
 
-// AuthResult represents the result of authentication
-type AuthResult struct {
+// Result represents the result of authentication
+type Result struct {
 	Username   string
 	ExternalID string // External user ID (e.g., LDAP DN, API user ID)
 	Email      string // Optional

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -25,7 +25,7 @@ type Application struct {
 
 	// Core infrastructure
 	DB                   *store.Store
-	MetricsRecorder      metrics.MetricsRecorder
+	MetricsRecorder      metrics.Recorder
 	MetricsCache         cache.Cache
 	MetricsCacheCloser   func() error
 	RateLimitRedisClient *redis.Client

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -74,7 +74,7 @@ func TestInitializeMetricsCacheDisabled(t *testing.T) {
 		ctx,
 		&config.Config{MetricsEnabled: false, MetricsGaugeUpdateEnabled: true},
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, c)
 	assert.Nil(t, closer)
 
@@ -83,7 +83,7 @@ func TestInitializeMetricsCacheDisabled(t *testing.T) {
 		ctx,
 		&config.Config{MetricsEnabled: true, MetricsGaugeUpdateEnabled: false},
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, c)
 	assert.Nil(t, closer)
 }

--- a/internal/bootstrap/cache.go
+++ b/internal/bootstrap/cache.go
@@ -11,7 +11,7 @@ import (
 )
 
 // initializeMetrics initializes Prometheus metrics
-func initializeMetrics(cfg *config.Config) metrics.MetricsRecorder {
+func initializeMetrics(cfg *config.Config) metrics.Recorder {
 	prometheusMetrics := metrics.Init(cfg.MetricsEnabled)
 	if cfg.MetricsEnabled {
 		log.Println("Prometheus metrics initialized")

--- a/internal/bootstrap/handlers.go
+++ b/internal/bootstrap/handlers.go
@@ -34,7 +34,7 @@ func initializeHandlers(
 	auditService *services.AuditService,
 	oauthProviders map[string]*auth.OAuthProvider,
 	oauthHTTPClient *http.Client,
-	prometheusMetrics metrics.MetricsRecorder,
+	prometheusMetrics metrics.Recorder,
 ) handlerSet {
 	return handlerSet{
 		auth: handlers.NewAuthHandler(

--- a/internal/bootstrap/redis.go
+++ b/internal/bootstrap/redis.go
@@ -19,12 +19,12 @@ func initializeRateLimitRedisClient(
 ) (*redis.Client, error) {
 	// Skip if rate limiting is disabled
 	if !cfg.EnableRateLimit {
-		return nil, nil
+		return nil, nil //nolint:nilnil // redis client not needed in this configuration
 	}
 
 	// Skip if using memory store
 	if cfg.RateLimitStore != string(middleware.RateLimitStoreRedis) {
-		return nil, nil
+		return nil, nil //nolint:nilnil // redis client not needed in this configuration
 	}
 
 	// Create go-redis client

--- a/internal/bootstrap/router.go
+++ b/internal/bootstrap/router.go
@@ -28,7 +28,7 @@ func setupRouter(
 	cfg *config.Config,
 	db *store.Store,
 	h handlerSet,
-	prometheusMetrics metrics.MetricsRecorder,
+	prometheusMetrics metrics.Recorder,
 	auditService *services.AuditService,
 	rateLimitRedisClient *redis.Client,
 	templatesFS embed.FS,

--- a/internal/bootstrap/server.go
+++ b/internal/bootstrap/server.go
@@ -158,7 +158,7 @@ func addMetricsGaugeUpdateJob(
 	m *graceful.Manager,
 	cfg *config.Config,
 	db *store.Store,
-	prometheusMetrics metrics.MetricsRecorder,
+	prometheusMetrics metrics.Recorder,
 	metricsCache cache.Cache,
 ) {
 	if !cfg.MetricsEnabled || !cfg.MetricsGaugeUpdateEnabled {
@@ -170,7 +170,7 @@ func addMetricsGaugeUpdateJob(
 		defer ticker.Stop()
 
 		// Create cache wrapper
-		cacheWrapper := metrics.NewMetricsCacheWrapper(db, metricsCache)
+		cacheWrapper := metrics.NewCacheWrapper(db, metricsCache)
 
 		// Update immediately on startup
 		updateGaugeMetricsWithCache(
@@ -281,8 +281,8 @@ var gaugeErrorLogger = newErrorLogger()
 // The cache TTL should match the update interval to ensure consistent behavior.
 func updateGaugeMetricsWithCache(
 	ctx context.Context,
-	cacheWrapper *metrics.MetricsCacheWrapper,
-	m metrics.MetricsRecorder,
+	cacheWrapper *metrics.CacheWrapper,
+	m metrics.Recorder,
 	cacheTTL time.Duration,
 ) {
 	// Update active access tokens count

--- a/internal/bootstrap/services.go
+++ b/internal/bootstrap/services.go
@@ -14,7 +14,7 @@ func initializeServices(
 	cfg *config.Config,
 	db *store.Store,
 	auditService *services.AuditService,
-	prometheusMetrics metrics.MetricsRecorder,
+	prometheusMetrics metrics.Recorder,
 ) (*services.UserService, *services.DeviceService, *services.TokenService, *services.ClientService, *services.AuthorizationService) {
 	// Initialize authentication providers
 	localProvider := auth.NewLocalAuthProvider(db)

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -204,9 +204,9 @@ func TestMemoryCache_Concurrent(t *testing.T) {
 	done := make(chan bool, 20)
 
 	// 10 writers
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		go func(n int) {
-			for j := 0; j < 100; j++ {
+			for j := range 100 {
 				key := "concurrent-key"
 				_ = cache.Set(ctx, key, int64(n*1000+j), time.Minute)
 			}
@@ -215,9 +215,9 @@ func TestMemoryCache_Concurrent(t *testing.T) {
 	}
 
 	// 10 readers
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
-			for j := 0; j < 100; j++ {
+			for range 100 {
 				_, _ = cache.Get(ctx, "concurrent-key")
 			}
 			done <- true
@@ -225,7 +225,7 @@ func TestMemoryCache_Concurrent(t *testing.T) {
 	}
 
 	// Wait for all goroutines
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		<-done
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -386,7 +386,7 @@ func getEnvSlice(key string, defaultValue []string) []string {
 
 func splitAndTrim(s, sep string) []string {
 	var out []string
-	for _, part := range strings.Split(s, sep) {
+	for part := range strings.SplitSeq(s, sep) {
 		if trimmed := strings.TrimSpace(part); trimmed != "" {
 			out = append(out, trimmed)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_Validate(t *testing.T) {
@@ -73,10 +74,10 @@ func TestConfig_Validate(t *testing.T) {
 			err := tt.config.Validate()
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -166,10 +167,10 @@ func TestMetricsCacheValidation(t *testing.T) {
 			err := tt.config.Validate()
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -20,7 +20,7 @@ import (
 )
 
 // generateFingerprint creates a SHA256 hash from IP (optional) and User-Agent
-func generateFingerprint(ip string, userAgent string, includeIP bool) string {
+func generateFingerprint(ip, userAgent string, includeIP bool) string {
 	data := userAgent
 	if includeIP {
 		data = ip + "|" + userAgent
@@ -98,7 +98,7 @@ type AuthHandler struct {
 	baseURL                     string
 	sessionFingerprintEnabled   bool
 	sessionFingerprintIncludeIP bool
-	metrics                     metrics.MetricsRecorder
+	metrics                     metrics.Recorder
 }
 
 func NewAuthHandler(
@@ -106,7 +106,7 @@ func NewAuthHandler(
 	baseURL string,
 	fingerprintEnabled bool,
 	fingerprintIncludeIP bool,
-	m metrics.MetricsRecorder,
+	m metrics.Recorder,
 ) *AuthHandler {
 	return &AuthHandler{
 		userService:                 us,

--- a/internal/handlers/authorization.go
+++ b/internal/handlers/authorization.go
@@ -371,10 +371,10 @@ func oauthErrorCode(err error) string {
 // scopesAreCovered returns true when all scopes in requested are present in granted.
 func scopesAreCovered(grantedScopes, requestedScopes string) bool {
 	granted := make(map[string]bool)
-	for _, s := range strings.Fields(grantedScopes) {
+	for s := range strings.FieldsSeq(grantedScopes) {
 		granted[s] = true
 	}
-	for _, s := range strings.Fields(requestedScopes) {
+	for s := range strings.FieldsSeq(requestedScopes) {
 		if !granted[s] {
 			return false
 		}

--- a/internal/handlers/authorization_test.go
+++ b/internal/handlers/authorization_test.go
@@ -15,16 +15,16 @@ import (
 
 func TestMaxStateLength_AcceptsAtLimit(t *testing.T) {
 	state := strings.Repeat("a", maxStateLength)
-	assert.False(t, len(state) > maxStateLength)
+	assert.LessOrEqual(t, len(state), maxStateLength)
 }
 
 func TestMaxStateLength_RejectsOverLimit(t *testing.T) {
 	state := strings.Repeat("a", maxStateLength+1)
-	assert.True(t, len(state) > maxStateLength)
+	assert.Greater(t, len(state), maxStateLength)
 }
 
 func TestMaxStateLength_AcceptsEmpty(t *testing.T) {
-	assert.False(t, len("") > maxStateLength)
+	assert.LessOrEqual(t, len(""), maxStateLength)
 }
 
 // ============================================================

--- a/internal/handlers/client.go
+++ b/internal/handlers/client.go
@@ -34,8 +34,7 @@ func parseRedirectURIs(input string) []string {
 		return redirectURIs
 	}
 
-	parts := strings.Split(input, ",")
-	for _, uri := range parts {
+	for uri := range strings.SplitSeq(input, ",") {
 		if trimmed := strings.TrimSpace(uri); trimmed != "" {
 			redirectURIs = append(redirectURIs, trimmed)
 		}
@@ -113,7 +112,7 @@ func (h *ClientHandler) ShowCreateClientPage(c *gin.Context) {
 			ActiveLink: "clients",
 		},
 		Title:  "Create OAuth Client",
-		Method: "POST",
+		Method: http.MethodPost,
 		Action: "/admin/clients",
 		IsEdit: false,
 	}))
@@ -164,7 +163,7 @@ func (h *ClientHandler) CreateClient(c *gin.Context) {
 				Client: clientData,
 				Error:  err.Error(),
 				Title:  "Create OAuth Client",
-				Method: "POST",
+				Method: http.MethodPost,
 				Action: "/admin/clients",
 				IsEdit: false,
 			}),
@@ -248,7 +247,7 @@ func (h *ClientHandler) ShowEditClientPage(c *gin.Context) {
 		},
 		Client: clientDisplay,
 		Title:  "Edit OAuth Client",
-		Method: "POST",
+		Method: http.MethodPost,
 		Action: "/admin/clients/" + clientID,
 		IsEdit: true,
 	}))
@@ -306,7 +305,7 @@ func (h *ClientHandler) UpdateClient(c *gin.Context) {
 				Client: clientDisplay,
 				Error:  err.Error(),
 				Title:  "Edit OAuth Client",
-				Method: "POST",
+				Method: http.MethodPost,
 				Action: "/admin/clients/" + clientID,
 				IsEdit: true,
 			}),

--- a/internal/handlers/oauth_handler.go
+++ b/internal/handlers/oauth_handler.go
@@ -22,7 +22,7 @@ import (
 )
 
 // generateFingerprintOAuth creates a SHA256 hash from IP (optional) and User-Agent
-func generateFingerprintOAuth(ip string, userAgent string, includeIP bool) string {
+func generateFingerprintOAuth(ip, userAgent string, includeIP bool) string {
 	data := userAgent
 	if includeIP {
 		data = ip + "|" + userAgent
@@ -39,7 +39,7 @@ type OAuthHandler struct {
 	httpClient                  *http.Client // Custom HTTP client for OAuth requests
 	sessionFingerprintEnabled   bool
 	sessionFingerprintIncludeIP bool
-	metrics                     metrics.MetricsRecorder
+	metrics                     metrics.Recorder
 }
 
 // NewOAuthHandler creates a new OAuth handler
@@ -49,7 +49,7 @@ func NewOAuthHandler(
 	httpClient *http.Client,
 	fingerprintEnabled bool,
 	fingerprintIncludeIP bool,
-	m metrics.MetricsRecorder,
+	m metrics.Recorder,
 ) *OAuthHandler {
 	return &OAuthHandler{
 		providers:                   providers,

--- a/internal/metrics/cache_test.go
+++ b/internal/metrics/cache_test.go
@@ -37,15 +37,15 @@ func (m *mockStore) CountPendingDeviceCodes() (int64, error) {
 	return 0, nil
 }
 
-// newTestCacheWrapper creates a MetricsCacheWrapper for testing
-func newTestCacheWrapper(store *mockStore, cache cache.Cache) *MetricsCacheWrapper {
-	return &MetricsCacheWrapper{
+// newTestCacheWrapper creates a CacheWrapper for testing
+func newTestCacheWrapper(store *mockStore, cache cache.Cache) *CacheWrapper {
+	return &CacheWrapper{
 		store: store,
 		cache: cache,
 	}
 }
 
-func TestMetricsCacheWrapper_GetActiveTokensCount_CacheHit(t *testing.T) {
+func TestCacheWrapper_GetActiveTokensCount_CacheHit(t *testing.T) {
 	ctx := context.Background()
 	memCache := cache.NewMemoryCache()
 
@@ -71,7 +71,7 @@ func TestMetricsCacheWrapper_GetActiveTokensCount_CacheHit(t *testing.T) {
 	}
 }
 
-func TestMetricsCacheWrapper_GetActiveTokensCount_CacheMiss(t *testing.T) {
+func TestCacheWrapper_GetActiveTokensCount_CacheMiss(t *testing.T) {
 	ctx := context.Background()
 	memCache := cache.NewMemoryCache()
 
@@ -112,7 +112,7 @@ func TestMetricsCacheWrapper_GetActiveTokensCount_CacheMiss(t *testing.T) {
 	}
 }
 
-func TestMetricsCacheWrapper_GetActiveTokensCount_DBError(t *testing.T) {
+func TestCacheWrapper_GetActiveTokensCount_DBError(t *testing.T) {
 	ctx := context.Background()
 	memCache := cache.NewMemoryCache()
 
@@ -131,7 +131,7 @@ func TestMetricsCacheWrapper_GetActiveTokensCount_DBError(t *testing.T) {
 	}
 }
 
-func TestMetricsCacheWrapper_GetActiveTokensCount_CacheExpiration(t *testing.T) {
+func TestCacheWrapper_GetActiveTokensCount_CacheExpiration(t *testing.T) {
 	ctx := context.Background()
 	memCache := cache.NewMemoryCache()
 
@@ -175,7 +175,7 @@ func TestMetricsCacheWrapper_GetActiveTokensCount_CacheExpiration(t *testing.T) 
 	}
 }
 
-func TestMetricsCacheWrapper_GetTotalDeviceCodesCount_CacheHit(t *testing.T) {
+func TestCacheWrapper_GetTotalDeviceCodesCount_CacheHit(t *testing.T) {
 	ctx := context.Background()
 	memCache := cache.NewMemoryCache()
 
@@ -201,7 +201,7 @@ func TestMetricsCacheWrapper_GetTotalDeviceCodesCount_CacheHit(t *testing.T) {
 	}
 }
 
-func TestMetricsCacheWrapper_GetPendingDeviceCodesCount_CacheHit(t *testing.T) {
+func TestCacheWrapper_GetPendingDeviceCodesCount_CacheHit(t *testing.T) {
 	ctx := context.Background()
 	memCache := cache.NewMemoryCache()
 
@@ -227,7 +227,7 @@ func TestMetricsCacheWrapper_GetPendingDeviceCodesCount_CacheHit(t *testing.T) {
 	}
 }
 
-func TestMetricsCacheWrapper_GetTotalDeviceCodesCount_CacheMiss(t *testing.T) {
+func TestCacheWrapper_GetTotalDeviceCodesCount_CacheMiss(t *testing.T) {
 	ctx := context.Background()
 	memCache := cache.NewMemoryCache()
 
@@ -265,7 +265,7 @@ func TestMetricsCacheWrapper_GetTotalDeviceCodesCount_CacheMiss(t *testing.T) {
 	}
 }
 
-func TestMetricsCacheWrapper_GetPendingDeviceCodesCount_CacheMiss(t *testing.T) {
+func TestCacheWrapper_GetPendingDeviceCodesCount_CacheMiss(t *testing.T) {
 	ctx := context.Background()
 	memCache := cache.NewMemoryCache()
 
@@ -303,7 +303,7 @@ func TestMetricsCacheWrapper_GetPendingDeviceCodesCount_CacheMiss(t *testing.T) 
 	}
 }
 
-func TestMetricsCacheWrapper_GetTotalDeviceCodesCount_DBError(t *testing.T) {
+func TestCacheWrapper_GetTotalDeviceCodesCount_DBError(t *testing.T) {
 	ctx := context.Background()
 	memCache := cache.NewMemoryCache()
 
@@ -322,7 +322,7 @@ func TestMetricsCacheWrapper_GetTotalDeviceCodesCount_DBError(t *testing.T) {
 	}
 }
 
-func TestMetricsCacheWrapper_GetPendingDeviceCodesCount_DBError(t *testing.T) {
+func TestCacheWrapper_GetPendingDeviceCodesCount_DBError(t *testing.T) {
 	ctx := context.Background()
 	memCache := cache.NewMemoryCache()
 
@@ -371,7 +371,7 @@ func (m *mockCacheAside) GetWithFetch(
 	return value, nil
 }
 
-func TestMetricsCacheWrapper_UsesGetWithFetch(t *testing.T) {
+func TestCacheWrapper_UsesGetWithFetch(t *testing.T) {
 	ctx := context.Background()
 	mockCache := &mockCacheAside{
 		MemoryCache: cache.NewMemoryCache(),
@@ -410,7 +410,7 @@ func TestMetricsCacheWrapper_UsesGetWithFetch(t *testing.T) {
 	}
 }
 
-func TestMetricsCacheWrapper_FallbackToManualCacheAside(t *testing.T) {
+func TestCacheWrapper_FallbackToManualCacheAside(t *testing.T) {
 	ctx := context.Background()
 	memCache := cache.NewMemoryCache()
 
@@ -445,7 +445,7 @@ func TestMetricsCacheWrapper_FallbackToManualCacheAside(t *testing.T) {
 }
 
 //nolint:dupl // Similar test structure to GetPendingDeviceCodesCount test is intentional
-func TestMetricsCacheWrapper_GetTotalDeviceCodesCount_WithCacheAside(t *testing.T) {
+func TestCacheWrapper_GetTotalDeviceCodesCount_WithCacheAside(t *testing.T) {
 	ctx := context.Background()
 	mockCache := &mockCacheAside{
 		MemoryCache: cache.NewMemoryCache(),
@@ -495,7 +495,7 @@ func TestMetricsCacheWrapper_GetTotalDeviceCodesCount_WithCacheAside(t *testing.
 }
 
 //nolint:dupl // Similar test structure to GetTotalDeviceCodesCount test is intentional
-func TestMetricsCacheWrapper_GetPendingDeviceCodesCount_WithCacheAside(t *testing.T) {
+func TestCacheWrapper_GetPendingDeviceCodesCount_WithCacheAside(t *testing.T) {
 	ctx := context.Background()
 	mockCache := &mockCacheAside{
 		MemoryCache: cache.NewMemoryCache(),

--- a/internal/metrics/http.go
+++ b/internal/metrics/http.go
@@ -14,7 +14,7 @@ const (
 )
 
 // HTTPMetricsMiddleware creates a Gin middleware that records HTTP metrics
-func HTTPMetricsMiddleware(m MetricsRecorder) gin.HandlerFunc {
+func HTTPMetricsMiddleware(m Recorder) gin.HandlerFunc {
 	// If NoopMetrics, return a lightweight middleware that does nothing
 	if _, ok := m.(*NoopMetrics); ok {
 		return func(c *gin.Context) {

--- a/internal/metrics/interface.go
+++ b/internal/metrics/interface.go
@@ -2,9 +2,9 @@ package metrics
 
 import "time"
 
-// MetricsRecorder defines the interface for recording application metrics
+// Recorder defines the interface for recording application metrics
 // Implementations include Metrics (Prometheus-based) and NoopMetrics (no-op)
-type MetricsRecorder interface {
+type Recorder interface {
 	// OAuth Device Flow
 	RecordOAuthDeviceCodeGenerated(success bool)
 	RecordOAuthDeviceCodeAuthorized(authorizationTime time.Duration)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -7,8 +7,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-// Ensure Metrics implements MetricsRecorder interface at compile time
-var _ MetricsRecorder = (*Metrics)(nil)
+// Ensure Metrics implements Recorder interface at compile time
+var _ Recorder = (*Metrics)(nil)
 
 // Metrics holds all Prometheus metrics for the application
 type Metrics struct {
@@ -62,7 +62,7 @@ var (
 // If enabled=true, returns Prometheus-based Metrics
 // If enabled=false, returns NoopMetrics (zero overhead)
 // Uses sync.Once to ensure Prometheus metrics are only registered once
-func Init(enabled bool) MetricsRecorder {
+func Init(enabled bool) Recorder {
 	if !enabled {
 		return NewNoopMetrics()
 	}

--- a/internal/metrics/noop.go
+++ b/internal/metrics/noop.go
@@ -2,15 +2,15 @@ package metrics
 
 import "time"
 
-// NoopMetrics is a no-operation implementation of MetricsRecorder
+// NoopMetrics is a no-operation implementation of Recorder
 // All methods are empty and do nothing, providing zero overhead when metrics are disabled
 type NoopMetrics struct{}
 
-// Ensure NoopMetrics implements MetricsRecorder interface at compile time
-var _ MetricsRecorder = (*NoopMetrics)(nil)
+// Ensure NoopMetrics implements Recorder interface at compile time
+var _ Recorder = (*NoopMetrics)(nil)
 
 // NewNoopMetrics creates a new no-operation metrics recorder
-func NewNoopMetrics() MetricsRecorder {
+func NewNoopMetrics() Recorder {
 	return &NoopMetrics{}
 }
 

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -20,7 +20,7 @@ const (
 )
 
 // generateFingerprint creates a SHA256 hash from IP (optional) and User-Agent
-func generateFingerprint(ip string, userAgent string, includeIP bool) string {
+func generateFingerprint(ip, userAgent string, includeIP bool) string {
 	data := userAgent
 	if includeIP {
 		data = ip + "|" + userAgent
@@ -58,7 +58,7 @@ func RequireAuth(userService *services.UserService) gin.HandlerFunc {
 
 // SessionFingerprintMiddleware validates session fingerprint to prevent session hijacking
 // Checks User-Agent (and optionally IP) against stored fingerprint
-func SessionFingerprintMiddleware(enabled bool, includeIP bool) gin.HandlerFunc {
+func SessionFingerprintMiddleware(enabled, includeIP bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Skip if fingerprinting is disabled
 		if !enabled {

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -71,7 +71,7 @@ func TestSessionIdleTimeout_Disabled(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 	r.ServeHTTP(w, req)
 
 	// Should not redirect even though last activity was long ago (idle timeout disabled)
@@ -90,7 +90,7 @@ func TestSessionIdleTimeout_ExceededTimeout(t *testing.T) {
 
 	// First request: set up an expired session
 	w1 := httptest.NewRecorder()
-	req1, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	req1, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 
 	// Create session with user and expired last activity
 	r2 := setupTestRouter()
@@ -139,7 +139,7 @@ func TestSessionIdleTimeout_UpdatesLastActivity(t *testing.T) {
 
 	// First request: set up session with old last activity
 	w1 := httptest.NewRecorder()
-	req1, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	req1, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 
 	r2 := setupTestRouter()
 	r2.Use(func(c *gin.Context) {
@@ -176,7 +176,7 @@ func TestSessionIdleTimeout_NoSessionSkipped(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 	r.ServeHTTP(w, req)
 
 	// Should proceed normally (no session to check)
@@ -206,7 +206,7 @@ func TestSessionIdleTimeout_WithinTimeout(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 	r.ServeHTTP(w, req)
 
 	// Should not redirect (within timeout)
@@ -225,7 +225,7 @@ func TestSessionFingerprintMiddleware_Disabled(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 	r.ServeHTTP(w, req)
 
 	// Should proceed normally (fingerprinting disabled)
@@ -257,7 +257,7 @@ func TestSessionFingerprintMiddleware_ValidFingerprint(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 	req.Header.Set("User-Agent", testUserAgent)
 	r.ServeHTTP(w, req)
 
@@ -293,7 +293,7 @@ func TestSessionFingerprintMiddleware_MismatchFingerprint(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 	// Use different User-Agent (simulating hijacked session)
 	req.Header.Set("User-Agent", "Mozilla/5.0 Different Browser")
 	r.ServeHTTP(w, req)
@@ -318,7 +318,7 @@ func TestSessionFingerprintMiddleware_NoSession(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 	r.ServeHTTP(w, req)
 
 	// Should proceed normally (no session to check)
@@ -342,7 +342,7 @@ func TestRequireAuth_RedirectURLEncoded(t *testing.T) {
 	w := httptest.NewRecorder()
 	// Request URL with complex query parameters (simulating OAuth authorize endpoint)
 	requestPath := "/oauth/authorize?client_id=test-client&redirect_uri=http%3A%2F%2Flocalhost%3A8888%2Fcallback&response_type=code&scope=read+write&state=abc123&code_challenge=xyz789&code_challenge_method=S256"
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", requestPath, nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, requestPath, nil)
 	r.ServeHTTP(w, req)
 
 	// Should redirect to login
@@ -351,7 +351,7 @@ func TestRequireAuth_RedirectURLEncoded(t *testing.T) {
 
 	// Parse the redirect location
 	parsedURL, err := url.Parse(location)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "/login", parsedURL.Path)
 
 	// Verify that the redirect parameter is present and URL-encoded
@@ -393,7 +393,7 @@ func TestSessionIdleTimeout_RedirectURLEncoded(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	requestPath := "/oauth/authorize?client_id=test-client&state=abc123"
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", requestPath, nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, requestPath, nil)
 	r.ServeHTTP(w, req)
 
 	// Should redirect to login with timeout error
@@ -401,7 +401,7 @@ func TestSessionIdleTimeout_RedirectURLEncoded(t *testing.T) {
 	location := w.Header().Get("Location")
 
 	parsedURL, err := url.Parse(location)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "/login", parsedURL.Path)
 
 	// Verify redirect parameter is properly encoded
@@ -443,7 +443,7 @@ func TestSessionFingerprintMiddleware_RedirectURLEncoded(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	requestPath := "/oauth/authorize?client_id=test-client&state=abc123"
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", requestPath, nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, requestPath, nil)
 	// Use different User-Agent
 	req.Header.Set("User-Agent", "Mozilla/5.0 Different Browser")
 	r.ServeHTTP(w, req)
@@ -453,7 +453,7 @@ func TestSessionFingerprintMiddleware_RedirectURLEncoded(t *testing.T) {
 	location := w.Header().Get("Location")
 
 	parsedURL, err := url.Parse(location)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "/login", parsedURL.Path)
 
 	// Verify redirect parameter is properly encoded

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -59,7 +60,7 @@ func NewRateLimiter(config RateLimitConfig) (gin.HandlerFunc, error) {
 	case RateLimitStoreRedis:
 		// Redis client must be provided when using Redis store
 		if config.RedisClient == nil {
-			return nil, fmt.Errorf(
+			return nil, errors.New(
 				"RedisClient is required when StoreType is redis (should be initialized in main.go)",
 			)
 		}

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -33,7 +33,7 @@ func TestNewMemoryRateLimiter(t *testing.T) {
 	})
 
 	// First requests should succeed
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
 		req.Header.Set("X-Forwarded-For", "192.168.1.100")
 		w := httptest.NewRecorder()
@@ -98,7 +98,7 @@ func TestRateLimiter_DifferentIPs(t *testing.T) {
 
 	for _, ip := range ips {
 		// Each IP can make 2 requests
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			req := httptest.NewRequest(http.MethodGet, "/test", nil)
 			req.Header.Set("X-Forwarded-For", ip)
 			w := httptest.NewRecorder()
@@ -173,7 +173,7 @@ func TestNewRedisRateLimiter_InvalidAddress(t *testing.T) {
 	})
 
 	// Should fail to create store
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, limiter)
 }
 
@@ -221,7 +221,7 @@ func TestNewRedisRateLimiter_Success(t *testing.T) {
 	testIP := "192.168.99." + time.Now().Format("150405")
 
 	// Make requests
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
 		req.Header.Set("X-Forwarded-For", testIP)
 		w := httptest.NewRecorder()
@@ -295,7 +295,7 @@ func TestRedisRateLimiter_MultiInstance(t *testing.T) {
 	testIP := "192.168.88." + time.Now().Format("150405")
 
 	// Make 3 requests to pod1
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
 		req.Header.Set("X-Forwarded-For", testIP)
 		w := httptest.NewRecorder()
@@ -304,7 +304,7 @@ func TestRedisRateLimiter_MultiInstance(t *testing.T) {
 	}
 
 	// Make 2 requests to pod2 (should succeed, total = 5)
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
 		req.Header.Set("X-Forwarded-For", testIP)
 		w := httptest.NewRecorder()
@@ -490,7 +490,7 @@ func TestCreateRedisClient(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	err := client.Ping(ctx).Err()
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Test with valid address (if Redis is available)
 	validClient := redis.NewClient(&redis.Options{

--- a/internal/models/audit_log.go
+++ b/internal/models/audit_log.go
@@ -45,7 +45,7 @@ const (
 	EventAuthorizationCodeDenied    EventType = "AUTHORIZATION_CODE_DENIED"
 	EventUserAuthorizationGranted   EventType = "USER_AUTHORIZATION_GRANTED"
 	EventUserAuthorizationRevoked   EventType = "USER_AUTHORIZATION_REVOKED"
-	EventClientTokensRevokedAll     EventType = "CLIENT_TOKENS_REVOKED_ALL" //nolint:gosec
+	EventClientTokensRevokedAll     EventType = "CLIENT_TOKENS_REVOKED_ALL" //nolint:gosec // G101: false positive, this is a const string describing an event type, not a credential
 
 	// Audit events
 	EventTypeAuditLogView     EventType = "AUDIT_LOG_VIEWED"
@@ -75,18 +75,18 @@ const (
 )
 
 // AuditDetails stores additional event-specific information as JSON
-type AuditDetails map[string]interface{}
+type AuditDetails map[string]any
 
 // Value implements the driver.Valuer interface for database storage
 func (a AuditDetails) Value() (driver.Value, error) {
 	if a == nil {
-		return nil, nil
+		return nil, nil //nolint:nilnil // nil driver.Value represents SQL NULL, which is valid here
 	}
 	return json.Marshal(a)
 }
 
 // Scan implements the sql.Scanner interface for database retrieval
-func (a *AuditDetails) Scan(value interface{}) error {
+func (a *AuditDetails) Scan(value any) error {
 	if value == nil {
 		*a = nil
 		return nil

--- a/internal/models/oauth_application.go
+++ b/internal/models/oauth_application.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base32"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/go-authgate/authgate/internal/util"
@@ -65,7 +66,7 @@ func (app *OAuthApplication) ValidateClientSecret(secret []byte) bool {
 type StringArray []string
 
 // Scan implements sql.Scanner interface
-func (s *StringArray) Scan(value interface{}) error {
+func (s *StringArray) Scan(value any) error {
 	if value == nil {
 		*s = []string{}
 		return nil
@@ -90,14 +91,14 @@ func (s StringArray) Join(sep string) string {
 	if len(s) == 0 {
 		return ""
 	}
-	result := ""
+	var b strings.Builder
 	for i, str := range s {
 		if i > 0 {
-			result += sep
+			b.WriteString(sep)
 		}
-		result += str
+		b.WriteString(str)
 	}
-	return result
+	return b.String()
 }
 
 // TableName overrides the table name used by OAuthApplication to `oauth_applications`

--- a/internal/models/oauth_application_test.go
+++ b/internal/models/oauth_application_test.go
@@ -61,7 +61,7 @@ func TestStringArray_Join(t *testing.T) {
 func TestStringArray_Scan(t *testing.T) {
 	tests := []struct {
 		name    string
-		value   interface{}
+		value   any
 		want    StringArray
 		wantErr bool
 	}{

--- a/internal/services/authorization.go
+++ b/internal/services/authorization.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -269,7 +270,7 @@ func (s *AuthorizationService) GetUserAuthorization(
 ) (*models.UserAuthorization, error) {
 	auth, err := s.store.GetUserAuthorization(userID, applicationID)
 	if err != nil {
-		return nil, nil // Treat as "not found" for consent check
+		return nil, nil //nolint:nilnil // nil UserAuthorization means "not found", which is not an error
 	}
 	return auth, nil
 }
@@ -512,20 +513,15 @@ func (s *AuthorizationService) isValidRedirectURI(
 	if uri == "" {
 		return false
 	}
-	for _, registered := range client.RedirectURIs {
-		if registered == uri {
-			return true
-		}
-	}
-	return false
+	return slices.Contains([]string(client.RedirectURIs), uri)
 }
 
 func (s *AuthorizationService) isValidScope(clientScopes, requestedScopes string) bool {
 	allowed := make(map[string]bool)
-	for _, sc := range strings.Fields(clientScopes) {
+	for sc := range strings.FieldsSeq(clientScopes) {
 		allowed[sc] = true
 	}
-	for _, sc := range strings.Fields(requestedScopes) {
+	for sc := range strings.FieldsSeq(requestedScopes) {
 		if !allowed[sc] {
 			return false
 		}

--- a/internal/services/authorization_test.go
+++ b/internal/services/authorization_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	testClientPlainSecret = "test-plain-secret" //nolint:gosec
+	testClientPlainSecret = "test-plain-secret" //nolint:gosec // G101: false positive, this is a test secret string, not a hardcoded credential
 	testPKCEVerifier      = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
 )
 
@@ -472,7 +472,7 @@ func TestListUserAuthorizations_MultipleClients(t *testing.T) {
 	svc := createTestAuthorizationService(t)
 	userID := uuid.New().String()
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		c := &models.OAuthApplication{
 			ClientID:           uuid.New().String(),
 			ClientSecret:       "secret",
@@ -504,7 +504,7 @@ func TestRevokeAllApplicationTokens_RevokesConsentRecords(t *testing.T) {
 	client := createAuthCodeFlowClient(t, svc, "confidential")
 
 	// Grant access for 2 users
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		userID := uuid.New().String()
 		_, err := svc.SaveUserAuthorization(
 			context.Background(), userID, client.ID, client.ClientID, "read",
@@ -611,7 +611,7 @@ func TestValidateAuthorizationRequest_GlobalPKCERequired(t *testing.T) {
 	_, err := svc.ValidateAuthorizationRequest(
 		client.ClientID, "https://app.example.com/callback", "code", "read", "",
 	)
-	assert.ErrorIs(t, err, ErrPKCERequired)
+	require.ErrorIs(t, err, ErrPKCERequired)
 
 	// With S256 → must succeed
 	req, err := svc.ValidateAuthorizationRequest(

--- a/internal/services/client_test.go
+++ b/internal/services/client_test.go
@@ -96,7 +96,7 @@ func TestListClientsPaginatedWithCreator(t *testing.T) {
 		assert.Equal(t, "alice", clientMap["Client 1"].CreatorUsername)
 		assert.Equal(t, "bob", clientMap["Client 2"].CreatorUsername)
 		assert.Equal(t, "alice", clientMap["Client 3"].CreatorUsername)
-		assert.Equal(t, "", clientMap["Client 4"].CreatorUsername) // No creator
+		assert.Empty(t, clientMap["Client 4"].CreatorUsername) // No creator
 	})
 
 	t.Run("handles pagination correctly", func(t *testing.T) {
@@ -104,7 +104,7 @@ func TestListClientsPaginatedWithCreator(t *testing.T) {
 		clients, pagination, err := clientService.ListClientsPaginatedWithCreator(params)
 
 		require.NoError(t, err)
-		assert.Equal(t, 2, len(clients))
+		assert.Len(t, clients, 2)
 		// Note: Store creates a default "AuthGate CLI" client, so we have 5 total
 		assert.GreaterOrEqual(t, int(pagination.Total), 4)
 		assert.Equal(t, 1, pagination.CurrentPage)
@@ -116,7 +116,7 @@ func TestListClientsPaginatedWithCreator(t *testing.T) {
 		clients, pagination, err := clientService.ListClientsPaginatedWithCreator(params)
 
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(clients))
+		assert.Len(t, clients, 1)
 		assert.Equal(t, "Client 1", clients[0].ClientName)
 		assert.Equal(t, "alice", clients[0].CreatorUsername)
 		assert.Equal(t, int64(1), pagination.Total)
@@ -127,7 +127,7 @@ func TestListClientsPaginatedWithCreator(t *testing.T) {
 		clients, pagination, err := clientService.ListClientsPaginatedWithCreator(params)
 
 		require.NoError(t, err)
-		assert.Equal(t, 0, len(clients))
+		assert.Empty(t, clients)
 		assert.Equal(t, int64(0), pagination.Total)
 	})
 
@@ -161,9 +161,9 @@ func TestListClientsPaginatedWithCreator(t *testing.T) {
 		clients, _, err := clientService.ListClientsPaginatedWithCreator(params)
 
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(clients))
+		assert.Len(t, clients, 1)
 		assert.Equal(t, "Client With Deleted User", clients[0].ClientName)
-		assert.Equal(t, "", clients[0].CreatorUsername) // User deleted, so empty
+		assert.Empty(t, clients[0].CreatorUsername) // User deleted, so empty
 	})
 }
 
@@ -202,7 +202,7 @@ func TestGetUsersByIDs(t *testing.T) {
 		userMap, err := s.GetUsersByIDs(userIDs)
 
 		require.NoError(t, err)
-		assert.Equal(t, 3, len(userMap))
+		assert.Len(t, userMap, 3)
 		assert.Equal(t, "user1", userMap[user1.ID].Username)
 		assert.Equal(t, "user2", userMap[user2.ID].Username)
 		assert.Equal(t, "user3", userMap[user3.ID].Username)
@@ -214,7 +214,7 @@ func TestGetUsersByIDs(t *testing.T) {
 		userMap, err := s.GetUsersByIDs(userIDs)
 
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(userMap))
+		assert.Len(t, userMap, 1)
 		assert.Equal(t, "user1", userMap[user1.ID].Username)
 		assert.Nil(t, userMap[nonExistentID])
 	})
@@ -223,7 +223,7 @@ func TestGetUsersByIDs(t *testing.T) {
 		userMap, err := s.GetUsersByIDs([]string{})
 
 		require.NoError(t, err)
-		assert.Equal(t, 0, len(userMap))
+		assert.Empty(t, userMap)
 	})
 
 	t.Run("handles duplicate IDs efficiently", func(t *testing.T) {
@@ -232,7 +232,7 @@ func TestGetUsersByIDs(t *testing.T) {
 		userMap, err := s.GetUsersByIDs(userIDs)
 
 		require.NoError(t, err)
-		assert.Equal(t, 2, len(userMap))
+		assert.Len(t, userMap, 2)
 		assert.Equal(t, "user1", userMap[user1.ID].Username)
 		assert.Equal(t, "user2", userMap[user2.ID].Username)
 	})

--- a/internal/services/device.go
+++ b/internal/services/device.go
@@ -31,14 +31,14 @@ type DeviceService struct {
 	store        *store.Store
 	config       *config.Config
 	auditService *AuditService
-	metrics      metrics.MetricsRecorder
+	metrics      metrics.Recorder
 }
 
 func NewDeviceService(
 	s *store.Store,
 	cfg *config.Config,
 	auditService *AuditService,
-	m metrics.MetricsRecorder,
+	m metrics.Recorder,
 ) *DeviceService {
 	return &DeviceService{
 		store:        s,

--- a/internal/services/device_security_test.go
+++ b/internal/services/device_security_test.go
@@ -175,18 +175,18 @@ func TestConstantTimeComparison(t *testing.T) {
 		iterations := 100000 // More iterations for better averaging
 
 		// Warm up
-		for i := 0; i < 1000; i++ {
+		for range 1000 {
 			subtle.ConstantTimeCompare([]byte(hash), []byte(almostMatch))
 		}
 
 		start1 := time.Now()
-		for i := 0; i < iterations; i++ {
+		for range iterations {
 			subtle.ConstantTimeCompare([]byte(hash), []byte(almostMatch))
 		}
 		duration1 := time.Since(start1)
 
 		start2 := time.Now()
-		for i := 0; i < iterations; i++ {
+		for range iterations {
 			subtle.ConstantTimeCompare([]byte(hash), []byte(noMatch))
 		}
 		duration2 := time.Since(start2)
@@ -207,7 +207,7 @@ func TestDeviceCodeGeneration(t *testing.T) {
 	t.Run("Generated codes are unique", func(t *testing.T) {
 		codes := make(map[string]bool)
 
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			dc, err := service.GenerateDeviceCode(context.Background(), client.ClientID, "read")
 			require.NoError(t, err)
 
@@ -225,7 +225,7 @@ func TestDeviceCodeGeneration(t *testing.T) {
 
 		// Check hex format
 		_, err = hex.DecodeString(dc.DeviceCode)
-		assert.NoError(t, err, "DeviceCode should be valid hex")
+		require.NoError(t, err, "DeviceCode should be valid hex")
 
 		// Check DeviceCodeID is last 8 chars
 		assert.Equal(t, dc.DeviceCode[32:], dc.DeviceCodeID)

--- a/internal/services/device_test.go
+++ b/internal/services/device_test.go
@@ -66,7 +66,7 @@ func TestGenerateDeviceCode_ActiveClient(t *testing.T) {
 	dc, err := deviceService.GenerateDeviceCode(context.Background(), client.ClientID, "read write")
 
 	// Assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, dc)
 	assert.NotEmpty(t, dc.DeviceCode)
 	assert.NotEmpty(t, dc.UserCode)
@@ -95,7 +95,7 @@ func TestGenerateDeviceCode_InactiveClient(t *testing.T) {
 	dc, err := deviceService.GenerateDeviceCode(context.Background(), client.ClientID, "read write")
 
 	// Assert
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, ErrClientInactive, err)
 	assert.Nil(t, dc)
 }
@@ -116,7 +116,7 @@ func TestGenerateDeviceCode_InvalidClient(t *testing.T) {
 	)
 
 	// Assert
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, ErrInvalidClient, err)
 	assert.Nil(t, dc)
 }
@@ -161,7 +161,7 @@ func TestGenerateDeviceCode_DeviceFlowDisabled(t *testing.T) {
 	dc, err := deviceService.GenerateDeviceCode(context.Background(), client.ClientID, "read write")
 
 	// Assert
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, ErrDeviceFlowNotEnabled, err)
 	assert.Nil(t, dc)
 }
@@ -185,11 +185,11 @@ func TestAuthorizeDeviceCode_Success(t *testing.T) {
 	err = deviceService.AuthorizeDeviceCode(context.Background(), dc.UserCode, userID, username)
 
 	// Assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Verify the device code is authorized
 	authorizedDC, err := deviceService.GetDeviceCode(dc.DeviceCode)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, authorizedDC.Authorized)
 	assert.Equal(t, userID, authorizedDC.UserID)
 }
@@ -211,7 +211,7 @@ func TestAuthorizeDeviceCode_InvalidUserCode(t *testing.T) {
 	)
 
 	// Assert
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, ErrUserCodeNotFound, err)
 }
 
@@ -232,7 +232,7 @@ func TestGetClientByUserCode_Success(t *testing.T) {
 	result, resultDC, err := deviceService.GetClientByUserCode(dc.UserCode)
 
 	// Assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "Test Client", result.ClientName)
 	assert.Equal(t, client.ClientID, result.ClientID)
 	assert.Equal(t, dc.UserCode, resultDC.UserCode)

--- a/internal/services/token_test.go
+++ b/internal/services/token_test.go
@@ -74,7 +74,7 @@ func TestExchangeDeviceCode_ActiveClient(t *testing.T) {
 	)
 
 	// Assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, token)
 	assert.NotEmpty(t, token.Token)
 	assert.Equal(t, "Bearer", token.TokenType)
@@ -110,7 +110,7 @@ func TestExchangeDeviceCode_InactiveClient(t *testing.T) {
 	)
 
 	// Assert - should fail with access denied
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, ErrAccessDenied, err)
 	assert.Nil(t, token)
 }
@@ -139,7 +139,7 @@ func TestExchangeDeviceCode_ClientMismatch(t *testing.T) {
 	)
 
 	// Assert
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, ErrAccessDenied, err)
 	assert.Nil(t, token)
 }
@@ -169,7 +169,7 @@ func TestExchangeDeviceCode_NotAuthorized(t *testing.T) {
 	)
 
 	// Assert
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, ErrAuthorizationPending, err)
 	assert.Nil(t, token)
 }
@@ -199,7 +199,7 @@ func TestExchangeDeviceCode_ExpiredCode(t *testing.T) {
 	)
 
 	// Assert
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, ErrExpiredToken, err)
 	assert.Nil(t, token)
 }
@@ -226,7 +226,7 @@ func TestExchangeDeviceCode_InvalidDeviceCode(t *testing.T) {
 	)
 
 	// Assert
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, ErrExpiredToken, err)
 	assert.Nil(t, token)
 }
@@ -256,7 +256,7 @@ func TestValidateToken_Success(t *testing.T) {
 	claims, err := tokenService.ValidateToken(context.Background(), token.Token)
 
 	// Assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, claims)
 	assert.Equal(t, client.ClientID, claims.ClientID)
 	assert.Equal(t, "read write", claims.Scopes)
@@ -273,7 +273,7 @@ func TestValidateToken_InvalidToken(t *testing.T) {
 	claims, err := tokenService.ValidateToken(context.Background(), "invalid-token")
 
 	// Assert
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, claims)
 }
 
@@ -306,7 +306,7 @@ func TestValidateToken_WrongSecret(t *testing.T) {
 	claims, err := differentTokenService.ValidateToken(context.Background(), token.Token)
 
 	// Assert
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, claims)
 }
 
@@ -335,7 +335,7 @@ func TestRevokeToken_Success(t *testing.T) {
 	err = tokenService.RevokeToken(token.Token)
 
 	// Assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Verify token is removed from database
 	_, err = s.GetAccessToken(token.Token)
@@ -353,7 +353,7 @@ func TestRevokeToken_InvalidToken(t *testing.T) {
 	err := tokenService.RevokeToken("non-existent-token")
 
 	// Assert
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "token not found")
 }
 
@@ -382,7 +382,7 @@ func TestRevokeTokenByID_Success(t *testing.T) {
 	err = tokenService.RevokeTokenByID(context.Background(), token.ID, dc.UserID)
 
 	// Assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Verify token is removed from database
 	_, err = s.GetAccessTokenByID(token.ID)
@@ -434,7 +434,7 @@ func TestGetUserTokens_Success(t *testing.T) {
 	tokens, err := tokenService.GetUserTokens(userID)
 
 	// Assert - should have 4 tokens (2 access + 2 refresh)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, tokens, 4)
 	// Verify we have tokens from both device code exchanges
 	tokenIDs := make([]string, len(tokens))
@@ -488,12 +488,12 @@ func TestRevokeAllUserTokens_Success(t *testing.T) {
 
 	// Revoke all user tokens
 	err = tokenService.RevokeAllUserTokens(userID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Verify all tokens are removed
 	tokens, err := tokenService.GetUserTokens(userID)
-	assert.NoError(t, err)
-	assert.Len(t, tokens, 0)
+	require.NoError(t, err)
+	assert.Empty(t, tokens)
 }
 
 func TestGetUserTokensWithClient_Success(t *testing.T) {
@@ -529,7 +529,7 @@ func TestGetUserTokensWithClient_Success(t *testing.T) {
 	tokensWithClient, err := tokenService.GetUserTokensWithClient(userID)
 
 	// Assert - should have 2 tokens (access + refresh)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, tokensWithClient, 2)
 
 	// Verify both tokens are present
@@ -587,7 +587,7 @@ func TestGetUserTokensWithClient_MultipleClients(t *testing.T) {
 	tokensWithClient, err := tokenService.GetUserTokensWithClient(userID)
 
 	// Assert - should have 4 tokens (2 access + 2 refresh)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, tokensWithClient, 4)
 
 	// Create maps for easier verification
@@ -618,9 +618,9 @@ func TestGetUserTokensWithClient_EmptyResult(t *testing.T) {
 	tokensWithClient, err := tokenService.GetUserTokensWithClient("non-existent-user")
 
 	// Assert
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tokensWithClient)
-	assert.Len(t, tokensWithClient, 0)
+	assert.Empty(t, tokensWithClient)
 }
 
 // ============================================================

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -86,7 +87,7 @@ func (s *UserService) authenticateExistingUser(
 	user *models.User,
 	password string,
 ) (*models.User, error) {
-	var authResult *auth.AuthResult
+	var authResult *auth.Result
 	var err error
 	var providerName string
 
@@ -284,7 +285,7 @@ func (s *UserService) authenticateAndCreateExternalUser(
 
 // syncExternalUser creates or updates local user record from external auth result
 func (s *UserService) syncExternalUser(
-	result *auth.AuthResult,
+	result *auth.Result,
 	authSource string,
 ) (*models.User, error) {
 	user, err := s.store.UpsertExternalUser(
@@ -574,14 +575,14 @@ func (s *UserService) generateUniqueUsername(baseUsername, provider string) stri
 	}
 
 	// Try with provider suffix
-	username = fmt.Sprintf("%s-%s", username, provider)
+	username = username + "-" + provider
 	if _, err := s.store.GetUserByUsername(username); err != nil {
 		return username
 	}
 
 	// Try with numbers
 	for i := 1; i <= 10; i++ {
-		candidate := fmt.Sprintf("%s-%s-%d", sanitizeUsername(baseUsername), provider, i)
+		candidate := sanitizeUsername(baseUsername) + "-" + provider + "-" + strconv.Itoa(i)
 		if _, err := s.store.GetUserByUsername(candidate); err != nil {
 			return candidate
 		}
@@ -589,7 +590,7 @@ func (s *UserService) generateUniqueUsername(baseUsername, provider string) stri
 
 	// Last resort: random suffix
 	randomSuffix := random.String(6)
-	return fmt.Sprintf("%s-%s", username, randomSuffix)
+	return username + "-" + randomSuffix
 }
 
 // sanitizeUsername removes special characters, keeps only alphanumeric, '_' and '-'.

--- a/internal/store/audit_filters.go
+++ b/internal/store/audit_filters.go
@@ -14,8 +14,8 @@ type AuditLogFilters struct {
 	ResourceID   string               `json:"resource_id,omitempty"`
 	Severity     models.EventSeverity `json:"severity,omitempty"`
 	Success      *bool                `json:"success,omitempty"`
-	StartTime    time.Time            `json:"start_time,omitempty"`
-	EndTime      time.Time            `json:"end_time,omitempty"`
+	StartTime    time.Time            `json:"start_time,omitzero"`
+	EndTime      time.Time            `json:"end_time,omitzero"`
 	ActorIP      string               `json:"actor_ip,omitempty"`
 	Search       string               `json:"search,omitempty"` // Search in action, resource_name, actor_username
 }

--- a/internal/store/pagination.go
+++ b/internal/store/pagination.go
@@ -58,15 +58,8 @@ func CalculatePagination(total int64, currentPage, pageSize int) PaginationResul
 	hasPrev := currentPage > 1
 	hasNext := currentPage < totalPages
 
-	prevPage := currentPage - 1
-	if prevPage < 1 {
-		prevPage = 1
-	}
-
-	nextPage := currentPage + 1
-	if nextPage > totalPages {
-		nextPage = totalPages
-	}
+	prevPage := max(currentPage-1, 1)
+	nextPage := min(currentPage+1, totalPages)
 
 	return PaginationResult{
 		Total:       total,

--- a/internal/token/local_test.go
+++ b/internal/token/local_test.go
@@ -83,8 +83,8 @@ func TestLocalTokenProvider_ValidateToken_InvalidToken(t *testing.T) {
 		"invalid-token-string",
 	)
 
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, ErrInvalidToken)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidToken)
 }
 
 func TestLocalTokenProvider_ValidateToken_WrongSecret(t *testing.T) {
@@ -115,8 +115,8 @@ func TestLocalTokenProvider_ValidateToken_WrongSecret(t *testing.T) {
 		genResult.TokenString,
 	)
 
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, ErrInvalidToken)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidToken)
 }
 
 func TestLocalTokenProvider_ValidateToken_ExpiredToken(t *testing.T) {
@@ -145,8 +145,8 @@ func TestLocalTokenProvider_ValidateToken_ExpiredToken(t *testing.T) {
 		genResult.TokenString,
 	)
 
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, ErrExpiredToken)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrExpiredToken)
 }
 
 func TestLocalTokenProvider_Name(t *testing.T) {

--- a/internal/token/types.go
+++ b/internal/token/types.go
@@ -7,8 +7,8 @@ const (
 	TokenTypeBearer = "Bearer"
 )
 
-// TokenResult represents the result of token generation
-type TokenResult struct {
+// Result represents the result of token generation
+type Result struct {
 	TokenString string         // The JWT string
 	TokenType   string         // "Bearer"
 	ExpiresAt   time.Time      // Token expiration time
@@ -16,8 +16,8 @@ type TokenResult struct {
 	Success     bool           // Generation success status
 }
 
-// TokenValidationResult represents the result of token verification
-type TokenValidationResult struct {
+// ValidationResult represents the result of token verification
+type ValidationResult struct {
 	Valid     bool
 	UserID    string
 	ClientID  string
@@ -28,7 +28,7 @@ type TokenValidationResult struct {
 
 // RefreshResult represents the result of a refresh token operation
 type RefreshResult struct {
-	AccessToken  *TokenResult // New access token (required)
-	RefreshToken *TokenResult // New refresh token (only present in rotation mode)
-	Success      bool         // Operation success status
+	AccessToken  *Result // New access token (required)
+	RefreshToken *Result // New refresh token (only present in rotation mode)
+	Success      bool    // Operation success status
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,9 +1,12 @@
 package version
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 var (
-	App       string = "AuthGate"
+	App       = "AuthGate"
 	Version   string
 	GitCommit string
 	BuildTime string
@@ -14,18 +17,18 @@ var (
 
 // PrintVersion prints the version information
 func PrintVersion() {
-	fmt.Printf("%s version %s\n", App, getVersion())
+	fmt.Fprintf(os.Stdout, "%s version %s\n", App, getVersion())
 	if GitCommit != "" {
-		fmt.Printf("Git commit: %s\n", getShortCommit())
+		fmt.Fprintf(os.Stdout, "Git commit: %s\n", getShortCommit())
 	}
 	if BuildTime != "" {
-		fmt.Printf("Build time: %s\n", BuildTime)
+		fmt.Fprintf(os.Stdout, "Build time: %s\n", BuildTime)
 	}
 	if GoVersion != "" {
-		fmt.Printf("Go version: %s\n", GoVersion)
+		fmt.Fprintf(os.Stdout, "Go version: %s\n", GoVersion)
 	}
 	if BuildOS != "" && BuildArch != "" {
-		fmt.Printf("Built for: %s/%s\n", BuildOS, BuildArch)
+		fmt.Fprintf(os.Stdout, "Built for: %s/%s\n", BuildOS, BuildArch)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -67,20 +67,20 @@ func main() {
 	case "server":
 		runServer()
 	default:
-		fmt.Printf("Unknown command: %s\n\n", args[0])
+		fmt.Fprintf(os.Stdout, "Unknown command: %s\n\n", args[0])
 		printUsage()
 		os.Exit(1)
 	}
 }
 
 func printUsage() {
-	fmt.Printf("Usage: %s [OPTIONS] COMMAND\n\n", os.Args[0])
-	fmt.Println("OAuth 2.0 Device Authorization Grant server")
-	fmt.Println("\nCommands:")
-	fmt.Println("  server    Start the OAuth server")
-	fmt.Println("\nOptions:")
-	fmt.Println("  -v, --version    Show version information")
-	fmt.Println("  -h, --help       Show this help message")
+	fmt.Fprintf(os.Stdout, "Usage: %s [OPTIONS] COMMAND\n\n", os.Args[0])
+	fmt.Fprintln(os.Stdout, "OAuth 2.0 Device Authorization Grant server")
+	fmt.Fprintln(os.Stdout, "\nCommands:")
+	fmt.Fprintln(os.Stdout, "  server    Start the OAuth server")
+	fmt.Fprintln(os.Stdout, "\nOptions:")
+	fmt.Fprintln(os.Stdout, "  -v, --version    Show version information")
+	fmt.Fprintln(os.Stdout, "  -h, --help       Show this help message")
 }
 
 func runServer() {


### PR DESCRIPTION
- Refactor all authentication and token result types to use unified `Result` and `ValidationResult` names, simplifying type naming.
- Switch metrics interface and implementation from `MetricsRecorder` to `Recorder`.
- Prefer `require` over `assert` for error assertions in tests for stricter test validation.
- Replace most uses of `fmt.Sprintf` string construction with string concatenation for greater performance and simplicity.
- Use the `range n` idiom for fixed-count loops in tests instead of classic `for i := 0; i < n; i++` style.
- In test files, update usage of `assert.Len(x, y)`/`assert.Equal(len(x), y)` to direct `assert.Len` or `assert.Empty`.
- Change function signatures and struct fields to use Go 1.18+ [`any`](https://go.dev/doc/go1.18#generics) type instead of `interface{}` where appropriate.
- Standardize code and tests to always use `http.Method*` constants (e.g., `http.MethodGet`, `http.MethodPost`) instead of string literals.
- Simplify and modernize for-loop style and string joining for memory and speed improvements.
- Use `strings.FieldsSeq`/`SplitSeq` (or similar) in place of `strings.Fields`/`Split` for improved code uniformity.
- Return nil values with explicit comment and `//nolint:nilnil` where returning nil is intentional and not an