### PR TITLE
feat(middleware): add HTTP security headers

### DIFF
--- a/internal/bootstrap/router.go
+++ b/internal/bootstrap/router.go
@@ -44,7 +44,7 @@ func setupRouter(
 	r.Use(metrics.HTTPMetricsMiddleware(prometheusMetrics))
 	r.Use(gin.Logger(), gin.Recovery())
 	r.Use(middleware.IPMiddleware())
-	r.Use(middleware.SecurityHeaders(strings.HasPrefix(cfg.BaseURL, "https")))
+	r.Use(middleware.SecurityHeaders(strings.HasPrefix(cfg.BaseURL, "https://")))
 
 	// Setup session middleware
 	setupSessionMiddleware(r, cfg)

--- a/internal/middleware/security_headers.go
+++ b/internal/middleware/security_headers.go
@@ -6,9 +6,18 @@ import (
 
 // SecurityHeaders returns a middleware that sets HTTP security headers
 // to protect against common web vulnerabilities. HSTS is only applied
-// when useHSTS is true (i.e. when BaseURL uses HTTPS), so local HTTP
+// when useHSTS is true (i.e. when BaseURL uses https://), so local HTTP
 // development is unaffected.
 func SecurityHeaders(useHSTS bool) gin.HandlerFunc {
+	// Build CSP once; the templates use inline scripts/handlers and external CDNs.
+	csp := "default-src 'self'; " +
+		"script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; " +
+		"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+		"font-src 'self' https://fonts.gstatic.com; " +
+		"img-src 'self' data:; " +
+		"connect-src 'self'; " +
+		"frame-ancestors 'none'"
+
 	return func(c *gin.Context) {
 		h := c.Writer.Header()
 
@@ -18,13 +27,10 @@ func SecurityHeaders(useHSTS bool) gin.HandlerFunc {
 		// Deny framing to prevent clickjacking on login/consent pages
 		h.Set("X-Frame-Options", "DENY")
 
-		// Restrict resource origins — only allow same-origin by default
-		h.Set(
-			"Content-Security-Policy",
-			"default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'",
-		)
+		// Restrict resource origins to known CDNs used by templates
+		h.Set("Content-Security-Policy", csp)
 
-		// Disable referrer to avoid leaking OAuth parameters
+		// Limit cross-origin referrer to origin only, avoiding OAuth parameter leaks
 		h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
 
 		// Restrict browser features that an OAuth server doesn't need

--- a/internal/middleware/security_headers_test.go
+++ b/internal/middleware/security_headers_test.go
@@ -22,10 +22,21 @@ func TestSecurityHeaders_WithHSTS(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
-	assert.Equal(t, "DENY", w.Header().Get("X-Frame-Options"))
-	assert.Contains(t, w.Header().Get("Content-Security-Policy"), "default-src 'self'")
-	assert.Equal(t, "strict-origin-when-cross-origin", w.Header().Get("Referrer-Policy"))
+	assert.Equal(t, "nosniff",
+		w.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, "DENY",
+		w.Header().Get("X-Frame-Options"))
+
+	csp := w.Header().Get("Content-Security-Policy")
+	assert.Contains(t, csp, "default-src 'self'")
+	assert.Contains(t, csp, "script-src")
+	assert.Contains(t, csp, "cdn.jsdelivr.net")
+	assert.Contains(t, csp, "fonts.googleapis.com")
+	assert.Contains(t, csp, "fonts.gstatic.com")
+	assert.Contains(t, csp, "frame-ancestors 'none'")
+
+	assert.Equal(t, "strict-origin-when-cross-origin",
+		w.Header().Get("Referrer-Policy"))
 	assert.Contains(t, w.Header().Get("Permissions-Policy"), "camera=()")
 	assert.Equal(t, "max-age=31536000; includeSubDomains",
 		w.Header().Get("Strict-Transport-Security"))
@@ -44,9 +55,13 @@ func TestSecurityHeaders_WithoutHSTS(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
-	assert.Equal(t, "DENY", w.Header().Get("X-Frame-Options"))
-	assert.Contains(t, w.Header().Get("Content-Security-Policy"), "default-src 'self'")
-	assert.Empty(t, w.Header().Get("Strict-Transport-Security"),
+	assert.Equal(t, "nosniff",
+		w.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, "DENY",
+		w.Header().Get("X-Frame-Options"))
+	assert.Contains(t,
+		w.Header().Get("Content-Security-Policy"), "default-src 'self'")
+	assert.Empty(t,
+		w.Header().Get("Strict-Transport-Security"),
 		"HSTS must not be set for HTTP")
 }


### PR DESCRIPTION
## Summary
- Add `SecurityHeaders` middleware setting CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy on all responses
- HSTS (`Strict-Transport-Security`) is only enabled when `BASE_URL` starts with `https://`, so local HTTP development is unaffected
- CSP allows cdn.jsdelivr.net, Google Fonts, and unsafe-inline scripts used by templates

## Test plan
- [x] `TestSecurityHeaders_WithHSTS` — verifies all headers including HSTS when HTTPS
- [x] `TestSecurityHeaders_WithoutHSTS` — verifies HSTS is absent for HTTP
- [x] `make test` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)