### PR TITLE
refactor(store): fix audit log stats query mutation and remove dead code

### DIFF
--- a/internal/services/client.go
+++ b/internal/services/client.go
@@ -404,10 +404,6 @@ func (s *ClientService) DeleteClient(ctx context.Context, clientID, actorUserID 
 	return nil
 }
 
-func (s *ClientService) ListClients() ([]models.OAuthApplication, error) {
-	return s.store.ListClients()
-}
-
 // ListClientsPaginated returns paginated OAuth clients with search support
 func (s *ClientService) ListClientsPaginated(
 	params store.PaginationParams,

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -140,8 +140,9 @@ func (s *Store) seedData(ctx context.Context, cfg *config.Config) error {
 	// Create default user if not exists
 	var userCount int64
 	s.db.WithContext(ctx).Model(&models.User{}).Count(&userCount)
-	userID := uuid.New().String()
+	var userID string
 	if userCount == 0 {
+		userID = uuid.New().String()
 		var password string
 		var err error
 
@@ -183,6 +184,17 @@ func (s *Store) seedData(ctx context.Context, cfg *config.Config) error {
 	var clientCount int64
 	s.db.WithContext(ctx).Model(&models.OAuthApplication{}).Count(&clientCount)
 	if clientCount == 0 {
+		// If admin user was not just created, look up the existing admin user ID
+		if userID == "" {
+			var adminUser models.User
+			if err := s.db.WithContext(ctx).
+				Where("username = ?", "admin").
+				First(&adminUser).
+				Error; err != nil {
+				return fmt.Errorf("failed to find admin user for default client: %w", err)
+			}
+			userID = adminUser.ID
+		}
 		clientID := uuid.New().String()
 		client := &models.OAuthApplication{
 			UserID:             userID,
@@ -323,14 +335,6 @@ func (s *Store) GetClient(clientID string) (*models.OAuthApplication, error) {
 		return nil, err
 	}
 	return &client, nil
-}
-
-func (s *Store) ListClients() ([]models.OAuthApplication, error) {
-	var clients []models.OAuthApplication
-	if err := s.db.Order("created_at DESC").Find(&clients).Error; err != nil {
-		return nil, err
-	}
-	return clients, nil
 }
 
 // ListClientsPaginated returns paginated OAuth clients with search and optional status filter support
@@ -804,22 +808,25 @@ func (s *Store) GetAuditLogStats(startTime, endTime time.Time) (AuditLogStats, e
 		EventsBySeverity: make(map[models.EventSeverity]int64),
 	}
 
-	// Build base query
-	query := s.db.Model(&models.AuditLog{})
-	if !startTime.IsZero() {
-		query = query.Where("event_time >= ?", startTime)
-	}
-	if !endTime.IsZero() {
-		query = query.Where("event_time <= ?", endTime)
+	// Build base query as a function to avoid GORM query state mutation
+	baseQuery := func() *gorm.DB {
+		q := s.db.Model(&models.AuditLog{})
+		if !startTime.IsZero() {
+			q = q.Where("event_time >= ?", startTime)
+		}
+		if !endTime.IsZero() {
+			q = q.Where("event_time <= ?", endTime)
+		}
+		return q
 	}
 
 	// Total events
-	if err := query.Count(&stats.TotalEvents).Error; err != nil {
+	if err := baseQuery().Count(&stats.TotalEvents).Error; err != nil {
 		return stats, err
 	}
 
 	// Success/Failure counts
-	if err := query.Where("success = ?", true).Count(&stats.SuccessCount).Error; err != nil {
+	if err := baseQuery().Where("success = ?", true).Count(&stats.SuccessCount).Error; err != nil {
 		return stats, err
 	}
 	stats.FailureCount = stats.TotalEvents - stats.SuccessCount
@@ -829,7 +836,7 @@ func (s *Store) GetAuditLogStats(startTime, endTime time.Time) (AuditLogStats, e
 		EventType models.EventType
 		Count     int64
 	}
-	if err := query.Select("event_type, COUNT(*) as count").
+	if err := baseQuery().Select("event_type, COUNT(*) as count").
 		Group("event_type").
 		Find(&typeResults).Error; err != nil {
 		return stats, err
@@ -843,7 +850,7 @@ func (s *Store) GetAuditLogStats(startTime, endTime time.Time) (AuditLogStats, e
 		Severity models.EventSeverity
 		Count    int64
 	}
-	if err := query.Select("severity, COUNT(*) as count").
+	if err := baseQuery().Select("severity, COUNT(*) as count").
 		Group("severity").
 		Find(&severityResults).Error; err != nil {
 		return stats, err

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -280,6 +280,63 @@ func testBasicOperations(t *testing.T, driver string, pgContainer *postgres.Post
 		err := store.Health()
 		assert.NoError(t, err)
 	})
+
+	t.Run("GetAuditLogStats", func(t *testing.T) {
+		store := createFreshStore(t, driver, pgContainer)
+
+		now := time.Now()
+
+		// Create audit logs: 2 successful, 1 failed, mixed types and severities
+		logs := []models.AuditLog{
+			{
+				ID:        uuid.New().String(),
+				EventType: models.EventAuthenticationSuccess,
+				EventTime: now.Add(-time.Hour),
+				Severity:  models.SeverityInfo,
+				Action:    "login",
+				Success:   true,
+				CreatedAt: now,
+			},
+			{
+				ID:        uuid.New().String(),
+				EventType: models.EventAuthenticationFailure,
+				EventTime: now.Add(-30 * time.Minute),
+				Severity:  models.SeverityWarning,
+				Action:    "login_fail",
+				Success:   false,
+				CreatedAt: now,
+			},
+			{
+				ID:        uuid.New().String(),
+				EventType: models.EventAuthenticationSuccess,
+				EventTime: now.Add(-10 * time.Minute),
+				Severity:  models.SeverityInfo,
+				Action:    "login",
+				Success:   true,
+				CreatedAt: now,
+			},
+		}
+		for i := range logs {
+			err := store.db.Create(&logs[i]).Error
+			require.NoError(t, err)
+		}
+
+		stats, err := store.GetAuditLogStats(time.Time{}, time.Time{})
+		require.NoError(t, err)
+
+		// Verify total counts
+		assert.Equal(t, int64(3), stats.TotalEvents)
+		assert.Equal(t, int64(2), stats.SuccessCount)
+		assert.Equal(t, int64(1), stats.FailureCount)
+
+		// Verify events by type counts ALL events (not just successful)
+		assert.Equal(t, int64(2), stats.EventsByType[models.EventAuthenticationSuccess])
+		assert.Equal(t, int64(1), stats.EventsByType[models.EventAuthenticationFailure])
+
+		// Verify events by severity counts ALL events (not just successful)
+		assert.Equal(t, int64(2), stats.EventsBySeverity[models.SeverityInfo])
+		assert.Equal(t, int64(1), stats.EventsBySeverity[models.SeverityWarning])
+	})
 }
 
 // TestDriverFactory tests the driver factory pattern


### PR DESCRIPTION
## Summary
- **Fix critical bug** in `GetAuditLogStats`: GORM's `.Where()` mutated shared query state, causing `EventsByType` and `EventsBySeverity` to only count successful events instead of all events. Replaced with a `baseQuery()` factory function that returns a fresh query each time.
- **Remove dead code**: Deleted unused `Store.ListClients()` and `ClientService.ListClients()` (zero callers, superseded by paginated variants).
- **Defer UUID generation** in `seedData()`: Moved `uuid.New()` inside the `if userCount == 0` block to avoid unnecessary work on every startup. Added fallback to look up existing admin user when only the client seed runs.
- **Add test** for `GetAuditLogStats` verifying that type/severity counts include all events (not just successful ones).

## Test plan
- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues
- [x] `go vet ./...` — clean
- [x] New `GetAuditLogStats` test exercises the fixed bug directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)