### PR TITLE
fix(security): prevent OAuth account takeover via unverified email auto-linking

### DIFF
--- a/internal/auth/oauth_gitea.go
+++ b/internal/auth/oauth_gitea.go
@@ -38,5 +38,6 @@ func (p *OAuthProvider) getGiteaUserInfo(
 		Email:          user.Email,
 		FullName:       user.FullName,
 		AvatarURL:      user.AvatarURL,
+		EmailVerified:  false, // Gitea API does not expose email verification status
 	}, nil
 }

--- a/internal/auth/oauth_gitea_test.go
+++ b/internal/auth/oauth_gitea_test.go
@@ -64,6 +64,7 @@ func TestGetGiteaUserInfo_Success(t *testing.T) {
 	assert.Equal(t, "Gitea Tester", info.FullName)
 	assert.Equal(t, "gitea@example.com", info.Email)
 	assert.Equal(t, "https://gitea.example.com/avatars/99", info.AvatarURL)
+	assert.False(t, info.EmailVerified, "Gitea API does not expose email verification status")
 }
 
 func TestGetGiteaUserInfo_NoEmail(t *testing.T) {

--- a/internal/auth/oauth_github.go
+++ b/internal/auth/oauth_github.go
@@ -55,6 +55,7 @@ func (p *OAuthProvider) getGitHubUserInfo(
 		Email:          user.Email,
 		FullName:       user.Name,
 		AvatarURL:      user.AvatarURL,
+		EmailVerified:  true, // GitHub enforces email verification; fallback path filters for Verified: true
 	}, nil
 }
 

--- a/internal/auth/oauth_github_test.go
+++ b/internal/auth/oauth_github_test.go
@@ -50,6 +50,7 @@ func TestGetGitHubUserInfo_Success(t *testing.T) {
 	assert.Equal(t, "The Octocat", info.FullName)
 	assert.Equal(t, "octocat@github.com", info.Email)
 	assert.Equal(t, "https://github.com/avatars/octocat", info.AvatarURL)
+	assert.True(t, info.EmailVerified, "GitHub emails are always verified")
 }
 
 func TestGetGitHubUserInfo_FetchesPrimaryEmail(t *testing.T) {
@@ -75,6 +76,7 @@ func TestGetGitHubUserInfo_FetchesPrimaryEmail(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "primary@example.com", info.Email)
+	assert.True(t, info.EmailVerified)
 }
 
 func TestGetGitHubUserInfo_FallsBackToFirstVerifiedEmail(t *testing.T) {

--- a/internal/auth/oauth_gitlab.go
+++ b/internal/auth/oauth_gitlab.go
@@ -38,5 +38,6 @@ func (p *OAuthProvider) getGitLabUserInfo(
 		Email:          user.Email,
 		FullName:       user.Name,
 		AvatarURL:      user.AvatarURL,
+		EmailVerified:  false, // GitLab API does not expose email verification status
 	}, nil
 }

--- a/internal/auth/oauth_gitlab_test.go
+++ b/internal/auth/oauth_gitlab_test.go
@@ -72,6 +72,7 @@ func TestGetGitLabUserInfo_Success(t *testing.T) {
 	assert.Equal(t, "Jane Doe", info.FullName)
 	assert.Equal(t, "jane@example.com", info.Email)
 	assert.Equal(t, "https://gitlab.com/uploads/avatar.png", info.AvatarURL)
+	assert.False(t, info.EmailVerified, "GitLab API does not expose email verification status")
 }
 
 func TestGetGitLabUserInfo_NoEmail(t *testing.T) {

--- a/internal/auth/oauth_microsoft.go
+++ b/internal/auth/oauth_microsoft.go
@@ -49,6 +49,7 @@ func (p *OAuthProvider) getMicrosoftUserInfo(
 		Username:       strings.Split(email, "@")[0],
 		Email:          email,
 		FullName:       fullName,
-		AvatarURL:      "", // Microsoft Graph /me doesn't include photo by default
+		AvatarURL:      "",   // Microsoft Graph /me doesn't include photo by default
+		EmailVerified:  true, // Microsoft Entra ID email is tenant-controlled and admin-managed
 	}, nil
 }

--- a/internal/auth/oauth_microsoft_test.go
+++ b/internal/auth/oauth_microsoft_test.go
@@ -46,6 +46,7 @@ func TestGetMicrosoftUserInfo_Success_WithMail(t *testing.T) {
 	assert.Equal(t, "jane.doe", info.Username) // split on @
 	assert.Equal(t, "Jane Doe", info.FullName)
 	assert.Equal(t, "jane.doe@corp.com", info.Email) // mail preferred over UPN
+	assert.True(t, info.EmailVerified, "Microsoft Entra ID email is tenant-controlled")
 }
 
 func TestGetMicrosoftUserInfo_Success_FallsBackToUPN(t *testing.T) {

--- a/internal/auth/oauth_provider.go
+++ b/internal/auth/oauth_provider.go
@@ -36,6 +36,7 @@ type OAuthUserInfo struct {
 	Email          string // User email (required)
 	FullName       string // User full name
 	AvatarURL      string // Avatar URL
+	EmailVerified  bool   // Whether the provider has verified the email address
 }
 
 // OAuthProvider handles OAuth authentication

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -32,6 +32,9 @@ var (
 	ErrUserSyncFailed            = errors.New("failed to sync user from external provider")
 	ErrUsernameConflict          = errors.New("username already exists")
 	ErrOAuthAutoRegisterDisabled = errors.New("OAuth auto-registration is disabled")
+	ErrOAuthEmailNotVerified     = errors.New(
+		"OAuth email not verified and auto-registration is disabled",
+	)
 )
 
 type UserService struct {
@@ -330,8 +333,22 @@ func (s *UserService) AuthenticateWithOAuth(
 	// 2. Check if user exists with same email
 	user, err := s.store.GetUserByEmail(oauthUserInfo.Email)
 	if err == nil {
-		// User exists: link OAuth to existing user
-		return s.linkOAuthToExistingUser(ctx, user, provider, oauthUserInfo, token)
+		// Only auto-link when the provider has verified the email address.
+		// Without this check, an attacker who controls an OAuth account with
+		// a victim's email could take over the victim's AuthGate account.
+		if oauthUserInfo.EmailVerified {
+			return s.linkOAuthToExistingUser(ctx, user, provider, oauthUserInfo, token)
+		}
+		log.Printf(
+			"[OAuth] Skipping auto-link for user=%s provider=%s: email not verified by provider",
+			user.Username,
+			provider,
+		)
+		// Fall through to auto-register check — treat as new user
+		if !s.oauthAutoRegister {
+			return nil, ErrOAuthEmailNotVerified
+		}
+		return s.createUserWithOAuth(ctx, provider, oauthUserInfo, token)
 	}
 
 	// 3. Check if auto-registration is enabled

--- a/internal/services/user_oauth_test.go
+++ b/internal/services/user_oauth_test.go
@@ -126,3 +126,119 @@ func TestAuthenticateWithOAuth_AutoRegisterDisabled(t *testing.T) {
 	_, err := svc.AuthenticateWithOAuth(context.Background(), "github", info, newOAuthToken())
 	assert.ErrorIs(t, err, ErrOAuthAutoRegisterDisabled)
 }
+
+// TestAuthenticateWithOAuth_LinkExistingUser_VerifiedEmail verifies that when
+// EmailVerified is true and a local user with the same email exists, the OAuth
+// identity is auto-linked to the existing account.
+func TestAuthenticateWithOAuth_LinkExistingUser_VerifiedEmail(t *testing.T) {
+	svc := newOAuthUserService(t)
+
+	// Create an existing user first via a different provider.
+	existingInfo := &auth.OAuthUserInfo{
+		ProviderUserID: uuid.New().String(),
+		Username:       "existing",
+		Email:          "shared@example.com",
+		EmailVerified:  true,
+	}
+	user1, err := svc.AuthenticateWithOAuth(
+		context.Background(),
+		"github",
+		existingInfo,
+		newOAuthToken(),
+	)
+	require.NoError(t, err)
+
+	// Now authenticate via a different provider with a verified email matching
+	// the existing user — should auto-link rather than create a new account.
+	linkInfo := &auth.OAuthUserInfo{
+		ProviderUserID: uuid.New().String(),
+		Username:       "attacker",
+		Email:          "shared@example.com",
+		EmailVerified:  true,
+	}
+	user2, err := svc.AuthenticateWithOAuth(
+		context.Background(),
+		"microsoft",
+		linkInfo,
+		newOAuthToken(),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, user1.ID, user2.ID, "should link to existing user, not create a new one")
+}
+
+// TestAuthenticateWithOAuth_SkipLinkUnverifiedEmail verifies that when
+// EmailVerified is false and a local user with the same email exists, the
+// OAuth identity is NOT linked to the existing account. The attempt to create
+// a new account also fails because of the UNIQUE email constraint, which is
+// the correct security behaviour — the attacker cannot hijack the victim's
+// account.
+func TestAuthenticateWithOAuth_SkipLinkUnverifiedEmail(t *testing.T) {
+	svc := newOAuthUserService(t)
+
+	// Create an existing user.
+	existingInfo := &auth.OAuthUserInfo{
+		ProviderUserID: uuid.New().String(),
+		Username:       "victim",
+		Email:          "victim@example.com",
+		EmailVerified:  true,
+	}
+	_, err := svc.AuthenticateWithOAuth(
+		context.Background(),
+		"github",
+		existingInfo,
+		newOAuthToken(),
+	)
+	require.NoError(t, err)
+
+	// Attacker authenticates via a provider that does NOT verify email.
+	attackerInfo := &auth.OAuthUserInfo{
+		ProviderUserID: uuid.New().String(),
+		Username:       "attacker",
+		Email:          "victim@example.com",
+		EmailVerified:  false,
+	}
+	_, err = svc.AuthenticateWithOAuth(context.Background(), "gitea", attackerInfo, newOAuthToken())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "email already in use",
+		"unverified email must NOT auto-link; duplicate email prevents new account")
+}
+
+// TestAuthenticateWithOAuth_UnverifiedEmail_AutoRegisterDisabled verifies that
+// when EmailVerified is false, a matching local user exists, and auto-register
+// is disabled, the authentication returns ErrOAuthEmailNotVerified.
+func TestAuthenticateWithOAuth_UnverifiedEmail_AutoRegisterDisabled(t *testing.T) {
+	db := setupTestStore(t)
+	c := cache.NewMemoryCache[models.User]()
+
+	// First create a user with auto-register enabled.
+	svcEnabled := NewUserService(db, nil, nil, AuthModeLocal, true, nil, c, 5*time.Minute)
+	existingInfo := &auth.OAuthUserInfo{
+		ProviderUserID: uuid.New().String(),
+		Username:       "localuser",
+		Email:          "local@example.com",
+		EmailVerified:  true,
+	}
+	_, err := svcEnabled.AuthenticateWithOAuth(
+		context.Background(),
+		"github",
+		existingInfo,
+		newOAuthToken(),
+	)
+	require.NoError(t, err)
+
+	// Now use a service with auto-register disabled.
+	svcDisabled := NewUserService(db, nil, nil, AuthModeLocal, false, nil, c, 5*time.Minute)
+	attackerInfo := &auth.OAuthUserInfo{
+		ProviderUserID: uuid.New().String(),
+		Username:       "attacker",
+		Email:          "local@example.com",
+		EmailVerified:  false,
+	}
+	_, err = svcDisabled.AuthenticateWithOAuth(
+		context.Background(),
+		"gitea",
+		attackerInfo,
+		newOAuthToken(),
+	)
+	assert.ErrorIs(t, err, ErrOAuthEmailNotVerified)
+}


### PR DESCRIPTION
## Summary

- **Vulnerability**: When a user authenticates via OAuth (Gitea, GitLab, Microsoft), if no existing OAuth connection exists, AuthenticateWithOAuth silently links the OAuth identity to an existing local user by email without verifying email ownership. An attacker controlling an OAuth provider account with a victim email could take over the victim AuthGate account.
- **Fix**: Add EmailVerified field to OAuthUserInfo. Only auto-link OAuth accounts to existing users when the provider confirms the email is verified. GitHub and Microsoft are marked verified; Gitea and GitLab are not (their APIs do not expose verification status).
- **New sentinel error** ErrOAuthEmailNotVerified returned when an unverified email matches an existing user and auto-registration is disabled.

## Test plan

- [x] TestAuthenticateWithOAuth_LinkExistingUser_VerifiedEmail -- verified email auto-links to existing user
- [x] TestAuthenticateWithOAuth_SkipLinkUnverifiedEmail -- unverified email does NOT auto-link; blocked by UNIQUE email constraint
- [x] TestAuthenticateWithOAuth_UnverifiedEmail_AutoRegisterDisabled -- unverified email + existing user + auto-register off returns ErrOAuthEmailNotVerified
- [x] Provider tests assert correct EmailVerified values (GitHub/Microsoft: true, Gitea/GitLab: false)
- [x] All existing tests continue to pass
- [x] make lint passes with zero issues