### PR TITLE
refactor(cache): add NoopCache to eliminate nil checks in token service

### DIFF
--- a/internal/bootstrap/cache.go
+++ b/internal/bootstrap/cache.go
@@ -119,7 +119,8 @@ func initializeTokenCache(
 	cfg *config.Config,
 ) (core.Cache[models.AccessToken], func() error, error) {
 	if !cfg.TokenCacheEnabled {
-		return nil, nil, nil
+		noop := cache.NewNoopCache[models.AccessToken]()
+		return noop, noop.Close, nil
 	}
 	return initializeCache[models.AccessToken](ctx, cfg, cacheOpts{
 		cacheType:   cfg.TokenCacheType,

--- a/internal/cache/noop.go
+++ b/internal/cache/noop.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-authgate/authgate/internal/core"
+)
+
+// Compile-time interface check.
+var _ core.Cache[struct{}] = (*NoopCache[struct{}])(nil)
+
+// NoopCache implements Cache interface with no-op behavior.
+// Used when caching is disabled.
+type NoopCache[T any] struct{}
+
+// NewNoopCache creates a new no-op cache instance.
+func NewNoopCache[T any]() *NoopCache[T] {
+	return &NoopCache[T]{}
+}
+
+// Get always returns ErrCacheMiss.
+func (n *NoopCache[T]) Get(_ context.Context, _ string) (T, error) {
+	var zero T
+	return zero, ErrCacheMiss
+}
+
+// Set is a no-op.
+func (n *NoopCache[T]) Set(_ context.Context, _ string, _ T, _ time.Duration) error {
+	return nil
+}
+
+// Delete is a no-op.
+func (n *NoopCache[T]) Delete(_ context.Context, _ string) error {
+	return nil
+}
+
+// Close is a no-op.
+func (n *NoopCache[T]) Close() error {
+	return nil
+}
+
+// Health always reports healthy.
+func (n *NoopCache[T]) Health(_ context.Context) error {
+	return nil
+}
+
+// GetWithFetch delegates directly to fetchFunc, bypassing any caching.
+func (n *NoopCache[T]) GetWithFetch(
+	ctx context.Context,
+	key string,
+	_ time.Duration,
+	fetchFunc func(ctx context.Context, key string) (T, error),
+) (T, error) {
+	return fetchFunc(ctx, key)
+}

--- a/internal/cache/noop_test.go
+++ b/internal/cache/noop_test.go
@@ -1,0 +1,85 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestNoopCache_Get(t *testing.T) {
+	c := NewNoopCache[string]()
+	_, err := c.Get(context.Background(), "key")
+	if !errors.Is(err, ErrCacheMiss) {
+		t.Fatalf("Get: want ErrCacheMiss, got %v", err)
+	}
+}
+
+func TestNoopCache_Set(t *testing.T) {
+	c := NewNoopCache[string]()
+	if err := c.Set(context.Background(), "key", "val", time.Minute); err != nil {
+		t.Fatalf("Set: unexpected error: %v", err)
+	}
+	// Value should not be retained
+	_, err := c.Get(context.Background(), "key")
+	if !errors.Is(err, ErrCacheMiss) {
+		t.Fatalf("Get after Set: want ErrCacheMiss, got %v", err)
+	}
+}
+
+func TestNoopCache_Delete(t *testing.T) {
+	c := NewNoopCache[string]()
+	if err := c.Delete(context.Background(), "key"); err != nil {
+		t.Fatalf("Delete: unexpected error: %v", err)
+	}
+}
+
+func TestNoopCache_Close(t *testing.T) {
+	c := NewNoopCache[string]()
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: unexpected error: %v", err)
+	}
+}
+
+func TestNoopCache_Health(t *testing.T) {
+	c := NewNoopCache[string]()
+	if err := c.Health(context.Background()); err != nil {
+		t.Fatalf("Health: unexpected error: %v", err)
+	}
+}
+
+func TestNoopCache_GetWithFetch(t *testing.T) {
+	c := NewNoopCache[int]()
+	called := false
+	val, err := c.GetWithFetch(context.Background(), "k", time.Minute,
+		func(_ context.Context, key string) (int, error) {
+			called = true
+			if key != "k" {
+				t.Fatalf("fetchFunc received key %q, want %q", key, "k")
+			}
+			return 42, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("GetWithFetch: unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("GetWithFetch: fetchFunc was not called")
+	}
+	if val != 42 {
+		t.Fatalf("GetWithFetch: got %d, want 42", val)
+	}
+}
+
+func TestNoopCache_GetWithFetch_PropagatesError(t *testing.T) {
+	c := NewNoopCache[int]()
+	wantErr := errors.New("db down")
+	_, err := c.GetWithFetch(context.Background(), "k", time.Minute,
+		func(_ context.Context, _ string) (int, error) {
+			return 0, wantErr
+		},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("GetWithFetch: got error %v, want %v", err, wantErr)
+	}
+}

--- a/internal/handlers/session_test.go
+++ b/internal/handlers/session_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-authgate/authgate/internal/cache"
 	"github.com/go-authgate/authgate/internal/config"
 	"github.com/go-authgate/authgate/internal/metrics"
 	"github.com/go-authgate/authgate/internal/models"
@@ -41,7 +42,8 @@ func setupSessionServices(t *testing.T) (*store.Store, *services.TokenService) {
 	auditSvc := services.NewAuditService(s, false, 0)
 	deviceSvc := services.NewDeviceService(s, cfg, auditSvc, metrics.NewNoopMetrics())
 	tokenSvc := services.NewTokenService(
-		s, cfg, deviceSvc, localProvider, auditSvc, metrics.NewNoopMetrics(), nil,
+		s, cfg, deviceSvc, localProvider, auditSvc, metrics.NewNoopMetrics(),
+		cache.NewNoopCache[models.AccessToken](),
 	)
 
 	return s, tokenSvc

--- a/internal/handlers/token_client_credentials_test.go
+++ b/internal/handlers/token_client_credentials_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-authgate/authgate/internal/cache"
 	"github.com/go-authgate/authgate/internal/config"
 	"github.com/go-authgate/authgate/internal/core"
 	"github.com/go-authgate/authgate/internal/metrics"
@@ -46,7 +47,8 @@ func setupCCTestEnv(t *testing.T) (*gin.Engine, *store.Store) {
 	auditSvc := services.NewAuditService(s, false, 0)
 	deviceSvc := services.NewDeviceService(s, cfg, auditSvc, metrics.NewNoopMetrics())
 	tokenSvc := services.NewTokenService(
-		s, cfg, deviceSvc, localProvider, auditSvc, metrics.NewNoopMetrics(), nil,
+		s, cfg, deviceSvc, localProvider, auditSvc, metrics.NewNoopMetrics(),
+		cache.NewNoopCache[models.AccessToken](),
 	)
 	authzSvc := services.NewAuthorizationService(s, cfg, auditSvc)
 	handler := NewTokenHandler(tokenSvc, authzSvc, cfg)

--- a/internal/handlers/token_introspect_test.go
+++ b/internal/handlers/token_introspect_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-authgate/authgate/internal/cache"
 	"github.com/go-authgate/authgate/internal/config"
 	"github.com/go-authgate/authgate/internal/core"
 	"github.com/go-authgate/authgate/internal/metrics"
@@ -47,7 +48,8 @@ func setupIntrospectTestEnv(t *testing.T) (*gin.Engine, *store.Store, *services.
 	auditSvc := services.NewAuditService(s, false, 0)
 	deviceSvc := services.NewDeviceService(s, cfg, auditSvc, metrics.NewNoopMetrics())
 	tokenSvc := services.NewTokenService(
-		s, cfg, deviceSvc, localProvider, auditSvc, metrics.NewNoopMetrics(), nil,
+		s, cfg, deviceSvc, localProvider, auditSvc, metrics.NewNoopMetrics(),
+		cache.NewNoopCache[models.AccessToken](),
 	)
 	authzSvc := services.NewAuthorizationService(s, cfg, auditSvc)
 	handler := NewTokenHandler(tokenSvc, authzSvc, cfg)

--- a/internal/services/token.go
+++ b/internal/services/token.go
@@ -80,42 +80,38 @@ func (s *TokenService) getAccessTokenByHash(
 	ctx context.Context,
 	hash string,
 ) (*models.AccessToken, error) {
-	if s.tokenCache != nil {
-		tok, err := s.tokenCache.GetWithFetch(ctx, hash, s.config.TokenCacheTTL,
-			func(ctx context.Context, key string) (models.AccessToken, error) {
-				t, err := s.store.GetAccessTokenByHash(key)
-				if err != nil {
-					return models.AccessToken{}, err
-				}
-				return *t, nil
-			},
-		)
-		if err == nil {
-			return &tok, nil
-		}
-		// If the fetch function itself returned a DB error (e.g. record not found),
-		// propagate it. Otherwise, the cache backend failed — fall back to DB.
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, err
-		}
-		log.Printf("[TokenCache] cache lookup failed, falling back to DB: %v", err)
+	tok, err := s.tokenCache.GetWithFetch(ctx, hash, s.config.TokenCacheTTL,
+		func(ctx context.Context, key string) (models.AccessToken, error) {
+			t, err := s.store.GetAccessTokenByHash(key)
+			if err != nil {
+				return models.AccessToken{}, err
+			}
+			return *t, nil
+		},
+	)
+	if err == nil {
+		return &tok, nil
 	}
+	// If the fetch function itself returned a DB error (e.g. record not found),
+	// propagate it. Otherwise, the cache backend failed — fall back to DB.
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+	log.Printf("[TokenCache] cache lookup failed, falling back to DB: %v", err)
 	return s.store.GetAccessTokenByHash(hash)
 }
 
 // invalidateTokenCache removes a token from cache by its hash.
 func (s *TokenService) invalidateTokenCache(ctx context.Context, hash string) {
-	if s.tokenCache != nil {
-		if err := s.tokenCache.Delete(ctx, hash); err != nil {
-			hashPrefix := hash
-			if len(hashPrefix) > 8 {
-				hashPrefix = hashPrefix[:8]
-			}
-			log.Printf(
-				"[TokenCache] failed to invalidate cache for hash=%s...: %v",
-				hashPrefix, err,
-			)
+	if err := s.tokenCache.Delete(ctx, hash); err != nil {
+		hashPrefix := hash
+		if len(hashPrefix) > 8 {
+			hashPrefix = hashPrefix[:8]
 		}
+		log.Printf(
+			"[TokenCache] failed to invalidate cache for hash=%s...: %v",
+			hashPrefix, err,
+		)
 	}
 }
 

--- a/internal/services/token_cache_bench_test.go
+++ b/internal/services/token_cache_bench_test.go
@@ -49,6 +49,8 @@ func newBenchEnv(b *testing.B, withCache bool) *benchTokenEnv {
 	var tokenCache core.Cache[models.AccessToken]
 	if withCache {
 		tokenCache = cache.NewMemoryCache[models.AccessToken]()
+	} else {
+		tokenCache = cache.NewNoopCache[models.AccessToken]()
 	}
 	svc := NewTokenService(
 		s, cfg, deviceSvc, localProvider, nil, metrics.NewNoopMetrics(), tokenCache,

--- a/internal/services/token_cache_test.go
+++ b/internal/services/token_cache_test.go
@@ -161,8 +161,8 @@ func TestValidateToken_CacheInvalidatedOnDisable(t *testing.T) {
 	assert.Error(t, err, "cache should be invalidated after disable")
 }
 
-func TestValidateToken_NilCache(t *testing.T) {
-	// Test that everything works when cache is nil (disabled)
+func TestValidateToken_NoopCache(t *testing.T) {
+	// Test that everything works when cache is a no-op (disabled)
 	s := setupTestStore(t)
 	cfg := &config.Config{
 		JWTExpiration:                    1 * time.Hour,
@@ -174,7 +174,8 @@ func TestValidateToken_NilCache(t *testing.T) {
 	require.NoError(t, err)
 	deviceService := NewDeviceService(s, cfg, nil, metrics.NewNoopMetrics())
 	svc := NewTokenService(
-		s, cfg, deviceService, localProvider, nil, metrics.NewNoopMetrics(), nil,
+		s, cfg, deviceService, localProvider, nil, metrics.NewNoopMetrics(),
+		cache.NewNoopCache[models.AccessToken](),
 	)
 
 	ctx := context.Background()

--- a/internal/services/token_client_credentials_test.go
+++ b/internal/services/token_client_credentials_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-authgate/authgate/internal/cache"
 	"github.com/go-authgate/authgate/internal/config"
 	"github.com/go-authgate/authgate/internal/core"
 	"github.com/go-authgate/authgate/internal/metrics"
@@ -61,7 +62,7 @@ func newCCTokenService(t *testing.T) (*TokenService, *store.Store) {
 		localProvider,
 		nil,
 		metrics.NewNoopMetrics(),
-		nil,
+		cache.NewNoopCache[models.AccessToken](),
 	)
 	return svc, s
 }

--- a/internal/services/token_introspect_test.go
+++ b/internal/services/token_introspect_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-authgate/authgate/internal/cache"
 	"github.com/go-authgate/authgate/internal/config"
 	"github.com/go-authgate/authgate/internal/metrics"
 	"github.com/go-authgate/authgate/internal/models"
@@ -28,7 +29,8 @@ func newIntrospectTokenService(t *testing.T) (*TokenService, *store.Store) {
 	}
 	localProvider, err := token.NewLocalTokenProvider(cfg)
 	require.NoError(t, err)
-	svc := NewTokenService(s, cfg, nil, localProvider, nil, metrics.NewNoopMetrics(), nil)
+	svc := NewTokenService(s, cfg, nil, localProvider, nil, metrics.NewNoopMetrics(),
+		cache.NewNoopCache[models.AccessToken]())
 	return svc, s
 }
 

--- a/internal/services/token_management.go
+++ b/internal/services/token_management.go
@@ -89,18 +89,16 @@ func (s *TokenService) RevokeAllUserTokens(userID string) error {
 	// Collect hashes before deletion so we can invalidate the cache,
 	// but only invalidate if revocation succeeds.
 	var hashes []string
-	if s.tokenCache != nil {
-		if tokens, err := s.store.GetTokensByUserID(userID); err == nil {
-			hashes = make([]string, 0, len(tokens))
-			for _, t := range tokens {
-				hashes = append(hashes, t.TokenHash)
-			}
-		} else {
-			log.Printf(
-				"[TokenCache] failed to collect user token hashes for invalidation user=%s: %v",
-				userID, err,
-			)
+	if tokens, err := s.store.GetTokensByUserID(userID); err == nil {
+		hashes = make([]string, 0, len(tokens))
+		for _, t := range tokens {
+			hashes = append(hashes, t.TokenHash)
 		}
+	} else {
+		log.Printf(
+			"[TokenCache] failed to collect user token hashes for invalidation user=%s: %v",
+			userID, err,
+		)
 	}
 
 	if err := s.store.RevokeTokensByUserID(userID); err != nil {

--- a/internal/services/token_refresh.go
+++ b/internal/services/token_refresh.go
@@ -30,16 +30,12 @@ func (s *TokenService) revokeTokenFamilyWithAudit(
 	}
 
 	// Collect hashes before revocation for cache invalidation
-	var hashesToInvalidate []string
-	if s.tokenCache != nil {
-		var err error
-		hashesToInvalidate, err = s.store.GetActiveTokenHashesByFamilyID(familyID)
-		if err != nil {
-			log.Printf(
-				"[TokenCache] failed to collect family hashes for invalidation family=%s: %v",
-				familyID, err,
-			)
-		}
+	hashesToInvalidate, err := s.store.GetActiveTokenHashesByFamilyID(familyID)
+	if err != nil {
+		log.Printf(
+			"[TokenCache] failed to collect family hashes for invalidation family=%s: %v",
+			familyID, err,
+		)
 	}
 
 	revokedCount, err := s.store.RevokeTokenFamily(familyID)

--- a/internal/services/token_test.go
+++ b/internal/services/token_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-authgate/authgate/internal/cache"
 	"github.com/go-authgate/authgate/internal/config"
 	"github.com/go-authgate/authgate/internal/metrics"
 	"github.com/go-authgate/authgate/internal/models"
@@ -29,7 +30,7 @@ func createTestTokenService(t *testing.T, s *store.Store, cfg *config.Config) *T
 		localProvider,
 		nil,
 		metrics.NewNoopMetrics(),
-		nil,
+		cache.NewNoopCache[models.AccessToken](),
 	)
 }
 


### PR DESCRIPTION
## Summary

- Introduce NoopCache[T] (Null Object Pattern) implementing core.Cache[T] with no-op behavior, matching the existing NoopMetrics pattern
- Wire NoopCache in bootstrap when token cache is disabled instead of returning nil
- Remove all 4 if s.tokenCache != nil guards across token.go, token_management.go, and token_refresh.go
- Update all test call sites (8 files) to use NoopCache instead of nil

## Motivation

The TokenService had repeated if s.tokenCache != nil checks before every cache operation. This is the classic case for the Null Object Pattern — provide a no-op implementation that is always safe to call, eliminating defensive nil checks and reducing nesting.

## Test plan

- [x] NoopCache unit tests cover all 7 interface methods including error propagation
- [x] All service tests pass (go test ./internal/services/... -v)
- [x] Benchmarks confirm performance parity (BenchmarkValidateToken_NoCache / BenchmarkValidateToken_WithCache)
- [x] grep -rn tokenCache != nil internal/services/ returns 0 results

Generated with [Claude Code](https://claude.com/claude-code)