### PR TITLE
fix(ui): disable auto-submit on search toolbar input

### DIFF
--- a/internal/templates/search_filter_toolbar_component.templ
+++ b/internal/templates/search_filter_toolbar_component.templ
@@ -30,7 +30,6 @@ templ SfSearchRow(props SfSearchRowProps) {
 				class="search-input"
 				placeholder={ props.Placeholder }
 				value={ props.Search }
-				data-debounce-search
 			/>
 		</div>
 		<select name="page_size" id="page_size" class="page-size-select" onchange="this.form.submit()">


### PR DESCRIPTION
## Summary
- Remove `data-debounce-search` attribute from the shared search toolbar input
- Search now only submits when the user clicks the "Search" button or presses Enter, instead of auto-submitting after every keystroke (300ms debounce)

## Test plan
- [ ] Visit any page with the search toolbar (e.g., `/admin/clients`, `/account/sessions`, `/admin/audit`)
- [ ] Type in the search box — confirm it does **not** auto-submit
- [ ] Click "Search" button — confirm it submits
- [ ] Press Enter in the search box — confirm it submits
- [ ] Verify page size dropdown still auto-submits on change

🤖 Generated with [Claude Code](https://claude.ai/claude-code)