### PR TITLE
feat: add strongly-typed user and IP context management

### DIFF
--- a/internal/middleware/context.go
+++ b/internal/middleware/context.go
@@ -2,13 +2,19 @@ package middleware
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/go-authgate/authgate/internal/util"
 )
 
 // IPMiddleware extracts client IP and stores it in the context
 func IPMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		clientIP := c.ClientIP()
 		// Gin's ClientIP() handles X-Forwarded-For and other headers
-		c.Set("client_ip", c.ClientIP())
+		c.Set("client_ip", clientIP)
+
+		// Also store in request context for services layer
+		c.Request = c.Request.WithContext(util.SetIPContext(c.Request.Context(), clientIP))
+
 		c.Next()
 	}
 }

--- a/internal/models/context.go
+++ b/internal/models/context.go
@@ -2,23 +2,44 @@ package models
 
 import (
 	"context"
-
-	"github.com/gin-gonic/gin"
 )
 
+// contextKey is a private type to prevent key collisions in context
+type contextKey int
+
+const (
+	contextKeyUser contextKey = iota
+)
+
+// SetUserContext embeds user object into a standard context
+func SetUserContext(ctx context.Context, user *User) context.Context {
+	if user != nil {
+		return context.WithValue(ctx, contextKeyUser, user)
+	}
+	return ctx
+}
+
 // GetUsernameFromContext extracts the username from the user object in context.
-// It attempts to extract from Gin context's "user" key set by RequireAuth middleware.
 // Returns empty string if user cannot be determined.
 func GetUsernameFromContext(ctx context.Context) string {
-	// Try to extract from Gin context first
-	if ginCtx, ok := ctx.(*gin.Context); ok {
-		if userVal, exists := ginCtx.Get("user"); exists {
-			// Direct type assertion - no need to import models since we're IN models
-			if user, ok := userVal.(*User); ok {
-				return user.Username
-			}
-		}
+	if user, ok := ctx.Value(contextKeyUser).(*User); ok && user != nil {
+		return user.Username
 	}
-
 	return ""
+}
+
+// GetUserIDFromContext extracts user ID from context
+func GetUserIDFromContext(ctx context.Context) string {
+	if user, ok := ctx.Value(contextKeyUser).(*User); ok && user != nil {
+		return user.ID
+	}
+	return ""
+}
+
+// GetUserFromContext extracts full user object from context
+func GetUserFromContext(ctx context.Context) *User {
+	if user, ok := ctx.Value(contextKeyUser).(*User); ok {
+		return user
+	}
+	return nil
 }

--- a/internal/models/context_test.go
+++ b/internal/models/context_test.go
@@ -1,0 +1,225 @@
+package models
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSetUserContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		user     *User
+		expected bool
+	}{
+		{
+			name: "Valid user",
+			user: &User{
+				ID:       "user-123",
+				Username: "testuser",
+			},
+			expected: true,
+		},
+		{
+			name:     "Nil user",
+			user:     nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			newCtx := SetUserContext(ctx, tt.user)
+
+			if newCtx == nil {
+				t.Fatal("SetUserContext returned nil context")
+			}
+
+			// Try to retrieve the user
+			retrievedUser := GetUserFromContext(newCtx)
+			if tt.expected {
+				if retrievedUser == nil {
+					t.Error("Expected user to be in context, but got nil")
+				} else if retrievedUser.ID != tt.user.ID {
+					t.Errorf("Expected user ID %s, got %s", tt.user.ID, retrievedUser.ID)
+				}
+			} else {
+				if retrievedUser != nil {
+					t.Error("Expected no user in context, but got one")
+				}
+			}
+		})
+	}
+}
+
+func TestGetUsernameFromContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		user     *User
+		expected string
+	}{
+		{
+			name: "Valid user",
+			user: &User{
+				ID:       "user-123",
+				Username: "testuser",
+			},
+			expected: "testuser",
+		},
+		{
+			name:     "Nil user",
+			user:     nil,
+			expected: "",
+		},
+		{
+			name:     "Empty context",
+			user:     nil,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ctx context.Context
+			if tt.user != nil {
+				ctx = SetUserContext(context.Background(), tt.user)
+			} else {
+				ctx = context.Background()
+			}
+
+			username := GetUsernameFromContext(ctx)
+			if username != tt.expected {
+				t.Errorf("Expected username %q, got %q", tt.expected, username)
+			}
+		})
+	}
+}
+
+func TestGetUserIDFromContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		user     *User
+		expected string
+	}{
+		{
+			name: "Valid user",
+			user: &User{
+				ID:       "user-123",
+				Username: "testuser",
+			},
+			expected: "user-123",
+		},
+		{
+			name:     "Nil user",
+			user:     nil,
+			expected: "",
+		},
+		{
+			name:     "Empty context",
+			user:     nil,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ctx context.Context
+			if tt.user != nil {
+				ctx = SetUserContext(context.Background(), tt.user)
+			} else {
+				ctx = context.Background()
+			}
+
+			userID := GetUserIDFromContext(ctx)
+			if userID != tt.expected {
+				t.Errorf("Expected user ID %q, got %q", tt.expected, userID)
+			}
+		})
+	}
+}
+
+func TestGetUserFromContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		user     *User
+		expected bool
+	}{
+		{
+			name: "Valid user",
+			user: &User{
+				ID:       "user-123",
+				Username: "testuser",
+				Email:    "test@example.com",
+			},
+			expected: true,
+		},
+		{
+			name:     "Nil user",
+			user:     nil,
+			expected: false,
+		},
+		{
+			name:     "Empty context",
+			user:     nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ctx context.Context
+			if tt.user != nil {
+				ctx = SetUserContext(context.Background(), tt.user)
+			} else {
+				ctx = context.Background()
+			}
+
+			user := GetUserFromContext(ctx)
+			if tt.expected {
+				if user == nil {
+					t.Error("Expected user to be in context, but got nil")
+				} else {
+					if user.ID != tt.user.ID {
+						t.Errorf("Expected user ID %s, got %s", tt.user.ID, user.ID)
+					}
+					if user.Username != tt.user.Username {
+						t.Errorf("Expected username %s, got %s", tt.user.Username, user.Username)
+					}
+					if user.Email != tt.user.Email {
+						t.Errorf("Expected email %s, got %s", tt.user.Email, user.Email)
+					}
+				}
+			} else {
+				if user != nil {
+					t.Error("Expected no user in context, but got one")
+				}
+			}
+		})
+	}
+}
+
+func TestContextChaining(t *testing.T) {
+	// Test that context values are preserved when chaining
+	user := &User{
+		ID:       "user-123",
+		Username: "testuser",
+	}
+
+	// Use a custom type for test key to avoid lint warnings
+	type testKey int
+	const testKeyOther testKey = 0
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, testKeyOther, "other_value")
+	ctx = SetUserContext(ctx, user)
+
+	// Check user is accessible
+	if GetUsernameFromContext(ctx) != "testuser" {
+		t.Error("User context was not preserved")
+	}
+
+	// Check other values are accessible
+	if val := ctx.Value(testKeyOther); val != "other_value" {
+		t.Error("Other context values were not preserved")
+	}
+}

--- a/internal/services/audit.go
+++ b/internal/services/audit.go
@@ -155,6 +155,11 @@ func (s *AuditService) Log(ctx context.Context, entry AuditLogEntry) {
 		entry.ActorUsername = models.GetUsernameFromContext(ctx)
 	}
 
+	// Extract user ID from context if not provided
+	if entry.ActorUserID == "" {
+		entry.ActorUserID = models.GetUserIDFromContext(ctx)
+	}
+
 	// Mask sensitive data
 	entry.Details = maskSensitiveDetails(entry.Details)
 
@@ -204,6 +209,11 @@ func (s *AuditService) LogSync(ctx context.Context, entry AuditLogEntry) error {
 	// Extract username from context if not provided
 	if entry.ActorUsername == "" {
 		entry.ActorUsername = models.GetUsernameFromContext(ctx)
+	}
+
+	// Extract user ID from context if not provided
+	if entry.ActorUserID == "" {
+		entry.ActorUserID = models.GetUserIDFromContext(ctx)
 	}
 
 	// Mask sensitive data

--- a/internal/util/context.go
+++ b/internal/util/context.go
@@ -2,24 +2,28 @@ package util
 
 import (
 	"context"
-
-	"github.com/gin-gonic/gin"
 )
 
+// contextKey is a private type to prevent key collisions in context
+type contextKey int
+
+const (
+	contextKeyClientIP contextKey = iota
+)
+
+// SetIPContext embeds client IP into a standard context
+func SetIPContext(ctx context.Context, ip string) context.Context {
+	if ip != "" {
+		return context.WithValue(ctx, contextKeyClientIP, ip)
+	}
+	return ctx
+}
+
 // GetIPFromContext extracts the client IP address from the context.
-// It first attempts to extract from Gin context (via ClientIP method),
-// then falls back to checking for "client_ip" value set by IPMiddleware.
 // Returns empty string if IP cannot be determined.
 func GetIPFromContext(ctx context.Context) string {
-	// Try to extract from Gin context first
-	if ginCtx, ok := ctx.(*gin.Context); ok {
-		return ginCtx.ClientIP()
-	}
-
-	// Try to get from context value (set by middleware)
-	if ip, ok := ctx.Value("client_ip").(string); ok {
+	if ip, ok := ctx.Value(contextKeyClientIP).(string); ok {
 		return ip
 	}
-
 	return ""
 }

--- a/internal/util/context_test.go
+++ b/internal/util/context_test.go
@@ -1,0 +1,108 @@
+package util
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSetIPContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip       string
+		expected bool
+	}{
+		{
+			name:     "Valid IP",
+			ip:       "192.168.1.1",
+			expected: true,
+		},
+		{
+			name:     "Empty IP",
+			ip:       "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			newCtx := SetIPContext(ctx, tt.ip)
+
+			if newCtx == nil {
+				t.Fatal("SetIPContext returned nil context")
+			}
+
+			// Try to retrieve the IP
+			retrievedIP := GetIPFromContext(newCtx)
+			if tt.expected {
+				if retrievedIP != tt.ip {
+					t.Errorf("Expected IP %s, got %s", tt.ip, retrievedIP)
+				}
+			} else {
+				if retrievedIP != "" {
+					t.Errorf("Expected empty IP, but got %s", retrievedIP)
+				}
+			}
+		})
+	}
+}
+
+func TestGetIPFromContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip       string
+		expected string
+	}{
+		{
+			name:     "Valid IPv4",
+			ip:       "192.168.1.1",
+			expected: "192.168.1.1",
+		},
+		{
+			name:     "Valid IPv6",
+			ip:       "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+			expected: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+		},
+		{
+			name:     "Empty context",
+			ip:       "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ctx context.Context
+			if tt.ip != "" {
+				ctx = SetIPContext(context.Background(), tt.ip)
+			} else {
+				ctx = context.Background()
+			}
+
+			ip := GetIPFromContext(ctx)
+			if ip != tt.expected {
+				t.Errorf("Expected IP %q, got %q", tt.expected, ip)
+			}
+		})
+	}
+}
+
+func TestIPContextChaining(t *testing.T) {
+	// Test that context values are preserved when chaining
+	type testKey int
+	const testKeyOther testKey = 0
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, testKeyOther, "other_value")
+	ctx = SetIPContext(ctx, "192.168.1.1")
+
+	// Check IP is accessible
+	if GetIPFromContext(ctx) != "192.168.1.1" {
+		t.Error("IP context was not preserved")
+	}
+
+	// Check other values are accessible
+	if val := ctx.Value(testKeyOther); val != "other_value" {
+		t.Error("Other context values were not preserved")
+	}
+}


### PR DESCRIPTION
- Add context-safe setters and getters for user and client IP, replacing access via gin.Context with dedicated context keys
- Pass user and client IP into the standard context within middlewares for downstream access in service layers
- Update audit logging to extract ActorUserID from context if missing
- Provide strongly-typed context value storage to prevent collisions
- Add comprehensive tests for context user and IP helpers, covering normal, nil, and chaining scenarios