### PR TITLE
docs(jwt): enhance JWT verification guide with missing details

### DIFF
--- a/internal/templates/docs/jwt-verification.md
+++ b/internal/templates/docs/jwt-verification.md
@@ -379,11 +379,11 @@ server.listen(8081, () => console.log("Resource server on :8081"));
 
 ### Timeline
 
-```
-T+0:    AuthGate restarts with new key; JWKS endpoint serves new public key
-T+0~1h: Resource servers with cached old JWKS re-fetch on unknown kid
-T+1h:   All old access tokens have expired (default expiry = 1 hour)
-```
+| Time   | Event                                                                  |
+| ------ | ---------------------------------------------------------------------- |
+| T+0    | AuthGate restarts with new key; JWKS endpoint serves new public key    |
+| T+0~1h | Resource servers with cached old JWKS re-fetch on unknown `kid`        |
+| T+1h   | All old access tokens have expired (default expiry = 1 hour)           |
 
 > **Limitations**: AuthGate serves a single active public key in the JWKS response. During rotation, resource servers that don't handle unknown `kid` gracefully may reject new tokens until their JWKS cache expires (up to 1 hour). Once a resource server refreshes to the new JWKS, it can no longer verify still-unexpired tokens signed with the old key. To minimize disruption, use short-lived access tokens or schedule rotation during low-traffic periods.
 


### PR DESCRIPTION
## Summary

- Add algorithm comparison table (HS256/RS256/ES256) with recommendation
- Add missing `iat` claim to the JWT claims table (was in JSON example but not in the table)
- Add scope checking to all three code examples (Go, Python, Node.js) to match verification step 6
- Add HS256 behavior note under JWKS Endpoint section
- Add "Cache by `kid`" best practice to caching table
- Expand Key Rotation with timeline (T+0 → T+1h) and single-key limitation
- Add two new Common Pitfalls (`kid` header checking, JWKS re-fetch on unknown `kid`) and clock skew tolerance guidance

## Test plan

- [ ] Verify the Mermaid diagrams render correctly on GitHub
- [ ] Review code examples for correctness (scope checking logic)
- [ ] Confirm claims table now matches the JSON payload example

🤖 Generated with [Claude Code](https://claude.com/claude-code)