### PR TITLE
refactor: refactor dependency wiring with unified service sets

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -33,12 +33,8 @@ type Application struct {
 	RateLimitRedisClient *redis.Client
 
 	// Services
-	AuditService         *services.AuditService
-	UserService          *services.UserService
-	DeviceService        *services.DeviceService
-	TokenService         *services.TokenService
-	ClientService        *services.ClientService
-	AuthorizationService *services.AuthorizationService
+	AuditService *services.AuditService
+	Services     serviceSet
 
 	// HTTP
 	HandlerSet  handlerSet
@@ -125,11 +121,7 @@ func (app *Application) initializeBusinessLayer() {
 	)
 
 	// Initialize all business services
-	app.UserService,
-		app.DeviceService,
-		app.TokenService,
-		app.ClientService,
-		app.AuthorizationService = initializeServices(
+	app.Services = initializeServices(
 		app.Config,
 		app.DB,
 		app.AuditService,
@@ -146,19 +138,15 @@ func (app *Application) initializeHTTPLayer() {
 	oauthHTTPClient := createOAuthHTTPClient(app.Config)
 
 	// Handlers
-	app.HandlerSet = initializeHandlers(
-		app.Config,
-		app.UserService,
-		app.DeviceService,
-		app.TokenService,
-		app.ClientService,
-		app.AuthorizationService,
-		app.AuditService,
-		oauthProviders,
-		oauthHTTPClient,
-		app.MetricsRecorder,
-		app.TemplatesFS,
-	)
+	app.HandlerSet = initializeHandlers(handlerDeps{
+		cfg:            app.Config,
+		services:       app.Services,
+		auditService:   app.AuditService,
+		oauthProviders: oauthProviders,
+		oauthClient:    oauthHTTPClient,
+		metrics:        app.MetricsRecorder,
+		templatesFS:    app.TemplatesFS,
+	})
 
 	// Router
 	app.Router = setupRouter(
@@ -169,6 +157,7 @@ func (app *Application) initializeHTTPLayer() {
 		app.AuditService,
 		app.RateLimitRedisClient,
 		app.TemplatesFS,
+		oauthProviders,
 	)
 
 	// HTTP Server

--- a/internal/bootstrap/handlers.go
+++ b/internal/bootstrap/handlers.go
@@ -26,50 +26,58 @@ type handlerSet struct {
 	userService   *services.UserService
 }
 
+// handlerDeps holds all dependencies needed to construct the handler set
+type handlerDeps struct {
+	cfg            *config.Config
+	services       serviceSet
+	auditService   *services.AuditService
+	oauthProviders map[string]*auth.OAuthProvider
+	oauthClient    *http.Client
+	metrics        core.Recorder
+	templatesFS    embed.FS
+}
+
 // initializeHandlers creates all HTTP handlers
-func initializeHandlers(
-	cfg *config.Config,
-	userService *services.UserService,
-	deviceService *services.DeviceService,
-	tokenService *services.TokenService,
-	clientService *services.ClientService,
-	authorizationService *services.AuthorizationService,
-	auditService *services.AuditService,
-	oauthProviders map[string]*auth.OAuthProvider,
-	oauthHTTPClient *http.Client,
-	prometheusMetrics core.Recorder,
-	templatesFS embed.FS,
-) handlerSet {
+func initializeHandlers(deps handlerDeps) handlerSet {
 	return handlerSet{
 		auth: handlers.NewAuthHandler(
-			userService,
-			cfg.BaseURL,
-			cfg.SessionFingerprint,
-			cfg.SessionFingerprintIP,
-			prometheusMetrics,
+			deps.services.user,
+			deps.cfg.BaseURL,
+			deps.cfg.SessionFingerprint,
+			deps.cfg.SessionFingerprintIP,
+			deps.metrics,
 		),
-		device:  handlers.NewDeviceHandler(deviceService, userService, authorizationService, cfg),
-		token:   handlers.NewTokenHandler(tokenService, authorizationService, cfg),
-		client:  handlers.NewClientHandler(clientService, authorizationService),
-		session: handlers.NewSessionHandler(tokenService, userService),
+		device: handlers.NewDeviceHandler(
+			deps.services.device,
+			deps.services.user,
+			deps.services.authorization,
+			deps.cfg,
+		),
+		token: handlers.NewTokenHandler(
+			deps.services.token,
+			deps.services.authorization,
+			deps.cfg,
+		),
+		client:  handlers.NewClientHandler(deps.services.client, deps.services.authorization),
+		session: handlers.NewSessionHandler(deps.services.token, deps.services.user),
 		oauth: handlers.NewOAuthHandler(
-			oauthProviders,
-			userService,
-			oauthHTTPClient,
-			cfg.BaseURL,
-			cfg.SessionFingerprint,
-			cfg.SessionFingerprintIP,
-			prometheusMetrics,
+			deps.oauthProviders,
+			deps.services.user,
+			deps.oauthClient,
+			deps.cfg.BaseURL,
+			deps.cfg.SessionFingerprint,
+			deps.cfg.SessionFingerprintIP,
+			deps.metrics,
 		),
-		audit: handlers.NewAuditHandler(auditService),
+		audit: handlers.NewAuditHandler(deps.auditService),
 		authorization: handlers.NewAuthorizationHandler(
-			authorizationService,
-			tokenService,
-			userService,
-			cfg,
+			deps.services.authorization,
+			deps.services.token,
+			deps.services.user,
+			deps.cfg,
 		),
-		oidc:        handlers.NewOIDCHandler(tokenService, userService, cfg),
-		docs:        handlers.NewDocsHandler(templatesFS),
-		userService: userService,
+		oidc:        handlers.NewOIDCHandler(deps.services.token, deps.services.user, deps.cfg),
+		docs:        handlers.NewDocsHandler(deps.templatesFS),
+		userService: deps.services.user,
 	}
 }

--- a/internal/bootstrap/router.go
+++ b/internal/bootstrap/router.go
@@ -33,6 +33,7 @@ func setupRouter(
 	auditService *services.AuditService,
 	rateLimitRedisClient *redis.Client,
 	templatesFS embed.FS,
+	oauthProviders map[string]*auth.OAuthProvider,
 ) *gin.Engine {
 	// Setup Gin mode
 	setupGinMode(cfg)
@@ -62,7 +63,7 @@ func setupRouter(
 	rateLimiters := setupRateLimiting(cfg, auditService, rateLimitRedisClient)
 
 	// Setup all routes
-	setupAllRoutes(r, cfg, h, rateLimiters)
+	setupAllRoutes(r, cfg, h, rateLimiters, oauthProviders)
 
 	// Log server startup info
 	logServerStartup(cfg)
@@ -118,10 +119,8 @@ func setupAllRoutes(
 	cfg *config.Config,
 	h handlerSet,
 	rateLimiters rateLimitMiddlewares,
+	oauthProviders map[string]*auth.OAuthProvider,
 ) {
-	// Get OAuth providers
-	oauthProviders := initializeOAuthProviders(cfg)
-
 	// Public routes
 	r.GET("/", func(c *gin.Context) {
 		c.Redirect(http.StatusFound, "/account/sessions")

--- a/internal/bootstrap/services.go
+++ b/internal/bootstrap/services.go
@@ -9,6 +9,15 @@ import (
 	"github.com/go-authgate/authgate/internal/store"
 )
 
+// serviceSet holds all initialized business logic services
+type serviceSet struct {
+	user          *services.UserService
+	device        *services.DeviceService
+	token         *services.TokenService
+	client        *services.ClientService
+	authorization *services.AuthorizationService
+}
+
 // initializeServices creates all business logic services
 func initializeServices(
 	cfg *config.Config,
@@ -16,7 +25,7 @@ func initializeServices(
 	auditService *services.AuditService,
 	prometheusMetrics core.Recorder,
 	userCache core.Cache[models.User],
-) (*services.UserService, *services.DeviceService, *services.TokenService, *services.ClientService, *services.AuthorizationService) {
+) serviceSet {
 	// Initialize authentication providers
 	localProvider := auth.NewLocalAuthProvider(db)
 	httpAPIProvider := initializeHTTPAPIAuthProvider(cfg)
@@ -47,5 +56,11 @@ func initializeServices(
 	clientService := services.NewClientService(db, auditService)
 	authorizationService := services.NewAuthorizationService(db, cfg, auditService)
 
-	return userService, deviceService, tokenService, clientService, authorizationService
+	return serviceSet{
+		user:          userService,
+		device:        deviceService,
+		token:         tokenService,
+		client:        clientService,
+		authorization: authorizationService,
+	}
 }


### PR DESCRIPTION
- Refactor application bootstrap to group business services into a single serviceSet instead of separate fields
- Simplify handler initialization by introducing a handlerDeps struct to pass dependencies as a cohesive unit
- Update handler construction to consume the new serviceSet and dependency struct throughout
- Change service initialization to return a structured serviceSet rather than multiple values
- Move OAuth provider initialization out of route setup and pass providers explicitly through router and handler layers