### PR TITLE
fix(store): handle Count errors in seedData to fail fast on DB issues

### DIFF
--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -139,7 +139,9 @@ func generateRandomPassword(length int) (string, error) {
 func (s *Store) seedData(ctx context.Context, cfg *config.Config) error {
 	// Create default user if not exists
 	var userCount int64
-	s.db.WithContext(ctx).Model(&models.User{}).Count(&userCount)
+	if err := s.db.WithContext(ctx).Model(&models.User{}).Count(&userCount).Error; err != nil {
+		return fmt.Errorf("failed to count users: %w", err)
+	}
 	var userID string
 	if userCount == 0 {
 		userID = uuid.New().String()
@@ -182,7 +184,12 @@ func (s *Store) seedData(ctx context.Context, cfg *config.Config) error {
 
 	// Create default OAuth client if not exists
 	var clientCount int64
-	s.db.WithContext(ctx).Model(&models.OAuthApplication{}).Count(&clientCount)
+	if err := s.db.WithContext(ctx).
+		Model(&models.OAuthApplication{}).
+		Count(&clientCount).
+		Error; err != nil {
+		return fmt.Errorf("failed to count OAuth clients: %w", err)
+	}
 	if clientCount == 0 {
 		// If admin user was not just created, look up the existing admin user ID
 		if userID == "" {


### PR DESCRIPTION
## Summary
- Add error handling for `Count()` calls on `User` and `OAuthApplication` models in `seedData()`
- Previously, if the database query failed, `count` would remain 0, potentially causing duplicate admin user creation or incorrect client seeding
- Now returns a wrapped error immediately so startup fails fast and deterministically

Addresses review feedback from [#89](https://github.com/go-authgate/authgate/pull/89#discussion_r2901616546).

## Test plan
- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)