### PR TITLE
feat: add first-class documentation site with rendered Markdown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/redis/rueidis v1.0.72
 	github.com/redis/rueidis/rueidisaside v1.0.72
+	github.com/russross/blackfriday/v2 v2.1.0
 	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.1
@@ -257,7 +258,6 @@ require (
 	github.com/raeperd/recvcheck v0.2.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryancurrah/gomodguard v1.4.1 // indirect
 	github.com/ryanrolds/sqlclosecheck v0.5.1 // indirect
 	github.com/sanposhiho/wastedassign/v2 v2.1.0 // indirect

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -157,6 +157,7 @@ func (app *Application) initializeHTTPLayer() {
 		oauthProviders,
 		oauthHTTPClient,
 		app.MetricsRecorder,
+		app.TemplatesFS,
 	)
 
 	// Router

--- a/internal/bootstrap/handlers.go
+++ b/internal/bootstrap/handlers.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"embed"
 	"net/http"
 
 	"github.com/go-authgate/authgate/internal/auth"
@@ -21,6 +22,7 @@ type handlerSet struct {
 	audit         *handlers.AuditHandler
 	authorization *handlers.AuthorizationHandler
 	oidc          *handlers.OIDCHandler
+	docs          *handlers.DocsHandler
 	userService   *services.UserService
 }
 
@@ -36,6 +38,7 @@ func initializeHandlers(
 	oauthProviders map[string]*auth.OAuthProvider,
 	oauthHTTPClient *http.Client,
 	prometheusMetrics core.Recorder,
+	templatesFS embed.FS,
 ) handlerSet {
 	return handlerSet{
 		auth: handlers.NewAuthHandler(
@@ -66,6 +69,7 @@ func initializeHandlers(
 			cfg,
 		),
 		oidc:        handlers.NewOIDCHandler(tokenService, userService, cfg),
+		docs:        handlers.NewDocsHandler(templatesFS),
 		userService: userService,
 	}
 }

--- a/internal/bootstrap/router.go
+++ b/internal/bootstrap/router.go
@@ -127,6 +127,10 @@ func setupAllRoutes(
 		c.Redirect(http.StatusFound, "/account/sessions")
 	})
 
+	// Documentation routes (public)
+	r.GET("/docs", h.docs.ShowDocsIndex)
+	r.GET("/docs/:slug", h.docs.ShowDocsPage)
+
 	// Swagger documentation (development only)
 	if !cfg.IsProduction {
 		r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))

--- a/internal/handlers/docs.go
+++ b/internal/handlers/docs.go
@@ -1,0 +1,152 @@
+package handlers
+
+import (
+	"bytes"
+	"embed"
+	"net/http"
+	"regexp"
+
+	bf "github.com/russross/blackfriday/v2"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-authgate/authgate/internal/models"
+	"github.com/go-authgate/authgate/internal/templates"
+)
+
+// docsMeta defines the ordered list of documentation pages.
+var docsMeta = []struct {
+	Slug  string
+	Title string
+}{
+	{"getting-started", "Getting Started"},
+	{"device-flow", "Device Flow"},
+	{"auth-code-flow", "Auth Code Flow"},
+}
+
+// parsedDoc holds the pre-rendered HTML for a single documentation page.
+type parsedDoc struct {
+	Slug  string
+	Title string
+	HTML  string
+}
+
+// DocsHandler serves static documentation pages rendered from embedded Markdown.
+type DocsHandler struct {
+	pages   []parsedDoc
+	pageMap map[string]parsedDoc
+}
+
+// NewDocsHandler reads and pre-parses all Markdown documentation files at startup.
+func NewDocsHandler(templatesFS embed.FS) *DocsHandler {
+	h := &DocsHandler{
+		pageMap: make(map[string]parsedDoc, len(docsMeta)),
+	}
+
+	for _, meta := range docsMeta {
+		path := "internal/templates/docs/" + meta.Slug + ".md"
+
+		mdBytes, err := templatesFS.ReadFile(path)
+		if err != nil {
+			// Non-fatal: page will be missing from the map and sidebar
+			continue
+		}
+
+		htmlBytes := bf.Run(
+			mdBytes,
+			bf.WithExtensions(bf.CommonExtensions|bf.AutoHeadingIDs|bf.HardLineBreak),
+		)
+
+		doc := parsedDoc{
+			Slug:  meta.Slug,
+			Title: meta.Title,
+			HTML:  postProcessMermaid(htmlBytes),
+		}
+
+		h.pages = append(h.pages, doc)
+		h.pageMap[meta.Slug] = doc
+	}
+
+	return h
+}
+
+// ShowDocsIndex redirects to the first documentation page.
+func (h *DocsHandler) ShowDocsIndex(c *gin.Context) {
+	if len(h.pages) == 0 {
+		c.Redirect(http.StatusFound, "/")
+		return
+	}
+
+	c.Redirect(http.StatusFound, "/docs/"+h.pages[0].Slug)
+}
+
+// ShowDocsPage renders a single documentation page identified by :slug.
+func (h *DocsHandler) ShowDocsPage(c *gin.Context) {
+	slug := c.Param("slug")
+
+	doc, ok := h.pageMap[slug]
+	if !ok {
+		// Unknown slug → redirect to first page
+		if len(h.pages) > 0 {
+			c.Redirect(http.StatusFound, "/docs/"+h.pages[0].Slug)
+		} else {
+			c.Redirect(http.StatusFound, "/")
+		}
+		return
+	}
+
+	// Build sidebar entries, marking the active page
+	entries := make([]templates.DocsEntry, len(h.pages))
+	for i, p := range h.pages {
+		entries[i] = templates.DocsEntry{
+			Slug:     p.Slug,
+			Title:    p.Title,
+			IsActive: p.Slug == slug,
+		}
+	}
+
+	// Resolve optional navbar props from session
+	navbarProps := templates.NavbarProps{
+		ActiveLink: "docs",
+	}
+
+	if u, exists := c.Get("user"); exists {
+		if user, ok := u.(*models.User); ok {
+			navbarProps.Username = user.Username
+			navbarProps.IsAdmin = user.IsAdmin()
+		}
+	}
+
+	templates.RenderTempl(c, http.StatusOK, templates.DocsPage(templates.DocsPageProps{
+		NavbarProps: navbarProps,
+		Title:       doc.Title,
+		ContentHTML: doc.HTML,
+		Entries:     entries,
+	}))
+}
+
+// mermaidPattern matches <pre><code class="language-mermaid">…</code></pre> blocks
+// produced by blackfriday from fenced ```mermaid code blocks.
+var mermaidPattern = regexp.MustCompile(
+	`<pre><code class="language-mermaid">([\s\S]*?)</code></pre>`,
+)
+
+// postProcessMermaid converts blackfriday-rendered mermaid code fences into
+// <div class="mermaid"> elements that mermaid.js can pick up and render.
+func postProcessMermaid(html []byte) string {
+	replaced := mermaidPattern.ReplaceAllFunc(html, func(match []byte) []byte {
+		// Extract the inner content (everything between the <code> tags)
+		sub := mermaidPattern.FindSubmatch(match)
+		if len(sub) < 2 {
+			return match
+		}
+
+		inner := bytes.TrimSpace(sub[1])
+		var buf bytes.Buffer
+		buf.WriteString(`<div class="mermaid">`)
+		buf.Write(inner)
+		buf.WriteString(`</div>`)
+		return buf.Bytes()
+	})
+
+	return string(replaced)
+}

--- a/internal/templates/docs/auth-code-flow.md
+++ b/internal/templates/docs/auth-code-flow.md
@@ -1,0 +1,196 @@
+# Authorization Code Flow + PKCE
+
+The **Authorization Code Flow** (RFC 6749) with **PKCE** (Proof Key for Code Exchange, RFC 7636) is the recommended OAuth 2.0 flow for web applications, single-page apps (SPAs), and mobile apps.
+
+PKCE replaces the need for a client secret, making it safe for **public clients** where the secret cannot be kept confidential.
+
+## When to Use This Flow
+
+Use Authorization Code + PKCE when:
+
+- You are building a **web application** with a server-side backend
+- You are building a **single-page app** (React, Vue, Angular, etc.)
+- You are building a **mobile application**
+- You need users to see a **consent screen** before granting access
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant AuthGate
+    participant Browser
+
+    App->>App: (1) Generate code_verifier + code_challenge (PKCE)
+
+    App->>Browser: (2) Redirect to /oauth/authorize<br/>?code_challenge=...&client_id=...&state=...
+    Browser->>AuthGate: GET /oauth/authorize
+
+    AuthGate->>Browser: Show login page (if not logged in)
+    Browser->>AuthGate: Submit credentials
+
+    AuthGate->>Browser: Show consent screen (scopes)
+    Browser->>AuthGate: User approves
+
+    AuthGate->>Browser: (3) Redirect to redirect_uri?code=AUTH_CODE&state=...
+    Browser->>App: Callback with AUTH_CODE
+
+    App->>AuthGate: (4) POST /oauth/token (code + code_verifier)
+    AuthGate-->>App: (5) access_token + refresh_token
+```
+
+### Step 1: Generate PKCE Parameters
+
+Before redirecting, your app generates a cryptographically random `code_verifier` and derives a `code_challenge` from it:
+
+**Go**
+
+```go
+import (
+    "crypto/rand"
+    "crypto/sha256"
+    "encoding/base64"
+)
+
+// Generate code_verifier (32 random bytes → 43-char base64url string)
+buf := make([]byte, 32)
+_, _ = rand.Read(buf)
+codeVerifier := base64.RawURLEncoding.EncodeToString(buf)
+
+// Derive code_challenge = BASE64URL(SHA256(code_verifier))
+h := sha256.Sum256([]byte(codeVerifier))
+codeChallenge := base64.RawURLEncoding.EncodeToString(h[:])
+```
+
+**Python**
+
+```python
+import hashlib
+import base64
+import secrets
+
+# Generate code_verifier (32 random bytes → 43-char base64url string)
+code_verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+
+# Derive code_challenge = BASE64URL(SHA256(code_verifier))
+digest = hashlib.sha256(code_verifier.encode()).digest()
+code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+```
+
+**JavaScript (Node.js)**
+
+```javascript
+// Generate code_verifier (43-128 random chars)
+const codeVerifier = crypto.randomBytes(32).toString("base64url");
+
+// Derive code_challenge = BASE64URL(SHA256(code_verifier))
+const codeChallenge = crypto
+  .createHash("sha256")
+  .update(codeVerifier)
+  .digest("base64url");
+```
+
+Store the `code_verifier` securely (session or memory) — you'll need it in Step 4.
+
+### Step 2: Redirect to Authorization Endpoint
+
+Build the authorization URL and redirect the user:
+
+```
+GET /oauth/authorize
+  ?client_id=YOUR_CLIENT_ID
+  &redirect_uri=https://yourapp.com/callback
+  &response_type=code
+  &scope=openid profile email
+  &state=RANDOM_STATE
+  &code_challenge=CODE_CHALLENGE
+  &code_challenge_method=S256
+```
+
+> **Always include `state`** — a random value that you verify on callback to prevent CSRF attacks.
+
+The user will be prompted to log in (if not already) and then see a consent screen listing the requested scopes.
+
+### Step 3: Handle the Callback
+
+After approval, AuthGate redirects to your `redirect_uri` with an authorization code:
+
+```
+https://yourapp.com/callback?code=AUTH_CODE&state=RANDOM_STATE
+```
+
+Verify that `state` matches what you sent in Step 2.
+
+### Step 4: Exchange Code for Tokens
+
+Exchange the authorization code for tokens by including the `code_verifier`:
+
+```bash
+curl -X POST https://your-authgate/oauth/token \
+  -d "grant_type=authorization_code" \
+  -d "code=AUTH_CODE" \
+  -d "redirect_uri=https://yourapp.com/callback" \
+  -d "client_id=YOUR_CLIENT_ID" \
+  -d "code_verifier=CODE_VERIFIER"
+```
+
+Response:
+
+```json
+{
+  "access_token": "eyJhbG...",
+  "refresh_token": "def502...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "openid profile email"
+}
+```
+
+### Step 5: Refresh the Access Token
+
+When the access token expires, use the refresh token:
+
+```bash
+curl -X POST https://your-authgate/oauth/token \
+  -d "grant_type=refresh_token" \
+  -d "refresh_token=REFRESH_TOKEN" \
+  -d "client_id=YOUR_CLIENT_ID"
+```
+
+## Registering an Auth Code Client
+
+In the admin panel (**Admin → OAuth Clients → New**):
+
+1. Set **Client Type**:
+   - `public` — for SPAs and mobile apps using PKCE (no client secret)
+   - `confidential` — for server-side web apps that can store a secret
+2. Enable **Authorization Code Flow**
+3. Add your **Redirect URIs** (one per line)
+4. Note the generated `client_id`
+
+## Managing User Authorizations
+
+Users can review and revoke per-app access at **Account → Authorized Apps**.
+
+Admins can force re-authentication for all users of a client at **Admin → OAuth Clients → [client] → Revoke All**.
+
+## Security Considerations
+
+| Requirement           | Details                                             |
+| --------------------- | --------------------------------------------------- |
+| Always use PKCE       | Prevents authorization code interception            |
+| Validate `state`      | Prevents CSRF attacks                               |
+| Use HTTPS             | Required in production; prevents token leakage      |
+| Short-lived codes     | Authorization codes expire after a few minutes      |
+| Rotate refresh tokens | Set `ENABLE_TOKEN_ROTATION=true` for extra security |
+
+## Example Client
+
+See [github.com/go-authgate/oauth-cli](https://github.com/go-authgate/oauth-cli) for a working Go implementation of Authorization Code + PKCE.
+
+For a hybrid CLI that auto-detects the environment and uses Device Flow over SSH or Auth Code Flow locally, see [github.com/go-authgate/cli](https://github.com/go-authgate/cli).
+
+## Related
+
+- [Getting Started](./getting-started)
+- [Device Authorization Flow](./device-flow)

--- a/internal/templates/docs/device-flow.md
+++ b/internal/templates/docs/device-flow.md
@@ -1,0 +1,132 @@
+# Device Authorization Flow
+
+The **Device Authorization Grant** (RFC 8628) lets CLI tools, scripts, and headless environments authenticate users without requiring a browser on the device itself. Instead, the user visits a short URL on any device (phone, laptop, etc.) to complete authentication.
+
+## When to Use This Flow
+
+Use the Device Flow when:
+
+- You are building a **CLI tool** (e.g., `my-tool login`)
+- Your environment is **headless** (e.g., a remote server over SSH)
+- Opening a browser automatically is not possible or desirable
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant CLI
+    participant AuthGate
+    participant Browser
+
+    CLI->>AuthGate: POST /oauth/device/code (client_id)
+    AuthGate-->>CLI: device_code, user_code, verification_uri
+
+    note over CLI: Display verification_uri + user_code to user
+
+    loop Poll every 5s
+        CLI->>AuthGate: POST /oauth/token (device_code)
+        AuthGate-->>CLI: authorization_pending
+    end
+
+    Browser->>AuthGate: Visit verification_uri
+    Browser->>AuthGate: Enter user_code + approve
+
+    CLI->>AuthGate: POST /oauth/token (device_code)
+    AuthGate-->>CLI: access_token + refresh_token
+```
+
+### Step 1: Request a Device Code
+
+Your CLI calls `POST /oauth/device/code` with its `client_id`:
+
+```bash
+curl -X POST https://your-authgate/oauth/device/code \
+  -d "client_id=YOUR_CLIENT_ID"
+```
+
+Response:
+
+```json
+{
+  "device_code": "abc123...",
+  "user_code": "WXYZ-1234",
+  "verification_uri": "https://your-authgate/device",
+  "expires_in": 1800,
+  "interval": 5
+}
+```
+
+### Step 2: Display Instructions to the User
+
+Show the user where to go and what code to enter:
+
+```
+Open https://your-authgate/device in your browser.
+Enter code: WXYZ-1234
+Waiting for authorization...
+```
+
+### Step 3: Poll for the Token
+
+While the user completes the browser step, your CLI polls for the token:
+
+```bash
+curl -X POST https://your-authgate/oauth/token \
+  -d "grant_type=urn:ietf:params:oauth:grant-type:device_code" \
+  -d "device_code=abc123..." \
+  -d "client_id=YOUR_CLIENT_ID"
+```
+
+Possible responses while polling:
+
+| Response                | Meaning                                 |
+| ----------------------- | --------------------------------------- |
+| `authorization_pending` | User hasn't approved yet — keep polling |
+| `slow_down`             | Polling too fast — increase interval    |
+| `expired_token`         | Device code expired — restart flow      |
+| `access_denied`         | User rejected the request               |
+| `200 OK` + tokens       | Success!                                |
+
+### Step 4: Use and Refresh Tokens
+
+Once you receive an `access_token`, include it in API requests:
+
+```bash
+curl -H "Authorization: Bearer ACCESS_TOKEN" https://api.example.com/resource
+```
+
+When the access token expires, use the `refresh_token`:
+
+```bash
+curl -X POST https://your-authgate/oauth/token \
+  -d "grant_type=refresh_token" \
+  -d "refresh_token=REFRESH_TOKEN" \
+  -d "client_id=YOUR_CLIENT_ID"
+```
+
+## Registering a Device Flow Client
+
+In the admin panel (**Admin → OAuth Clients → New**):
+
+1. Set **Client Type** to `public` (no client secret required)
+2. Enable **Device Authorization Flow**
+3. Note the generated `client_id`
+
+## Token Expiry and Rotation
+
+| Setting                | Default    | Config                       |
+| ---------------------- | ---------- | ---------------------------- |
+| Access token lifetime  | 1 hour     | `JWT_EXPIRATION`             |
+| Device code lifetime   | 30 minutes | `DEVICE_CODE_EXPIRATION`     |
+| Refresh token rotation | Disabled   | `ENABLE_TOKEN_ROTATION=true` |
+
+> When token rotation is enabled, each refresh invalidates the old refresh token and issues a new one. This limits the blast radius of a stolen refresh token.
+
+## Example CLI Client
+
+See [github.com/go-authgate/device-cli](https://github.com/go-authgate/device-cli) for a working example in Go that implements the complete Device Flow.
+
+## Related
+
+- [Getting Started](./getting-started)
+- [Authorization Code Flow](./auth-code-flow)

--- a/internal/templates/docs/getting-started.md
+++ b/internal/templates/docs/getting-started.md
@@ -1,0 +1,83 @@
+# Getting Started with AuthGate
+
+AuthGate is an OAuth 2.0 authorization server that enables secure, passwordless authentication for CLI tools, IoT devices, web apps, and mobile applications — without embedding client secrets.
+
+## What is AuthGate?
+
+AuthGate implements two core OAuth 2.0 flows:
+
+- **Device Authorization Grant (RFC 8628)** — ideal for CLI tools, scripts, and headless environments where opening a browser programmatically is inconvenient or impossible.
+- **Authorization Code Flow + PKCE (RFC 7636)** — the recommended flow for web and mobile applications.
+
+## Quick Setup
+
+### 1. Start the Server
+
+```bash
+./authgate server
+```
+
+On first run, AuthGate seeds a default `admin` user and an `AuthGate CLI` OAuth client. The randomly generated password and client ID are printed to the server logs.
+
+### 2. Configure Your Client
+
+Log in to the admin panel and navigate to **Admin → OAuth Clients** to:
+
+- View the auto-generated `AuthGate CLI` client and its `client_id`
+- Create new clients for your applications
+- Choose between **Device Flow** and **Authorization Code Flow** per client
+
+### 3. Authenticate
+
+Depending on your use case, pick the appropriate flow:
+
+| Use Case           | Recommended Flow           |
+| ------------------ | -------------------------- |
+| CLI tool or script | Device Authorization Grant |
+| Web application    | Authorization Code + PKCE  |
+| Mobile application | Authorization Code + PKCE  |
+| Server-to-server   | Client Credentials         |
+
+## Core Concepts
+
+### OAuth Clients
+
+Every application that wants to authenticate via AuthGate needs a registered **OAuth Client**. Clients have:
+
+- A unique `client_id`
+- An optional `client_secret` (for confidential clients only)
+- Configured allowed redirect URIs
+- Enabled grant types (device flow, auth code flow, or both)
+
+### Tokens
+
+After a successful authentication, AuthGate issues:
+
+- **Access Token** — a short-lived JWT (default: 1 hour) used to access protected resources
+- **Refresh Token** — a longer-lived token used to obtain new access tokens without re-authentication
+
+### Scopes
+
+Scopes define the level of access a client is requesting. Users see a consent screen listing the requested scopes before approving access.
+
+## Configuration
+
+AuthGate is configured via environment variables. Copy `.env.example` to `.env` and set:
+
+```bash
+# Required
+JWT_SECRET=<generate with: openssl rand -hex 32>
+SESSION_SECRET=<generate with: openssl rand -hex 32>
+BASE_URL=https://your-domain.com
+
+# Database (default: SQLite)
+DATABASE_DRIVER=sqlite
+DATABASE_DSN=authgate.db
+```
+
+See the full configuration reference in `.env.example`.
+
+## Next Steps
+
+- [Device Authorization Flow](./device-flow) — Learn how CLI and headless clients authenticate
+- [Authorization Code Flow](./auth-code-flow) — Learn how web and mobile apps authenticate

--- a/internal/templates/docs_page.templ
+++ b/internal/templates/docs_page.templ
@@ -1,0 +1,96 @@
+package templates
+
+templ DocsPage(props DocsPageProps) {
+	@Layout("Docs - "+props.Title, LayoutHasNavbar, &props.NavbarProps) {
+		<link rel="stylesheet" href="/static/css/pages/docs.css"/>
+		<div class="docs-layout">
+			<aside class="docs-sidebar" aria-label="Documentation navigation">
+				<div class="docs-sidebar-header">
+					<span class="docs-sidebar-title">Documentation</span>
+				</div>
+				<nav class="docs-sidebar-nav">
+					for _, entry := range props.Entries {
+						<a
+							href={ templ.URL("/docs/" + entry.Slug) }
+							class={ templ.Classes("docs-sidebar-link", templ.KV("active", entry.IsActive)) }
+						>
+							{ entry.Title }
+						</a>
+					}
+				</nav>
+			</aside>
+			<article class="docs-content markdown-body" aria-label="Documentation content">
+				@templ.Raw(props.ContentHTML)
+			</article>
+		</div>
+		<!-- Syntax highlighting: Prism.js (manual mode so all grammars load before run) -->
+		<script>window.Prism = window.Prism || {}; Prism.manual = true;</script>
+		<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"></script>
+		<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-bash.min.js"></script>
+		<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-go.min.js"></script>
+		<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-python.min.js"></script>
+		<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-json.min.js"></script>
+		<script>Prism.highlightAll();</script>
+		<!-- Mermaid diagrams -->
+		<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+		<script>mermaid.initialize({ startOnLoad: true, theme: 'default' });</script>
+		<!-- Code block enhancements: language badge + copy button -->
+		<script>
+		(function () {
+			document.querySelectorAll('.markdown-body pre').forEach(function (pre) {
+				var code = pre.querySelector('code[class*="language-"]');
+				var match = code && code.className.match(/language-(\w+)/);
+				var lang = match ? match[1] : null;
+
+				// Wrap pre in a relative container so badge/button sit outside
+				// the pre's overflow-x scroll region
+				var wrapper = document.createElement('div');
+				wrapper.className = 'code-block';
+				pre.parentNode.insertBefore(wrapper, pre);
+				wrapper.appendChild(pre);
+
+				// Language badge (top-right, fades out on hover)
+				if (lang) {
+					var badge = document.createElement('span');
+					badge.className = 'code-lang-badge';
+					badge.textContent = lang;
+					wrapper.appendChild(badge);
+				}
+
+				// Copy button (top-right, fades in on hover)
+				var btn = document.createElement('button');
+				btn.className = 'code-copy-btn';
+				btn.setAttribute('aria-label', 'Copy code');
+				btn.textContent = 'copy';
+				wrapper.appendChild(btn);
+
+				btn.addEventListener('click', function () {
+					var text = code ? code.textContent : pre.textContent;
+
+					function onCopied() {
+						btn.textContent = 'copied!';
+						btn.classList.add('code-copy-btn--copied');
+						setTimeout(function () {
+							btn.textContent = 'copy';
+							btn.classList.remove('code-copy-btn--copied');
+						}, 2000);
+					}
+
+					if (navigator.clipboard) {
+						navigator.clipboard.writeText(text).then(onCopied);
+					} else {
+						var ta = document.createElement('textarea');
+						ta.value = text;
+						ta.style.cssText = 'position:fixed;opacity:0;pointer-events:none;';
+						document.body.appendChild(ta);
+						ta.select();
+						document.execCommand('copy');
+						document.body.removeChild(ta);
+						onCopied();
+					}
+				});
+			});
+		})();
+		</script>
+	}
+}

--- a/internal/templates/layout_component.templ
+++ b/internal/templates/layout_component.templ
@@ -57,7 +57,8 @@ templ Layout(title string, layoutType LayoutType, navbar *NavbarProps) {
 						<span class="footer-brand-desc">OAuth 2.0 Authorization Server</span>
 					</div>
 					<nav class="footer-links" aria-label="Footer navigation">
-						<a href="/swagger/index.html" class="footer-link" target="_blank" rel="noopener noreferrer">API Docs</a>
+						<a href="/docs/getting-started" class="footer-link">Docs</a>
+						<a href="/swagger/index.html" class="footer-link" target="_blank" rel="noopener noreferrer">API</a>
 						<a href="/health" class="footer-link">Health</a>
 					</nav>
 				</div>

--- a/internal/templates/navbar_component.templ
+++ b/internal/templates/navbar_component.templ
@@ -21,7 +21,12 @@ templ Navbar(props *NavbarProps) {
 							@NavDropdownItem("/account/sessions", "Active Sessions", props.ActiveLink == "sessions", false, false)
 							@NavDropdownItem("/account/authorizations", "Authorized Apps", props.ActiveLink == "authorizations", false, false)
 						}
-						@NavDropdown("API Docs", props.ActiveLink == "apidocs") {
+						@NavDropdown("Docs", props.ActiveLink == "docs") {
+							@NavDropdownItem("/docs/getting-started", "Getting Started", props.ActiveLink == "docs", false, false)
+							@NavDropdownItem("/docs/device-flow", "Device Flow", props.ActiveLink == "docs", false, false)
+							@NavDropdownItem("/docs/auth-code-flow", "Auth Code Flow", props.ActiveLink == "docs", false, false)
+						}
+						@NavDropdown("API", props.ActiveLink == "apidocs") {
 							@NavDropdownItem("/swagger/index.html", "Swagger UI", props.ActiveLink == "apidocs", false, true)
 						}
 						if props.IsAdmin {
@@ -38,7 +43,12 @@ templ Navbar(props *NavbarProps) {
 					</div>
 				} else {
 					<div class="navbar-links">
-						@NavDropdown("API Docs", props.ActiveLink == "apidocs") {
+						@NavDropdown("Docs", props.ActiveLink == "docs") {
+							@NavDropdownItem("/docs/getting-started", "Getting Started", props.ActiveLink == "docs", false, false)
+							@NavDropdownItem("/docs/device-flow", "Device Flow", props.ActiveLink == "docs", false, false)
+							@NavDropdownItem("/docs/auth-code-flow", "Auth Code Flow", props.ActiveLink == "docs", false, false)
+						}
+						@NavDropdown("API", props.ActiveLink == "apidocs") {
 							@NavDropdownItem("/swagger/index.html", "Swagger UI", props.ActiveLink == "apidocs", false, true)
 						}
 					</div>

--- a/internal/templates/props.go
+++ b/internal/templates/props.go
@@ -202,6 +202,21 @@ type ClientAuthorizationsPageProps struct {
 	Error          string
 }
 
+// DocsEntry represents a single entry in the docs sidebar navigation
+type DocsEntry struct {
+	Slug     string
+	Title    string
+	IsActive bool
+}
+
+// DocsPageProps contains properties for the docs page
+type DocsPageProps struct {
+	NavbarProps
+	Title       string
+	ContentHTML string
+	Entries     []DocsEntry
+}
+
 // AuditLogsPageProps contains properties for the audit logs page
 type AuditLogsPageProps struct {
 	BaseProps

--- a/internal/templates/static/css/pages/docs.css
+++ b/internal/templates/static/css/pages/docs.css
@@ -1,0 +1,556 @@
+/* ============================================
+   Docs Page — Technical Documentation Layout
+   AuthGate Design System
+   ============================================ */
+
+/* ── Layout ─────────────────────────────────── */
+
+.docs-layout {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  grid-template-rows: 1fr;
+  min-height: calc(100vh - var(--navbar-height, 56px) - var(--footer-height, 80px));
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--space-6);
+  gap: 0;
+  align-items: start;
+}
+
+/* ── Sidebar ─────────────────────────────────── */
+
+.docs-sidebar {
+  position: sticky;
+  top: calc(var(--navbar-height, 56px) + var(--space-8));
+  max-height: calc(100vh - var(--navbar-height, 56px) - var(--space-16));
+  overflow-y: auto;
+  padding: var(--space-8) var(--space-6) var(--space-8) 0;
+  border-right: 1px solid var(--color-border);
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-gray-300) transparent;
+}
+
+.docs-sidebar::-webkit-scrollbar {
+  width: 4px;
+}
+
+.docs-sidebar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.docs-sidebar::-webkit-scrollbar-thumb {
+  background: var(--color-gray-300);
+  border-radius: 2px;
+}
+
+.docs-sidebar-header {
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-3);
+}
+
+.docs-sidebar-title {
+  display: block;
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+}
+
+.docs-sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.docs-sidebar-link {
+  display: block;
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 400;
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  border-radius: 4px;
+  border-left: 2px solid transparent;
+  transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
+  line-height: 1.4;
+}
+
+.docs-sidebar-link:hover {
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-tertiary);
+  border-left-color: var(--color-gray-300);
+}
+
+.docs-sidebar-link.active {
+  color: var(--color-primary);
+  background-color: var(--color-primary-pale);
+  border-left-color: var(--color-primary);
+  font-weight: 500;
+}
+
+/* ── Content Area ────────────────────────────── */
+
+.docs-content {
+  padding: var(--space-8) 0 var(--space-16) var(--space-10);
+  min-width: 0; /* prevent grid blowout */
+}
+
+/* ── Markdown Body ───────────────────────────── */
+
+.markdown-body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: 1.7;
+  color: var(--color-text-primary);
+  max-width: 800px;
+}
+
+/* Headings */
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4 {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--color-text-primary);
+  margin-top: var(--space-10);
+  margin-bottom: var(--space-4);
+}
+
+.markdown-body h1:first-child,
+.markdown-body h2:first-child,
+.markdown-body h3:first-child {
+  margin-top: 0;
+}
+
+.markdown-body h1 {
+  font-size: var(--text-3xl);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--space-6);
+}
+
+.markdown-body h2 {
+  font-size: var(--text-2xl);
+}
+
+.markdown-body h3 {
+  font-size: var(--text-xl);
+}
+
+.markdown-body h4 {
+  font-size: var(--text-lg);
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+
+/* Paragraphs & Text */
+
+.markdown-body p {
+  margin-top: 0;
+  margin-bottom: var(--space-4);
+}
+
+.markdown-body strong {
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.markdown-body em {
+  font-style: italic;
+}
+
+/* Links */
+
+.markdown-body a {
+  color: var(--color-primary);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+
+.markdown-body a:hover {
+  color: var(--color-primary-dark);
+  border-bottom-color: var(--color-primary-dark);
+}
+
+/* Inline code */
+
+.markdown-body code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-gray-800);
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+/* Code blocks */
+
+/* Wrapper injected by JS — provides the positioning context for badge + copy
+   button so they sit outside the pre's overflow-x scroll area */
+.code-block {
+  position: relative;
+  margin: var(--space-6) 0;
+}
+
+.markdown-body pre {
+  background-color: #1e2030;
+  border-radius: 8px;
+  padding: var(--space-5) var(--space-6);
+  overflow-x: auto;
+  margin: 0; /* wrapper owns the margin */
+  box-shadow: var(--shadow-sm);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.markdown-body pre code {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  color: #cdd6f4; /* base color for unrecognized text nodes; Prism .token.* overrides */
+  background: none;
+  border: none;
+  padding: 0;
+  white-space: pre;
+  word-break: normal;
+}
+
+/* ── Language badge ──────────────────────────── */
+
+.code-lang-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 5px 10px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(205, 214, 244, 0.3);
+  pointer-events: none;
+  line-height: 1;
+  border-bottom-left-radius: 6px;
+  border-top-right-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  transition: opacity 0.15s ease;
+}
+
+/* Badge fades out when copy button becomes visible */
+.code-block:hover .code-lang-badge {
+  opacity: 0;
+}
+
+/* ── Copy button ─────────────────────────────── */
+
+.code-copy-btn {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  padding: 4px 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  color: rgba(205, 214, 244, 0.5);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 5px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease, background 0.15s ease,
+    border-color 0.15s ease;
+  line-height: 1.5;
+}
+
+.code-block:hover .code-copy-btn {
+  opacity: 1;
+}
+
+.code-copy-btn:hover {
+  color: #cdd6f4;
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.code-copy-btn--copied {
+  color: #a6e3a1 !important;
+  border-color: rgba(166, 227, 161, 0.3) !important;
+  background: rgba(166, 227, 161, 0.07) !important;
+}
+
+/* ── Prism token colors — Catppuccin Mocha ───── */
+
+.markdown-body .token.comment,
+.markdown-body .token.prolog,
+.markdown-body .token.doctype,
+.markdown-body .token.cdata {
+  color: #6c7086; /* overlay0 — muted */
+  font-style: italic;
+}
+
+.markdown-body .token.punctuation {
+  color: #cdd6f4; /* text */
+}
+
+.markdown-body .token.boolean,
+.markdown-body .token.number,
+.markdown-body .token.constant,
+.markdown-body .token.symbol,
+.markdown-body .token.deleted {
+  color: #fab387; /* peach */
+}
+
+.markdown-body .token.string,
+.markdown-body .token.char,
+.markdown-body .token.inserted {
+  color: #a6e3a1; /* green */
+}
+
+.markdown-body .token.attr-name,
+.markdown-body .token.selector {
+  color: #89dceb; /* sky */
+}
+
+.markdown-body .token.keyword,
+.markdown-body .token.atrule,
+.markdown-body .token.attr-value {
+  color: #cba6f7; /* mauve */
+}
+
+.markdown-body .token.operator,
+.markdown-body .token.entity,
+.markdown-body .token.url {
+  color: #89dceb; /* sky */
+}
+
+.markdown-body .token.function,
+.markdown-body .token.class-name,
+.markdown-body .token.tag {
+  color: #89b4fa; /* blue */
+}
+
+.markdown-body .token.property {
+  color: #89b4fa; /* blue */
+}
+
+.markdown-body .token.regex,
+.markdown-body .token.variable,
+.markdown-body .token.builtin {
+  color: #f9e2af; /* yellow */
+}
+
+.markdown-body .token.important {
+  color: #f38ba8; /* red */
+  font-weight: bold;
+}
+
+.markdown-body .token.bold {
+  font-weight: bold;
+}
+
+.markdown-body .token.italic {
+  font-style: italic;
+}
+
+.markdown-body .token.namespace {
+  opacity: 0.75;
+}
+
+/* Blockquotes */
+
+.markdown-body blockquote {
+  margin: var(--space-6) 0;
+  padding: var(--space-4) var(--space-6);
+  background-color: var(--color-bg-secondary);
+  border-left: 3px solid var(--color-primary);
+  border-radius: 0 6px 6px 0;
+  color: var(--color-text-secondary);
+}
+
+.markdown-body blockquote p {
+  margin-bottom: 0;
+}
+
+.markdown-body blockquote p:not(:last-child) {
+  margin-bottom: var(--space-2);
+}
+
+/* Tables */
+
+.markdown-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: var(--space-6) 0;
+  font-size: var(--text-sm);
+  border-radius: 6px;
+  overflow: hidden;
+  box-shadow: var(--shadow-xs);
+  border: 1px solid var(--color-border);
+}
+
+.markdown-body thead {
+  position: sticky;
+  top: 0;
+}
+
+.markdown-body th {
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+  font-weight: 600;
+  font-size: var(--text-xs);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.markdown-body td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  vertical-align: top;
+  color: var(--color-text-primary);
+}
+
+.markdown-body tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.markdown-body tbody tr:nth-child(even) {
+  background-color: var(--color-gray-50);
+}
+
+.markdown-body tbody tr:hover {
+  background-color: var(--color-primary-pale);
+  transition: background-color 0.1s ease;
+}
+
+/* Lists */
+
+.markdown-body ul,
+.markdown-body ol {
+  padding-left: var(--space-6);
+  margin: 0 0 var(--space-4) 0;
+}
+
+.markdown-body ul {
+  list-style-type: disc;
+}
+
+.markdown-body ol {
+  list-style-type: decimal;
+}
+
+.markdown-body li {
+  margin-bottom: var(--space-2);
+  line-height: 1.7;
+}
+
+.markdown-body li > ul,
+.markdown-body li > ol {
+  margin-top: var(--space-2);
+  margin-bottom: 0;
+}
+
+/* Horizontal Rule */
+
+.markdown-body hr {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: var(--space-10) 0;
+}
+
+/* Images */
+
+.markdown-body img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 6px;
+  box-shadow: var(--shadow-md);
+  margin: var(--space-4) 0;
+}
+
+/* Mermaid Diagrams */
+
+.markdown-body .mermaid {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-6);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  margin: var(--space-6) 0;
+  overflow-x: auto;
+}
+
+/* ── Responsive ──────────────────────────────── */
+
+@media (max-width: 768px) {
+  .docs-layout {
+    grid-template-columns: 1fr;
+    padding: 0 var(--space-4);
+  }
+
+  .docs-sidebar {
+    position: static;
+    max-height: none;
+    padding: var(--space-6) 0 var(--space-4);
+    border-right: none;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .docs-sidebar-nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .docs-sidebar-link {
+    border-left: none;
+    border-bottom: 2px solid transparent;
+    border-radius: 4px;
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .docs-sidebar-link.active {
+    border-left-color: transparent;
+    border-bottom-color: var(--color-primary);
+  }
+
+  .docs-content {
+    padding: var(--space-6) 0 var(--space-10);
+  }
+
+  .markdown-body {
+    font-size: var(--text-sm);
+  }
+
+  .markdown-body h1 {
+    font-size: var(--text-2xl);
+  }
+
+  .markdown-body h2 {
+    font-size: var(--text-xl);
+  }
+
+  .markdown-body pre {
+    font-size: var(--text-xs);
+    padding: var(--space-4);
+  }
+
+  .markdown-body table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}


### PR DESCRIPTION
- Add a first-class documentation section rendered from embedded Markdown and served under public docs routes.
- Introduce a docs handler that pre-renders Markdown to HTML at startup, including Mermaid diagram support.
- Add Getting Started, Device Flow, and Auth Code Flow documentation pages with structured navigation.
- Integrate docs into the router, navbar, and footer, replacing the previous API Docs-only entry.
- Add a dedicated docs page template with sidebar navigation, syntax highlighting, Mermaid rendering, and copyable code blocks.
- Include a comprehensive docs-specific stylesheet for layout, markdown styling, and responsive behavior.
- Promote the Markdown renderer dependency to a direct module requirement.