### PR TITLE
refactor(cache): extract shared redis base and fetch-through helper

### DIFF
--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -123,14 +123,5 @@ func (m *MemoryCache[T]) GetWithFetch(
 	ttl time.Duration,
 	fetchFunc func(ctx context.Context, key string) (T, error),
 ) (T, error) {
-	if value, err := m.Get(ctx, key); err == nil {
-		return value, nil
-	}
-	value, err := fetchFunc(ctx, key)
-	if err != nil {
-		var zero T
-		return zero, err
-	}
-	_ = m.Set(ctx, key, value, ttl)
-	return value, nil
+	return fetchThrough(ctx, key, ttl, m.Get, m.Set, fetchFunc)
 }

--- a/internal/cache/redis_base.go
+++ b/internal/cache/redis_base.go
@@ -1,0 +1,92 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/redis/rueidis"
+)
+
+// redisBase provides shared Set, MSet, Delete, Health, and Close
+// implementations for Redis-backed caches.
+type redisBase[T any] struct {
+	client    rueidis.Client
+	keyPrefix string
+	closeFunc func()
+}
+
+// Set stores a value in Redis with TTL.
+func (r *redisBase[T]) Set(ctx context.Context, key string, value T, ttl time.Duration) error {
+	encoded, err := marshalValue(value)
+	if err != nil {
+		return err
+	}
+
+	cmd := r.client.B().Set().
+		Key(prefixedKey(r.keyPrefix, key)).
+		Value(encoded).
+		Ex(ttl).
+		Build()
+
+	if err := r.client.Do(ctx, cmd).Error(); err != nil {
+		return fmt.Errorf("%w: %v", ErrCacheUnavailable, err)
+	}
+
+	return nil
+}
+
+// MSet stores multiple values in Redis with TTL.
+func (r *redisBase[T]) MSet(ctx context.Context, values map[string]T, ttl time.Duration) error {
+	if len(values) == 0 {
+		return nil
+	}
+
+	cmds := make(rueidis.Commands, 0, len(values))
+	for key, value := range values {
+		encoded, err := marshalValue(value)
+		if err != nil {
+			return err
+		}
+
+		cmd := r.client.B().Set().
+			Key(prefixedKey(r.keyPrefix, key)).
+			Value(encoded).
+			Ex(ttl).
+			Build()
+		cmds = append(cmds, cmd)
+	}
+
+	for _, resp := range r.client.DoMulti(ctx, cmds...) {
+		if err := resp.Error(); err != nil {
+			return fmt.Errorf("%w: %v", ErrCacheUnavailable, err)
+		}
+	}
+
+	return nil
+}
+
+// Delete removes a key from Redis.
+func (r *redisBase[T]) Delete(ctx context.Context, key string) error {
+	cmd := r.client.B().Del().Key(prefixedKey(r.keyPrefix, key)).Build()
+	if err := r.client.Do(ctx, cmd).Error(); err != nil {
+		return fmt.Errorf("%w: %v", ErrCacheUnavailable, err)
+	}
+
+	return nil
+}
+
+// Close closes the Redis connection.
+func (r *redisBase[T]) Close() error {
+	r.closeFunc()
+	return nil
+}
+
+// Health checks if Redis is reachable.
+func (r *redisBase[T]) Health(ctx context.Context) error {
+	cmd := r.client.B().Ping().Build()
+	if err := r.client.Do(ctx, cmd).Error(); err != nil {
+		return fmt.Errorf("%w: %v", ErrCacheUnavailable, err)
+	}
+	return nil
+}

--- a/internal/cache/rueidis.go
+++ b/internal/cache/rueidis.go
@@ -16,8 +16,7 @@ var _ core.Cache[struct{}] = (*RueidisCache[struct{}])(nil)
 // RueidisCache implements Cache interface using Redis via rueidis client.
 // Suitable for multi-instance deployments where cache needs to be shared.
 type RueidisCache[T any] struct {
-	client    rueidis.Client
-	keyPrefix string
+	redisBase[T]
 }
 
 // NewRueidisCache creates a new Redis cache instance using rueidis.
@@ -44,8 +43,11 @@ func NewRueidisCache[T any](
 	}
 
 	return &RueidisCache[T]{
-		client:    client,
-		keyPrefix: keyPrefix,
+		redisBase: redisBase[T]{
+			client:    client,
+			keyPrefix: keyPrefix,
+			closeFunc: client.Close,
+		},
 	}, nil
 }
 
@@ -71,26 +73,6 @@ func (r *RueidisCache[T]) Get(ctx context.Context, key string) (T, error) {
 	return unmarshalValue[T](str)
 }
 
-// Set stores a value in Redis with TTL.
-func (r *RueidisCache[T]) Set(ctx context.Context, key string, value T, ttl time.Duration) error {
-	encoded, err := marshalValue(value)
-	if err != nil {
-		return err
-	}
-
-	cmd := r.client.B().Set().
-		Key(prefixedKey(r.keyPrefix, key)).
-		Value(encoded).
-		Ex(ttl).
-		Build()
-
-	if err := r.client.Do(ctx, cmd).Error(); err != nil {
-		return fmt.Errorf("%w: %v", ErrCacheUnavailable, err)
-	}
-
-	return nil
-}
-
 // MGet retrieves multiple values from Redis.
 func (r *RueidisCache[T]) MGet(ctx context.Context, keys []string) (map[string]T, error) {
 	if len(keys) == 0 {
@@ -112,62 +94,6 @@ func (r *RueidisCache[T]) MGet(ctx context.Context, keys []string) (map[string]T
 	return parseMultiGetResponse[T](keys, values), nil
 }
 
-// MSet stores multiple values in Redis with TTL.
-func (r *RueidisCache[T]) MSet(ctx context.Context, values map[string]T, ttl time.Duration) error {
-	if len(values) == 0 {
-		return nil
-	}
-
-	// Use pipeline for multiple SET commands
-	cmds := make(rueidis.Commands, 0, len(values))
-	for key, value := range values {
-		encoded, err := marshalValue(value)
-		if err != nil {
-			return err
-		}
-
-		cmd := r.client.B().Set().
-			Key(prefixedKey(r.keyPrefix, key)).
-			Value(encoded).
-			Ex(ttl).
-			Build()
-		cmds = append(cmds, cmd)
-	}
-
-	for _, resp := range r.client.DoMulti(ctx, cmds...) {
-		if err := resp.Error(); err != nil {
-			return fmt.Errorf("%w: %v", ErrCacheUnavailable, err)
-		}
-	}
-
-	return nil
-}
-
-// Delete removes a key from Redis.
-func (r *RueidisCache[T]) Delete(ctx context.Context, key string) error {
-	cmd := r.client.B().Del().Key(prefixedKey(r.keyPrefix, key)).Build()
-	if err := r.client.Do(ctx, cmd).Error(); err != nil {
-		return fmt.Errorf("%w: %v", ErrCacheUnavailable, err)
-	}
-
-	return nil
-}
-
-// Close closes the Redis connection.
-func (r *RueidisCache[T]) Close() error {
-	r.client.Close()
-	return nil
-}
-
-// Health checks if Redis is reachable.
-func (r *RueidisCache[T]) Health(ctx context.Context) error {
-	cmd := r.client.B().Ping().Build()
-	if err := r.client.Do(ctx, cmd).Error(); err != nil {
-		return fmt.Errorf("%w: %v", ErrCacheUnavailable, err)
-	}
-	return nil
-}
-
 // GetWithFetch retrieves a value using the cache-aside pattern.
 // On cache miss, fetchFunc is called and the result is stored in cache.
 // No stampede protection is provided.
@@ -177,14 +103,5 @@ func (r *RueidisCache[T]) GetWithFetch(
 	ttl time.Duration,
 	fetchFunc func(ctx context.Context, key string) (T, error),
 ) (T, error) {
-	if value, err := r.Get(ctx, key); err == nil {
-		return value, nil
-	}
-	value, err := fetchFunc(ctx, key)
-	if err != nil {
-		var zero T
-		return zero, err
-	}
-	_ = r.Set(ctx, key, value, ttl)
-	return value, nil
+	return fetchThrough(ctx, key, ttl, r.Get, r.Set, fetchFunc)
 }

--- a/internal/cache/rueidis_aside.go
+++ b/internal/cache/rueidis_aside.go
@@ -18,9 +18,9 @@ var _ core.Cache[struct{}] = (*RueidisAsideCache[struct{}])(nil)
 // Uses rueidis' automatic client-side caching with RESP3 protocol for cache invalidation.
 // Suitable for high-load multi-instance deployments (5+ pods).
 type RueidisAsideCache[T any] struct {
-	client    rueidisaside.CacheAsideClient
-	keyPrefix string
-	clientTTL time.Duration
+	redisBase[T]
+	asideClient rueidisaside.CacheAsideClient
+	clientTTL   time.Duration
 }
 
 // NewRueidisAsideCache creates a new Redis cache with client-side caching using rueidisaside.
@@ -38,7 +38,7 @@ func NewRueidisAsideCache[T any](
 	cacheSizeMB int,
 ) (*RueidisAsideCache[T], error) {
 	cacheSizeBytes := cacheSizeMB * 1024 * 1024
-	client, err := rueidisaside.NewClient(rueidisaside.ClientOption{
+	asideClient, err := rueidisaside.NewClient(rueidisaside.ClientOption{
 		ClientOption: rueidis.ClientOption{
 			InitAddress:  []string{addr},
 			Password:     password,
@@ -52,16 +52,22 @@ func NewRueidisAsideCache[T any](
 		return nil, fmt.Errorf("failed to create rueidisaside client: %w", err)
 	}
 
+	client := asideClient.Client()
+
 	// Test connection with provided context
-	if err := client.Client().Do(ctx, client.Client().B().Ping().Build()).Error(); err != nil {
-		client.Close()
+	if err := client.Do(ctx, client.B().Ping().Build()).Error(); err != nil {
+		asideClient.Close()
 		return nil, fmt.Errorf("failed to ping Redis: %w", err)
 	}
 
 	return &RueidisAsideCache[T]{
-		client:    client,
-		keyPrefix: keyPrefix,
-		clientTTL: clientTTL,
+		redisBase: redisBase[T]{
+			client:    client,
+			keyPrefix: keyPrefix,
+			closeFunc: asideClient.Close,
+		},
+		asideClient: asideClient,
+		clientTTL:   clientTTL,
 	}, nil
 }
 
@@ -69,8 +75,8 @@ func NewRueidisAsideCache[T any](
 // Uses DoCache to leverage RESP3 client-side caching with automatic invalidation.
 func (r *RueidisAsideCache[T]) Get(ctx context.Context, key string) (T, error) {
 	// Use DoCache for client-side caching (RESP3 automatic invalidation)
-	cmd := r.client.Client().B().Get().Key(prefixedKey(r.keyPrefix, key)).Cache()
-	resp := r.client.Client().DoCache(ctx, cmd, r.clientTTL)
+	cmd := r.client.B().Get().Key(prefixedKey(r.keyPrefix, key)).Cache()
+	resp := r.client.DoCache(ctx, cmd, r.clientTTL)
 
 	if err := resp.Error(); err != nil {
 		var zero T
@@ -98,7 +104,7 @@ func (r *RueidisAsideCache[T]) GetWithFetch(
 	ttl time.Duration,
 	fetchFunc func(ctx context.Context, key string) (T, error),
 ) (T, error) {
-	val, err := r.client.Get(
+	val, err := r.asideClient.Get(
 		ctx,
 		ttl,
 		prefixedKey(r.keyPrefix, key),
@@ -119,41 +125,15 @@ func (r *RueidisAsideCache[T]) GetWithFetch(
 	return unmarshalValue[T](val)
 }
 
-// Set stores a value in Redis with TTL.
-func (r *RueidisAsideCache[T]) Set(
-	ctx context.Context,
-	key string,
-	value T,
-	ttl time.Duration,
-) error {
-	encoded, err := marshalValue(value)
-	if err != nil {
-		return err
-	}
-
-	// Use standard SET command via the underlying client
-	cmd := r.client.Client().B().Set().
-		Key(prefixedKey(r.keyPrefix, key)).
-		Value(encoded).
-		Ex(ttl).
-		Build()
-
-	if err := r.client.Client().Do(ctx, cmd).Error(); err != nil {
-		return fmt.Errorf("%w: %v", ErrCacheUnavailable, err)
-	}
-
-	return nil
-}
-
 // MGet retrieves multiple values from Redis with client-side caching.
 func (r *RueidisAsideCache[T]) MGet(ctx context.Context, keys []string) (map[string]T, error) {
 	if len(keys) == 0 {
 		return make(map[string]T), nil
 	}
 
-	// Use standard MGET command via the underlying client
-	cmd := r.client.Client().B().Mget().Key(prefixedKeys(r.keyPrefix, keys)...).Cache()
-	resp := r.client.Client().DoCache(ctx, cmd, r.clientTTL)
+	// Use DoCache for client-side caching with MGET
+	cmd := r.client.B().Mget().Key(prefixedKeys(r.keyPrefix, keys)...).Cache()
+	resp := r.client.DoCache(ctx, cmd, r.clientTTL)
 
 	if err := resp.Error(); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrCacheUnavailable, err)
@@ -165,64 +145,4 @@ func (r *RueidisAsideCache[T]) MGet(ctx context.Context, keys []string) (map[str
 	}
 
 	return parseMultiGetResponse[T](keys, values), nil
-}
-
-// MSet stores multiple values in Redis with TTL.
-func (r *RueidisAsideCache[T]) MSet(
-	ctx context.Context,
-	values map[string]T,
-	ttl time.Duration,
-) error {
-	if len(values) == 0 {
-		return nil
-	}
-
-	// Use pipeline for multiple SET commands via the underlying client
-	cmds := make(rueidis.Commands, 0, len(values))
-	for key, value := range values {
-		encoded, err := marshalValue(value)
-		if err != nil {
-			return err
-		}
-
-		cmd := r.client.Client().B().Set().
-			Key(prefixedKey(r.keyPrefix, key)).
-			Value(encoded).
-			Ex(ttl).
-			Build()
-		cmds = append(cmds, cmd)
-	}
-
-	for _, resp := range r.client.Client().DoMulti(ctx, cmds...) {
-		if err := resp.Error(); err != nil {
-			return fmt.Errorf("%w: %v", ErrCacheUnavailable, err)
-		}
-	}
-
-	return nil
-}
-
-// Delete removes a key from Redis.
-func (r *RueidisAsideCache[T]) Delete(ctx context.Context, key string) error {
-	cmd := r.client.Client().B().Del().Key(prefixedKey(r.keyPrefix, key)).Build()
-	if err := r.client.Client().Do(ctx, cmd).Error(); err != nil {
-		return fmt.Errorf("%w: %v", ErrCacheUnavailable, err)
-	}
-
-	return nil
-}
-
-// Close closes the Redis connection.
-func (r *RueidisAsideCache[T]) Close() error {
-	r.client.Close()
-	return nil
-}
-
-// Health checks if Redis is reachable.
-func (r *RueidisAsideCache[T]) Health(ctx context.Context) error {
-	cmd := r.client.Client().B().Ping().Build()
-	if err := r.client.Client().Do(ctx, cmd).Error(); err != nil {
-		return fmt.Errorf("%w: %v", ErrCacheUnavailable, err)
-	}
-	return nil
 }

--- a/internal/cache/util.go
+++ b/internal/cache/util.go
@@ -1,8 +1,10 @@
 package cache
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/redis/rueidis"
 )
@@ -37,6 +39,28 @@ func unmarshalValue[T any](str string) (T, error) {
 		var zero T
 		return zero, fmt.Errorf("%w: %v", ErrInvalidValue, err)
 	}
+	return value, nil
+}
+
+// fetchThrough implements the cache-aside pattern: try Get, on miss call
+// fetchFunc and store the result via Set. Used by MemoryCache and RueidisCache.
+func fetchThrough[T any](
+	ctx context.Context,
+	key string,
+	ttl time.Duration,
+	get func(context.Context, string) (T, error),
+	set func(context.Context, string, T, time.Duration) error,
+	fetchFunc func(context.Context, string) (T, error),
+) (T, error) {
+	if value, err := get(ctx, key); err == nil {
+		return value, nil
+	}
+	value, err := fetchFunc(ctx, key)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	_ = set(ctx, key, value, ttl)
 	return value, nil
 }
 


### PR DESCRIPTION
## Summary
- Extract duplicated `Set`, `MSet`, `Delete`, `Close`, and `Health` methods from `RueidisCache` and `RueidisAsideCache` into an embedded `redisBase[T]` struct, eliminating ~60 lines of copy-paste
- Extract identical cache-aside logic (`Get` → fetch → `Set`) into a shared `fetchThrough[T]` helper, used by both `MemoryCache` and `RueidisCache`
- Net reduction of 56 lines with no behavior change

## Test plan
- [x] All 20 existing cache tests pass (`go test ./internal/cache/`)
- [x] Full project builds cleanly (`go build ./...`)
- [ ] Verify Redis-backed caches work in integration environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)