### PR TITLE
refactor(handlers): consolidate client display conversion and remove magic strings

### DIFF
--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -165,7 +165,7 @@ func (h *AuthHandler) Login(c *gin.Context,
 
 	// Set session fingerprint if enabled
 	if h.sessionFingerprintEnabled {
-		clientIP := c.GetString("client_ip") // Set by IPMiddleware
+		clientIP := c.GetString(middleware.ContextKeyClientIP) // Set by IPMiddleware
 		userAgent := c.Request.UserAgent()
 		fingerprint := middleware.GenerateFingerprint(
 			clientIP,

--- a/internal/handlers/authorization.go
+++ b/internal/handlers/authorization.go
@@ -252,19 +252,8 @@ func (h *AuthorizationHandler) redirectWithError(
 	c *gin.Context,
 	redirectURI, state, errorCode, description string,
 ) {
-	if redirectURI == "" {
-		templates.RenderTempl(
-			c,
-			http.StatusBadRequest,
-			templates.ErrorPage(templates.ErrorPageProps{
-				Error:   errorCode,
-				Message: description,
-			}),
-		)
-		return
-	}
 	u, err := url.Parse(redirectURI)
-	if err != nil {
+	if redirectURI == "" || err != nil {
 		templates.RenderTempl(
 			c,
 			http.StatusBadRequest,

--- a/internal/handlers/client.go
+++ b/internal/handlers/client.go
@@ -184,20 +184,7 @@ func (h *ClientHandler) CreateClient(c *gin.Context) {
 	userModel := user.(*models.User)
 
 	// Convert OAuthApplication to ClientDisplay for template
-	clientDisplay := &templates.ClientDisplay{
-		ID:                          resp.ID,
-		ClientID:                    resp.ClientID,
-		ClientName:                  resp.ClientName,
-		Description:                 resp.Description,
-		Scopes:                      resp.Scopes,
-		GrantTypes:                  resp.GrantTypes,
-		RedirectURIs:                resp.RedirectURIs.Join(", "),
-		ClientType:                  resp.ClientType,
-		EnableDeviceFlow:            resp.EnableDeviceFlow,
-		EnableAuthCodeFlow:          resp.EnableAuthCodeFlow,
-		EnableClientCredentialsFlow: resp.EnableClientCredentialsFlow,
-		Status:                      resp.Status,
-	}
+	clientDisplay := clientToDisplay(resp.OAuthApplication)
 
 	templates.RenderTempl(
 		c,
@@ -224,23 +211,7 @@ func (h *ClientHandler) ShowEditClientPage(c *gin.Context) {
 	user, _ := c.Get("user")
 	userModel := user.(*models.User)
 
-	// Convert OAuthApplication to ClientDisplay for template
-	clientDisplay := &templates.ClientDisplay{
-		ID:                          client.ID,
-		ClientID:                    client.ClientID,
-		ClientName:                  client.ClientName,
-		Description:                 client.Description,
-		Scopes:                      client.Scopes,
-		GrantTypes:                  client.GrantTypes,
-		RedirectURIs:                client.RedirectURIs.Join(", "),
-		ClientType:                  client.ClientType,
-		EnableDeviceFlow:            client.EnableDeviceFlow,
-		EnableAuthCodeFlow:          client.EnableAuthCodeFlow,
-		EnableClientCredentialsFlow: client.EnableClientCredentialsFlow,
-		Status:                      client.Status,
-		CreatedAt:                   client.CreatedAt,
-		UpdatedAt:                   client.UpdatedAt,
-	}
+	clientDisplay := clientToDisplay(client)
 
 	templates.RenderTempl(c, http.StatusOK, templates.AdminClientForm(templates.ClientFormPageProps{
 		BaseProps:   templates.BaseProps{CSRFToken: middleware.GetCSRFToken(c)},

--- a/internal/handlers/oauth_handler.go
+++ b/internal/handlers/oauth_handler.go
@@ -228,7 +228,7 @@ func (h *OAuthHandler) OAuthCallback(c *gin.Context) {
 
 	// Set session fingerprint if enabled
 	if h.sessionFingerprintEnabled {
-		clientIP := c.GetString("client_ip") // Set by IPMiddleware
+		clientIP := c.GetString(middleware.ContextKeyClientIP) // Set by IPMiddleware
 		userAgent := c.Request.UserAgent()
 		fingerprint := middleware.GenerateFingerprint(
 			clientIP,

--- a/internal/handlers/user_client.go
+++ b/internal/handlers/user_client.go
@@ -121,7 +121,7 @@ func (h *UserClientHandler) CreateApp(c *gin.Context) {
 		return
 	}
 
-	clientDisplay := appToDisplay(resp.OAuthApplication)
+	clientDisplay := clientToDisplay(resp.OAuthApplication)
 
 	templates.RenderTempl(
 		c,
@@ -166,7 +166,7 @@ func (h *UserClientHandler) ShowAppPage(c *gin.Context) {
 		templates.UserAppDetail(templates.UserClientDetailPageProps{
 			BaseProps:    templates.BaseProps{CSRFToken: middleware.GetCSRFToken(c)},
 			NavbarProps:  buildNavbarProps(c, userModel, "my-apps"),
-			Client:       appToDisplay(client),
+			Client:       clientToDisplay(client),
 			ActiveTokens: activeTokens,
 			Success:      successMsg,
 		}),
@@ -199,7 +199,7 @@ func (h *UserClientHandler) ShowEditAppPage(c *gin.Context) {
 		Method:      http.MethodPost,
 		Action:      action,
 		IsEdit:      true,
-		Client:      appToDisplay(client),
+		Client:      clientToDisplay(client),
 	}))
 }
 
@@ -304,7 +304,7 @@ func (h *UserClientHandler) RegenerateAppSecret(c *gin.Context) {
 	}
 
 	refreshed, _ := h.clientService.GetClient(clientID)
-	display := appToDisplay(refreshed)
+	display := clientToDisplay(refreshed)
 
 	templates.RenderTempl(
 		c,
@@ -316,30 +316,6 @@ func (h *UserClientHandler) RegenerateAppSecret(c *gin.Context) {
 			PlainSecret: newSecret,
 		}),
 	)
-}
-
-// appToDisplay converts an OAuthApplication to a ClientDisplay for user templates.
-func appToDisplay(app *models.OAuthApplication) *templates.ClientDisplay {
-	if app == nil {
-		return nil
-	}
-	return &templates.ClientDisplay{
-		ID:                          app.ID,
-		ClientID:                    app.ClientID,
-		ClientName:                  app.ClientName,
-		Description:                 app.Description,
-		UserID:                      app.UserID,
-		Scopes:                      app.Scopes,
-		GrantTypes:                  app.GrantTypes,
-		RedirectURIs:                app.RedirectURIs.Join(", "),
-		ClientType:                  app.ClientType,
-		EnableDeviceFlow:            app.EnableDeviceFlow,
-		EnableAuthCodeFlow:          app.EnableAuthCodeFlow,
-		EnableClientCredentialsFlow: app.EnableClientCredentialsFlow,
-		Status:                      app.Status,
-		CreatedAt:                   app.CreatedAt,
-		UpdatedAt:                   app.UpdatedAt,
-	}
 }
 
 func renderUserAppForm(

--- a/internal/handlers/utils.go
+++ b/internal/handlers/utils.go
@@ -7,6 +7,30 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// clientToDisplay converts an OAuthApplication model to a ClientDisplay template struct.
+func clientToDisplay(app *models.OAuthApplication) *templates.ClientDisplay {
+	if app == nil {
+		return nil
+	}
+	return &templates.ClientDisplay{
+		ID:                          app.ID,
+		ClientID:                    app.ClientID,
+		ClientName:                  app.ClientName,
+		Description:                 app.Description,
+		UserID:                      app.UserID,
+		Scopes:                      app.Scopes,
+		GrantTypes:                  app.GrantTypes,
+		RedirectURIs:                app.RedirectURIs.Join(", "),
+		ClientType:                  app.ClientType,
+		EnableDeviceFlow:            app.EnableDeviceFlow,
+		EnableAuthCodeFlow:          app.EnableAuthCodeFlow,
+		EnableClientCredentialsFlow: app.EnableClientCredentialsFlow,
+		Status:                      app.Status,
+		CreatedAt:                   app.CreatedAt,
+		UpdatedAt:                   app.UpdatedAt,
+	}
+}
+
 const ctxKeyPendingClientsCount = "pending_clients_count"
 
 // buildNavbarProps creates NavbarProps from a user model and active link identifier.

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -92,7 +92,7 @@ func SessionFingerprintMiddleware(enabled, includeIP bool) gin.HandlerFunc {
 
 			if storedFingerprint != nil {
 				// Get current fingerprint
-				clientIP := c.GetString("client_ip") // Set by IPMiddleware
+				clientIP := c.GetString(ContextKeyClientIP) // Set by IPMiddleware
 				userAgent := c.Request.UserAgent()
 				currentFingerprint := GenerateFingerprint(clientIP, userAgent, includeIP)
 

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -243,7 +243,7 @@ func TestSessionFingerprintMiddleware_ValidFingerprint(t *testing.T) {
 
 	// Set up session with fingerprint
 	r.Use(func(c *gin.Context) {
-		c.Set("client_ip", "192.168.1.1")
+		c.Set(ContextKeyClientIP, "192.168.1.1")
 		session := sessions.Default(c)
 		session.Set(SessionUserID, "user123")
 		// Generate fingerprint (User-Agent only, IP not included)
@@ -277,7 +277,7 @@ func TestSessionFingerprintMiddleware_MismatchFingerprint(t *testing.T) {
 
 	// Set up session with fingerprint from original browser
 	r.Use(func(c *gin.Context) {
-		c.Set("client_ip", "192.168.1.1")
+		c.Set(ContextKeyClientIP, "192.168.1.1")
 		session := sessions.Default(c)
 		session.Set(SessionUserID, "user123")
 
@@ -426,7 +426,7 @@ func TestSessionFingerprintMiddleware_RedirectURLEncoded(t *testing.T) {
 
 	// Set up session with fingerprint
 	r.Use(func(c *gin.Context) {
-		c.Set("client_ip", "192.168.1.1")
+		c.Set(ContextKeyClientIP, "192.168.1.1")
 		session := sessions.Default(c)
 		session.Set(SessionUserID, "user123")
 

--- a/internal/middleware/context.go
+++ b/internal/middleware/context.go
@@ -5,12 +5,15 @@ import (
 	"github.com/go-authgate/authgate/internal/util"
 )
 
+// ContextKeyClientIP is the gin context key for the client IP address.
+const ContextKeyClientIP = "client_ip"
+
 // IPMiddleware extracts client IP and stores it in the context
 func IPMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		clientIP := c.ClientIP()
 		// Gin's ClientIP() handles X-Forwarded-For and other headers
-		c.Set("client_ip", clientIP)
+		c.Set(ContextKeyClientIP, clientIP)
 
 		// Also store in request context for services layer
 		c.Request = c.Request.WithContext(util.SetIPContext(c.Request.Context(), clientIP))


### PR DESCRIPTION
## Summary
- Extract shared `clientToDisplay` helper in `utils.go`, replacing duplicate `appToDisplay` and 2 inline `OAuthApplication`→`ClientDisplay` conversions across `client.go` and `user_client.go`
- Export `ContextKeyClientIP` constant from `middleware/context.go`, replacing 6 raw `"client_ip"` string occurrences across handlers, middleware, and tests
- Merge duplicate error page rendering in `authorization.go:redirectWithError` into a single conditional

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Linter passes (`make lint`)
- [x] Build succeeds (`go build ./...`)
- [ ] Verify login flow works (session fingerprint uses new constant)
- [ ] Verify OAuth callback flow works
- [ ] Verify admin client create/edit pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)