### PR TITLE
docs(oauth): document Client Credentials OAuth flow

### DIFF
--- a/internal/handlers/docs.go
+++ b/internal/handlers/docs.go
@@ -21,6 +21,7 @@ var docsMeta = []struct {
 	{"getting-started", "Getting Started"},
 	{"device-flow", "Device Flow"},
 	{"auth-code-flow", "Auth Code Flow"},
+	{"client-credentials", "Client Credentials"},
 }
 
 // parsedDoc holds the pre-rendered HTML for a single documentation page.

--- a/internal/templates/docs/auth-code-flow.md
+++ b/internal/templates/docs/auth-code-flow.md
@@ -194,3 +194,4 @@ For a hybrid CLI that auto-detects the environment and uses Device Flow over SSH
 
 - [Getting Started](./getting-started)
 - [Device Authorization Flow](./device-flow)
+- [Client Credentials Flow](./client-credentials)

--- a/internal/templates/docs/client-credentials.md
+++ b/internal/templates/docs/client-credentials.md
@@ -1,0 +1,120 @@
+# Client Credentials Flow
+
+The **Client Credentials Grant** (RFC 6749 §4.4) is designed for machine-to-machine (M2M) authentication. No user is involved — the service authenticates as itself using a `client_id` and `client_secret`.
+
+## When to Use This Flow
+
+Use Client Credentials when:
+
+- You are building a **microservice, daemon, or CI/CD pipeline** that calls a protected API
+- There is **no user** involved (pure service-to-service identity)
+- The service can **securely store a `client_secret`** (server-side only — never in a browser or mobile app)
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant Svc as Service / Daemon
+    participant AuthGate as AuthGate
+    participant API as Protected API
+
+    Svc->>AuthGate: POST /oauth/token<br/>grant_type=client_credentials<br/>Authorization: Basic base64(id:secret)
+    AuthGate-->>Svc: {"access_token": "eyJ...", "expires_in": 3600}
+
+    note over Svc: Cache token until expires_in - 30s
+
+    Svc->>API: GET /resource<br/>Authorization: Bearer eyJ...
+    API->>AuthGate: GET /oauth/tokeninfo<br/>Authorization: Bearer eyJ...
+    AuthGate-->>API: {"active": true, "subject_type": "client", ...}
+    API-->>Svc: 200 OK
+
+    note over Svc: Token expires — request a new one (no refresh token)
+```
+
+### Step 1: Request an Access Token
+
+Authenticate with HTTP Basic Auth using your `client_id` and `client_secret`:
+
+```bash
+curl -X POST https://your-authgate/oauth/token \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -d "grant_type=client_credentials" \
+  -d "scope=read"
+```
+
+Response:
+
+```json
+{
+  "access_token": "eyJhbG...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "read"
+}
+```
+
+> No `refresh_token` is issued per RFC 6749 §4.4.3.
+
+### Step 2: Use the Token
+
+Include the access token as a Bearer header on every API request:
+
+```bash
+curl -H "Authorization: Bearer ACCESS_TOKEN" https://api.example.com/resource
+```
+
+Resource servers can verify tokens using the tokeninfo endpoint:
+
+```bash
+curl -H "Authorization: Bearer ACCESS_TOKEN" https://your-authgate/oauth/tokeninfo
+```
+
+The response includes `"subject_type": "client"` to distinguish M2M tokens from user-delegated tokens.
+
+### Step 3: Token Expires — Request a New One
+
+When the token expires, simply repeat Step 1. There is no refresh token to manage.
+
+Cache the token in memory and re-fetch it when it nears expiry (subtract ~30 seconds as a safety buffer):
+
+```
+if time.Now().Add(30 * time.Second).After(expiresAt) {
+    token = requestNewToken()
+}
+```
+
+## Registering a Client Credentials Client
+
+In the admin panel (**Admin → OAuth Clients → New**):
+
+1. Set **Client Type** to `confidential` (public clients cannot use this flow)
+2. Enable **Client Credentials Flow (RFC 6749 §4.4)**
+3. Add the **Scopes** the service may request (space-separated)
+4. Leave **Redirect URIs** empty — not required for this flow
+5. Note the generated `client_id` and store the `client_secret` in a secrets manager
+
+To rotate the secret later: **Admin → OAuth Clients → [client] → Regenerate Secret**
+
+## Token Lifecycle
+
+| Setting               | Default | Config                                |
+| --------------------- | ------- | ------------------------------------- |
+| Access token lifetime | 1 hour  | `CLIENT_CREDENTIALS_TOKEN_EXPIRATION` |
+| Refresh token         | None    | Not issued for this grant type        |
+
+## Security Considerations
+
+| Requirement            | Details                                                                                        |
+| ---------------------- | ---------------------------------------------------------------------------------------------- |
+| Store secrets securely | Use environment variables or a secrets manager; never commit `client_secret` to source control |
+| Use HTTPS              | The `client_secret` is sent on every token request; TLS is required in production              |
+| Keep TTL short         | Consider reducing `CLIENT_CREDENTIALS_TOKEN_EXPIRATION` (e.g. `15m`) for sensitive services    |
+| Restrict scopes        | Register only the scopes each service actually needs                                           |
+| One client per service | Separate clients enable independent revocation and per-service scope control                   |
+| Monitor audit logs     | Filter by `CLIENT_CREDENTIALS_TOKEN_ISSUED` to detect unexpected issuance                      |
+
+## Related
+
+- [Getting Started](./getting-started)
+- [Device Authorization Flow](./device-flow)
+- [Authorization Code Flow](./auth-code-flow)

--- a/internal/templates/docs/device-flow.md
+++ b/internal/templates/docs/device-flow.md
@@ -130,3 +130,4 @@ See [github.com/go-authgate/device-cli](https://github.com/go-authgate/device-cl
 
 - [Getting Started](./getting-started)
 - [Authorization Code Flow](./auth-code-flow)
+- [Client Credentials Flow](./client-credentials)

--- a/internal/templates/docs/getting-started.md
+++ b/internal/templates/docs/getting-started.md
@@ -4,10 +4,11 @@ AuthGate is an OAuth 2.0 authorization server that enables secure, passwordless 
 
 ## What is AuthGate?
 
-AuthGate implements two core OAuth 2.0 flows:
+AuthGate implements three core OAuth 2.0 flows:
 
 - **Device Authorization Grant (RFC 8628)** — ideal for CLI tools, scripts, and headless environments where opening a browser programmatically is inconvenient or impossible.
 - **Authorization Code Flow + PKCE (RFC 7636)** — the recommended flow for web and mobile applications.
+- **Client Credentials Grant (RFC 6749 §4.4)** — for machine-to-machine (M2M) authentication where no user is involved.
 
 ## Quick Setup
 
@@ -47,7 +48,7 @@ Every application that wants to authenticate via AuthGate needs a registered **O
 - A unique `client_id`
 - An optional `client_secret` (for confidential clients only)
 - Configured allowed redirect URIs
-- Enabled grant types (device flow, auth code flow, or both)
+- Enabled grant types (device flow, auth code flow, client credentials, or a combination)
 
 ### Tokens
 
@@ -81,3 +82,4 @@ See the full configuration reference in `.env.example`.
 
 - [Device Authorization Flow](./device-flow) — Learn how CLI and headless clients authenticate
 - [Authorization Code Flow](./auth-code-flow) — Learn how web and mobile apps authenticate
+- [Client Credentials Flow](./client-credentials) — Learn how services authenticate without a user

--- a/internal/templates/navbar_component.templ
+++ b/internal/templates/navbar_component.templ
@@ -24,10 +24,11 @@ templ Navbar(props *NavbarProps) {
 							@NavDropdownItem("/account/authorizations", "Authorized Apps", props.ActiveLink == "authorizations", false, false)
 							@NavDropdownItem("/apps", "My Apps", props.ActiveLink == "my-apps", false, false)
 						}
-						@NavDropdown("Docs", props.ActiveLink == "docs-getting-started" || props.ActiveLink == "docs-device-flow" || props.ActiveLink == "docs-auth-code-flow") {
+						@NavDropdown("Docs", props.ActiveLink == "docs-getting-started" || props.ActiveLink == "docs-device-flow" || props.ActiveLink == "docs-auth-code-flow" || props.ActiveLink == "docs-client-credentials") {
 							@NavDropdownItem("/docs/getting-started", "Getting Started", props.ActiveLink == "docs-getting-started", false, false)
 							@NavDropdownItem("/docs/device-flow", "Device Flow", props.ActiveLink == "docs-device-flow", false, false)
 							@NavDropdownItem("/docs/auth-code-flow", "Auth Code Flow", props.ActiveLink == "docs-auth-code-flow", false, false)
+							@NavDropdownItem("/docs/client-credentials", "Client Credentials", props.ActiveLink == "docs-client-credentials", false, false)
 						}
 						@NavDropdown("API", props.ActiveLink == "apidocs") {
 							@NavDropdownItem("/swagger/index.html", "Swagger UI", props.ActiveLink == "apidocs", false, true)
@@ -46,10 +47,11 @@ templ Navbar(props *NavbarProps) {
 					</div>
 				} else {
 					<div class="navbar-links">
-						@NavDropdown("Docs", props.ActiveLink == "docs-getting-started" || props.ActiveLink == "docs-device-flow" || props.ActiveLink == "docs-auth-code-flow") {
+						@NavDropdown("Docs", props.ActiveLink == "docs-getting-started" || props.ActiveLink == "docs-device-flow" || props.ActiveLink == "docs-auth-code-flow" || props.ActiveLink == "docs-client-credentials") {
 							@NavDropdownItem("/docs/getting-started", "Getting Started", props.ActiveLink == "docs-getting-started", false, false)
 							@NavDropdownItem("/docs/device-flow", "Device Flow", props.ActiveLink == "docs-device-flow", false, false)
 							@NavDropdownItem("/docs/auth-code-flow", "Auth Code Flow", props.ActiveLink == "docs-auth-code-flow", false, false)
+							@NavDropdownItem("/docs/client-credentials", "Client Credentials", props.ActiveLink == "docs-client-credentials", false, false)
 						}
 						@NavDropdown("API", props.ActiveLink == "apidocs") {
 							@NavDropdownItem("/swagger/index.html", "Swagger UI", props.ActiveLink == "apidocs", false, true)


### PR DESCRIPTION
- Add a new Client Credentials documentation page describing machine-to-machine OAuth flow usage
- Include Client Credentials in the docs metadata and navigation dropdown
- Update Getting Started to list Client Credentials as a core supported OAuth flow
- Add cross-links to the new flow from existing docs pages
- Adjust enabled grant type descriptions to include client credentials