### PR TITLE
refactor(security): fix info disclosure, TOCTOU race, and reduce parameter sprawl

### DIFF
--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -62,6 +62,7 @@ type DeviceCodeStore interface {
 	GetDeviceCodesByID(deviceCodeID string) ([]*models.DeviceCode, error)
 	GetDeviceCodeByUserCode(userCode string) (*models.DeviceCode, error)
 	UpdateDeviceCode(dc *models.DeviceCode) error
+	AuthorizeDeviceCode(id int64, userID string) error
 	DeleteDeviceCodeByID(id int64) error
 }
 

--- a/internal/handlers/authorization.go
+++ b/internal/handlers/authorization.go
@@ -56,7 +56,7 @@ func (h *AuthorizationHandler) ShowAuthorizePage(c *gin.Context) {
 
 	// Validate the authorization request parameters
 	req, err := h.authorizationService.ValidateAuthorizationRequest(
-		clientID, redirectURI, responseType, scope, codeChallengeMethod, nonce,
+		clientID, redirectURI, responseType, scope, codeChallenge, codeChallengeMethod, nonce,
 	)
 	if err != nil {
 		h.redirectWithError(c, redirectURI, state, oauthErrorCode(err), err.Error())
@@ -77,16 +77,7 @@ func (h *AuthorizationHandler) ShowAuthorizePage(c *gin.Context) {
 	if h.config.ConsentRemember {
 		existing, _ := h.authorizationService.GetUserAuthorization(userIDStr, req.Client.ID)
 		if existing != nil && util.IsScopeSubset(existing.Scopes, req.Scopes) {
-			h.issueCodeAndRedirect(
-				c,
-				req,
-				userIDStr,
-				redirectURI,
-				state,
-				nonce,
-				codeChallenge,
-				codeChallengeMethod,
-			)
+			h.issueCodeAndRedirect(c, req, userIDStr, state)
 			return
 		}
 	}
@@ -99,13 +90,13 @@ func (h *AuthorizationHandler) ShowAuthorizePage(c *gin.Context) {
 		ClientID:            req.Client.ClientID,
 		ClientName:          req.Client.ClientName,
 		ClientDescription:   req.Client.Description,
-		RedirectURI:         redirectURI,
+		RedirectURI:         req.RedirectURI,
 		Scopes:              req.Scopes,
 		ScopeList:           strings.Fields(req.Scopes),
 		State:               state,
-		Nonce:               nonce,
-		CodeChallenge:       codeChallenge,
-		CodeChallengeMethod: codeChallengeMethod,
+		Nonce:               req.Nonce,
+		CodeChallenge:       req.CodeChallenge,
+		CodeChallengeMethod: req.CodeChallengeMethod,
 	}))
 }
 
@@ -139,7 +130,7 @@ func (h *AuthorizationHandler) HandleAuthorize(c *gin.Context) {
 
 	// Re-validate request on POST to prevent parameter tampering
 	req, err := h.authorizationService.ValidateAuthorizationRequest(
-		clientID, redirectURI, "code", scope, codeChallengeMethod, nonce,
+		clientID, redirectURI, "code", scope, codeChallenge, codeChallengeMethod, nonce,
 	)
 	if err != nil {
 		h.redirectWithError(c, redirectURI, state, oauthErrorCode(err), err.Error())
@@ -160,32 +151,32 @@ func (h *AuthorizationHandler) HandleAuthorize(c *gin.Context) {
 		return
 	}
 
-	h.issueCodeAndRedirect(
-		c, req, userIDStr, redirectURI, state, nonce, codeChallenge, codeChallengeMethod,
-	)
+	h.issueCodeAndRedirect(c, req, userIDStr, state)
 }
 
 // issueCodeAndRedirect generates an authorization code and redirects to the client's redirect_uri.
 func (h *AuthorizationHandler) issueCodeAndRedirect(
 	c *gin.Context,
 	req *services.AuthorizationRequest,
-	userID, redirectURI, state, nonce, codeChallenge, codeChallengeMethod string,
+	userID, state string,
 ) {
 	plainCode, _, err := h.authorizationService.CreateAuthorizationCode(
 		c.Request.Context(),
-		req.Client.ID,
-		req.Client.ClientID,
-		userID,
-		redirectURI,
-		req.Scopes,
-		codeChallenge,
-		codeChallengeMethod,
-		nonce,
+		services.CreateAuthorizationCodeParams{
+			ApplicationID:       req.Client.ID,
+			ClientID:            req.Client.ClientID,
+			UserID:              userID,
+			RedirectURI:         req.RedirectURI,
+			Scopes:              req.Scopes,
+			CodeChallenge:       req.CodeChallenge,
+			CodeChallengeMethod: req.CodeChallengeMethod,
+			Nonce:               req.Nonce,
+		},
 	)
 	if err != nil {
 		h.redirectWithError(
 			c,
-			redirectURI,
+			req.RedirectURI,
 			state,
 			errServerError,
 			"Failed to generate authorization code",
@@ -193,7 +184,7 @@ func (h *AuthorizationHandler) issueCodeAndRedirect(
 		return
 	}
 
-	u, err := url.Parse(redirectURI)
+	u, err := url.Parse(req.RedirectURI)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid redirect_uri"})
 		return

--- a/internal/handlers/device.go
+++ b/internal/handlers/device.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"log"
 	"net/http"
 
 	"github.com/go-authgate/authgate/internal/config"
@@ -21,6 +22,8 @@ func deviceCodeErrorMessage(err error) string {
 		return "User code not found"
 	case errors.Is(err, services.ErrDeviceCodeExpired):
 		return "Code has expired, please request a new one"
+	case errors.Is(err, services.ErrDeviceCodeAlreadyAuthorized):
+		return "This code has already been authorized"
 	default:
 		return "Invalid or expired code"
 	}
@@ -124,7 +127,13 @@ func (h *DeviceHandler) DeviceCodeRequest(c *gin.Context) {
 			)
 			return
 		}
-		respondOAuthError(c, http.StatusInternalServerError, errServerError, err.Error())
+		log.Printf("[device] device code generation error: %v", err)
+		respondOAuthError(
+			c,
+			http.StatusInternalServerError,
+			errServerError,
+			"An internal error occurred",
+		)
 		return
 	}
 

--- a/internal/handlers/token.go
+++ b/internal/handlers/token.go
@@ -491,10 +491,28 @@ func (h *TokenHandler) handleAuthorizationCodeGrant(c *gin.Context) {
 	)
 	if err != nil {
 		errCode := errInvalidGrant
-		if errors.Is(err, services.ErrUnauthorizedClient) {
+		var description string
+		switch {
+		case errors.Is(err, services.ErrUnauthorizedClient):
 			errCode = errUnauthorizedClient
+			description = "Client authentication failed"
+		case errors.Is(err, services.ErrAuthCodeNotFound):
+			description = "Authorization code is invalid or expired"
+		case errors.Is(err, services.ErrAuthCodeExpired):
+			description = "Authorization code has expired"
+		case errors.Is(err, services.ErrAuthCodeAlreadyUsed):
+			description = "Authorization code has already been used"
+		case errors.Is(err, services.ErrInvalidRedirectURI):
+			description = "Redirect URI does not match"
+		case errors.Is(err, services.ErrPKCERequired):
+			description = "PKCE code_verifier is required for public clients"
+		case errors.Is(err, services.ErrInvalidCodeVerifier):
+			description = "PKCE code_verifier validation failed"
+		default:
+			log.Printf("[token] authorization code exchange error: %v", err)
+			description = "An internal error occurred"
 		}
-		respondOAuthError(c, http.StatusBadRequest, errCode, err.Error())
+		respondOAuthError(c, http.StatusBadRequest, errCode, description)
 		return
 	}
 

--- a/internal/mocks/mock_store.go
+++ b/internal/mocks/mock_store.go
@@ -421,6 +421,20 @@ func (m *MockDeviceCodeStore) EXPECT() *MockDeviceCodeStoreMockRecorder {
 	return m.recorder
 }
 
+// AuthorizeDeviceCode mocks base method.
+func (m *MockDeviceCodeStore) AuthorizeDeviceCode(id int64, userID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthorizeDeviceCode", id, userID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AuthorizeDeviceCode indicates an expected call of AuthorizeDeviceCode.
+func (mr *MockDeviceCodeStoreMockRecorder) AuthorizeDeviceCode(id, userID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeDeviceCode", reflect.TypeOf((*MockDeviceCodeStore)(nil).AuthorizeDeviceCode), id, userID)
+}
+
 // CreateDeviceCode mocks base method.
 func (m *MockDeviceCodeStore) CreateDeviceCode(dc *models.DeviceCode) error {
 	m.ctrl.T.Helper()
@@ -1357,6 +1371,20 @@ func NewMockStore(ctrl *gomock.Controller) *MockStore {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 	return m.recorder
+}
+
+// AuthorizeDeviceCode mocks base method.
+func (m *MockStore) AuthorizeDeviceCode(id int64, userID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthorizeDeviceCode", id, userID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AuthorizeDeviceCode indicates an expected call of AuthorizeDeviceCode.
+func (mr *MockStoreMockRecorder) AuthorizeDeviceCode(id, userID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeDeviceCode", reflect.TypeOf((*MockStore)(nil).AuthorizeDeviceCode), id, userID)
 }
 
 // Close mocks base method.

--- a/internal/services/authorization.go
+++ b/internal/services/authorization.go
@@ -74,7 +74,7 @@ func NewAuthorizationService(
 // ValidateAuthorizationRequest validates all parameters of an incoming authorization request.
 // Returns the parsed AuthorizationRequest on success.
 func (s *AuthorizationService) ValidateAuthorizationRequest(
-	clientID, redirectURI, responseType, scope, codeChallengeMethod, nonce string,
+	clientID, redirectURI, responseType, scope, codeChallenge, codeChallengeMethod, nonce string,
 ) (*AuthorizationRequest, error) {
 	// 1. response_type must be "code"
 	if responseType != "code" {
@@ -126,17 +126,29 @@ func (s *AuthorizationService) ValidateAuthorizationRequest(
 		Client:              client,
 		RedirectURI:         redirectURI,
 		Scopes:              scope,
+		CodeChallenge:       codeChallenge,
 		CodeChallengeMethod: codeChallengeMethod,
 		Nonce:               nonce,
 	}, nil
+}
+
+// CreateAuthorizationCodeParams bundles the inputs for authorization code creation.
+type CreateAuthorizationCodeParams struct {
+	ApplicationID       int64
+	ClientID            string
+	UserID              string
+	RedirectURI         string
+	Scopes              string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	Nonce               string
 }
 
 // CreateAuthorizationCode generates a one-time authorization code and saves it to the database.
 // Returns the plaintext code (to be sent in the redirect) and the stored record.
 func (s *AuthorizationService) CreateAuthorizationCode(
 	ctx context.Context,
-	applicationID int64,
-	clientID, userID, redirectURI, scopes, codeChallenge, codeChallengeMethod, nonce string,
+	params CreateAuthorizationCodeParams,
 ) (plainCode string, record *models.AuthorizationCode, err error) {
 	// Generate 32 cryptographically random bytes (256-bit entropy)
 	rawBytes, err := util.CryptoRandomBytes(32)
@@ -153,14 +165,14 @@ func (s *AuthorizationService) CreateAuthorizationCode(
 		UUID:                uuid.New().String(),
 		CodeHash:            codeHash,
 		CodePrefix:          codePrefix,
-		ApplicationID:       applicationID,
-		ClientID:            clientID,
-		UserID:              userID,
-		RedirectURI:         redirectURI,
-		Scopes:              scopes,
-		CodeChallenge:       codeChallenge,
-		CodeChallengeMethod: codeChallengeMethod,
-		Nonce:               nonce,
+		ApplicationID:       params.ApplicationID,
+		ClientID:            params.ClientID,
+		UserID:              params.UserID,
+		RedirectURI:         params.RedirectURI,
+		Scopes:              params.Scopes,
+		CodeChallenge:       params.CodeChallenge,
+		CodeChallengeMethod: params.CodeChallengeMethod,
+		Nonce:               params.Nonce,
 		ExpiresAt:           time.Now().Add(s.config.AuthCodeExpiration),
 	}
 
@@ -172,15 +184,15 @@ func (s *AuthorizationService) CreateAuthorizationCode(
 		s.auditService.Log(ctx, AuditLogEntry{
 			EventType:    models.EventAuthorizationCodeGenerated,
 			Severity:     models.SeverityInfo,
-			ActorUserID:  userID,
+			ActorUserID:  params.UserID,
 			ResourceType: models.ResourceAuthorization,
 			ResourceID:   record.UUID,
 			Action:       "Authorization code generated",
 			Details: models.AuditDetails{
-				"client_id":    clientID,
-				"scopes":       scopes,
-				"pkce":         codeChallenge != "",
-				"redirect_uri": redirectURI,
+				"client_id":    params.ClientID,
+				"scopes":       params.Scopes,
+				"pkce":         params.CodeChallenge != "",
+				"redirect_uri": params.RedirectURI,
 			},
 			Success: true,
 		})

--- a/internal/services/authorization_test.go
+++ b/internal/services/authorization_test.go
@@ -74,8 +74,7 @@ func TestValidateAuthorizationRequest_Success(t *testing.T) {
 		"https://app.example.com/callback",
 		"code",
 		"read",
-		"",
-		"",
+		"", "", "",
 	)
 
 	require.NoError(t, err)
@@ -88,7 +87,7 @@ func TestValidateAuthorizationRequest_DefaultScope(t *testing.T) {
 	client := createAuthCodeFlowClient(t, svc, "confidential")
 
 	req, err := svc.ValidateAuthorizationRequest(
-		client.ClientID, "https://app.example.com/callback", "code", "", "", "",
+		client.ClientID, "https://app.example.com/callback", "code", "", "", "", "",
 	)
 
 	require.NoError(t, err)
@@ -101,7 +100,7 @@ func TestValidateAuthorizationRequest_InvalidResponseType(t *testing.T) {
 	client := createAuthCodeFlowClient(t, svc, "confidential")
 
 	_, err := svc.ValidateAuthorizationRequest(
-		client.ClientID, "https://app.example.com/callback", "token", "", "", "",
+		client.ClientID, "https://app.example.com/callback", "token", "", "", "", "",
 	)
 	assert.ErrorIs(t, err, ErrUnsupportedResponseType)
 }
@@ -110,7 +109,7 @@ func TestValidateAuthorizationRequest_UnknownClient(t *testing.T) {
 	svc := createTestAuthorizationService(t)
 
 	_, err := svc.ValidateAuthorizationRequest(
-		"nonexistent", "https://app.example.com/callback", "code", "", "", "",
+		"nonexistent", "https://app.example.com/callback", "code", "", "", "", "",
 	)
 	assert.ErrorIs(t, err, ErrUnauthorizedClient)
 }
@@ -132,7 +131,7 @@ func TestValidateAuthorizationRequest_AuthCodeFlowDisabled(t *testing.T) {
 	require.NoError(t, svc.store.CreateClient(client))
 
 	_, err := svc.ValidateAuthorizationRequest(
-		client.ClientID, "https://app.example.com/callback", "code", "", "", "",
+		client.ClientID, "https://app.example.com/callback", "code", "", "", "", "",
 	)
 	assert.ErrorIs(t, err, ErrUnauthorizedClient)
 }
@@ -142,7 +141,7 @@ func TestValidateAuthorizationRequest_InvalidRedirectURI(t *testing.T) {
 	client := createAuthCodeFlowClient(t, svc, "confidential")
 
 	_, err := svc.ValidateAuthorizationRequest(
-		client.ClientID, "https://evil.example.com/callback", "code", "", "", "",
+		client.ClientID, "https://evil.example.com/callback", "code", "", "", "", "",
 	)
 	assert.ErrorIs(t, err, ErrInvalidRedirectURI)
 }
@@ -152,7 +151,7 @@ func TestValidateAuthorizationRequest_InvalidScope(t *testing.T) {
 	client := createAuthCodeFlowClient(t, svc, "confidential")
 
 	_, err := svc.ValidateAuthorizationRequest(
-		client.ClientID, "https://app.example.com/callback", "code", "admin", "", "",
+		client.ClientID, "https://app.example.com/callback", "code", "admin", "", "", "",
 	)
 	assert.ErrorIs(t, err, ErrInvalidAuthCodeScope)
 }
@@ -163,7 +162,7 @@ func TestValidateAuthorizationRequest_PublicClientRequiresPKCE(t *testing.T) {
 
 	// No code_challenge_method → should fail for public client
 	_, err := svc.ValidateAuthorizationRequest(
-		client.ClientID, "https://app.example.com/callback", "code", "read", "", "",
+		client.ClientID, "https://app.example.com/callback", "code", "read", "", "", "",
 	)
 	assert.ErrorIs(t, err, ErrPKCERequired)
 }
@@ -174,7 +173,7 @@ func TestValidateAuthorizationRequest_PKCEPlainRejected(t *testing.T) {
 
 	// "plain" method must be rejected (only S256 is accepted)
 	_, err := svc.ValidateAuthorizationRequest(
-		client.ClientID, "https://app.example.com/callback", "code", "read", "plain", "",
+		client.ClientID, "https://app.example.com/callback", "code", "read", "", "plain", "",
 	)
 	assert.ErrorIs(t, err, ErrInvalidAuthCodeRequest)
 }
@@ -184,7 +183,7 @@ func TestValidateAuthorizationRequest_PublicClientWithPKCE(t *testing.T) {
 	client := createAuthCodeFlowClient(t, svc, "public")
 
 	req, err := svc.ValidateAuthorizationRequest(
-		client.ClientID, "https://app.example.com/callback", "code", "read", "S256", "",
+		client.ClientID, "https://app.example.com/callback", "code", "read", "", "S256", "",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "S256", req.CodeChallengeMethod)
@@ -201,12 +200,13 @@ func TestCreateAuthorizationCode_Success(t *testing.T) {
 
 	plainCode, record, err := svc.CreateAuthorizationCode(
 		context.Background(),
-		client.ID,
-		client.ClientID,
-		userID,
-		"https://app.example.com/callback",
-		"read write",
-		"", "", "",
+		CreateAuthorizationCodeParams{
+			ApplicationID: client.ID,
+			ClientID:      client.ClientID,
+			UserID:        userID,
+			RedirectURI:   "https://app.example.com/callback",
+			Scopes:        "read write",
+		},
 	)
 
 	require.NoError(t, err)
@@ -229,9 +229,15 @@ func TestCreateAuthorizationCode_WithPKCE(t *testing.T) {
 
 	_, record, err := svc.CreateAuthorizationCode(
 		context.Background(),
-		client.ID, client.ClientID, userID,
-		"https://app.example.com/callback", "read",
-		challenge, "S256", "",
+		CreateAuthorizationCodeParams{
+			ApplicationID:       client.ID,
+			ClientID:            client.ClientID,
+			UserID:              userID,
+			RedirectURI:         "https://app.example.com/callback",
+			Scopes:              "read",
+			CodeChallenge:       challenge,
+			CodeChallengeMethod: "S256",
+		},
 	)
 
 	require.NoError(t, err)
@@ -250,8 +256,13 @@ func TestExchangeCode_Success_ConfidentialClient(t *testing.T) {
 
 	plainCode, _, err := svc.CreateAuthorizationCode(
 		context.Background(),
-		client.ID, client.ClientID, userID,
-		"https://app.example.com/callback", "read write", "", "", "",
+		CreateAuthorizationCodeParams{
+			ApplicationID: client.ID,
+			ClientID:      client.ClientID,
+			UserID:        userID,
+			RedirectURI:   "https://app.example.com/callback",
+			Scopes:        "read write",
+		},
 	)
 	require.NoError(t, err)
 
@@ -282,9 +293,15 @@ func TestExchangeCode_Success_PublicClient_PKCE_S256(t *testing.T) {
 
 	plainCode, _, err := svc.CreateAuthorizationCode(
 		context.Background(),
-		client.ID, client.ClientID, userID,
-		"https://app.example.com/callback", "read",
-		challenge, "S256", "",
+		CreateAuthorizationCodeParams{
+			ApplicationID:       client.ID,
+			ClientID:            client.ClientID,
+			UserID:              userID,
+			RedirectURI:         "https://app.example.com/callback",
+			Scopes:              "read",
+			CodeChallenge:       challenge,
+			CodeChallengeMethod: "S256",
+		},
 	)
 	require.NoError(t, err)
 
@@ -304,8 +321,13 @@ func TestExchangeCode_ReplayAttack(t *testing.T) {
 
 	plainCode, _, err := svc.CreateAuthorizationCode(
 		context.Background(),
-		client.ID, client.ClientID, userID,
-		"https://app.example.com/callback", "read", "", "", "",
+		CreateAuthorizationCodeParams{
+			ApplicationID: client.ID,
+			ClientID:      client.ClientID,
+			UserID:        userID,
+			RedirectURI:   "https://app.example.com/callback",
+			Scopes:        "read",
+		},
 	)
 	require.NoError(t, err)
 
@@ -328,8 +350,13 @@ func TestExchangeCode_ExpiredCode(t *testing.T) {
 
 	plainCode, _, err := svc.CreateAuthorizationCode(
 		context.Background(),
-		client.ID, client.ClientID, userID,
-		"https://app.example.com/callback", "read", "", "", "",
+		CreateAuthorizationCodeParams{
+			ApplicationID: client.ID,
+			ClientID:      client.ClientID,
+			UserID:        userID,
+			RedirectURI:   "https://app.example.com/callback",
+			Scopes:        "read",
+		},
 	)
 	require.NoError(t, err)
 
@@ -345,8 +372,13 @@ func TestExchangeCode_WrongRedirectURI(t *testing.T) {
 
 	plainCode, _, err := svc.CreateAuthorizationCode(
 		context.Background(),
-		client.ID, client.ClientID, userID,
-		"https://app.example.com/callback", "read", "", "", "",
+		CreateAuthorizationCodeParams{
+			ApplicationID: client.ID,
+			ClientID:      client.ClientID,
+			UserID:        userID,
+			RedirectURI:   "https://app.example.com/callback",
+			Scopes:        "read",
+		},
 	)
 	require.NoError(t, err)
 
@@ -362,8 +394,13 @@ func TestExchangeCode_WrongClientSecret(t *testing.T) {
 
 	plainCode, _, err := svc.CreateAuthorizationCode(
 		context.Background(),
-		client.ID, client.ClientID, userID,
-		"https://app.example.com/callback", "read", "", "", "",
+		CreateAuthorizationCodeParams{
+			ApplicationID: client.ID,
+			ClientID:      client.ClientID,
+			UserID:        userID,
+			RedirectURI:   "https://app.example.com/callback",
+			Scopes:        "read",
+		},
 	)
 	require.NoError(t, err)
 
@@ -383,9 +420,15 @@ func TestExchangeCode_WrongCodeVerifier(t *testing.T) {
 
 	plainCode, _, err := svc.CreateAuthorizationCode(
 		context.Background(),
-		client.ID, client.ClientID, userID,
-		"https://app.example.com/callback", "read",
-		challenge, "S256", "",
+		CreateAuthorizationCodeParams{
+			ApplicationID:       client.ID,
+			ClientID:            client.ClientID,
+			UserID:              userID,
+			RedirectURI:         "https://app.example.com/callback",
+			Scopes:              "read",
+			CodeChallenge:       challenge,
+			CodeChallengeMethod: "S256",
+		},
 	)
 	require.NoError(t, err)
 
@@ -622,13 +665,13 @@ func TestValidateAuthorizationRequest_GlobalPKCERequired(t *testing.T) {
 
 	// Without PKCE → must fail
 	_, err := svc.ValidateAuthorizationRequest(
-		client.ClientID, "https://app.example.com/callback", "code", "read", "", "",
+		client.ClientID, "https://app.example.com/callback", "code", "read", "", "", "",
 	)
 	require.ErrorIs(t, err, ErrPKCERequired)
 
 	// With S256 → must succeed
 	req, err := svc.ValidateAuthorizationRequest(
-		client.ClientID, "https://app.example.com/callback", "code", "read", "S256", "",
+		client.ClientID, "https://app.example.com/callback", "code", "read", "", "S256", "",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "S256", req.CodeChallengeMethod)
@@ -640,7 +683,7 @@ func TestValidateAuthorizationRequest_UnsupportedChallengeMethod(t *testing.T) {
 
 	// "RS256" is not a valid code_challenge_method
 	_, err := svc.ValidateAuthorizationRequest(
-		client.ClientID, "https://app.example.com/callback", "code", "read", "RS256", "",
+		client.ClientID, "https://app.example.com/callback", "code", "read", "", "RS256", "",
 	)
 	assert.ErrorIs(t, err, ErrInvalidAuthCodeRequest)
 }
@@ -671,8 +714,13 @@ func TestExchangeCode_WrongClientID(t *testing.T) {
 
 	plainCode, _, err := svc.CreateAuthorizationCode(
 		context.Background(),
-		client.ID, client.ClientID, userID,
-		"https://app.example.com/callback", "read", "", "", "",
+		CreateAuthorizationCodeParams{
+			ApplicationID: client.ID,
+			ClientID:      client.ClientID,
+			UserID:        userID,
+			RedirectURI:   "https://app.example.com/callback",
+			Scopes:        "read",
+		},
 	)
 	require.NoError(t, err)
 
@@ -696,9 +744,13 @@ func TestExchangeCode_PublicClientMissingCodeChallenge(t *testing.T) {
 	// Create a code without a PKCE challenge (simulates a code stored without PKCE)
 	plainCode, _, err := svc.CreateAuthorizationCode(
 		context.Background(),
-		client.ID, client.ClientID, userID,
-		"https://app.example.com/callback", "read",
-		"", "", "", // no PKCE challenge, no nonce
+		CreateAuthorizationCodeParams{
+			ApplicationID: client.ID,
+			ClientID:      client.ClientID,
+			UserID:        userID,
+			RedirectURI:   "https://app.example.com/callback",
+			Scopes:        "read",
+		},
 	)
 	require.NoError(t, err)
 

--- a/internal/services/device.go
+++ b/internal/services/device.go
@@ -14,16 +14,18 @@ import (
 	"github.com/go-authgate/authgate/internal/config"
 	"github.com/go-authgate/authgate/internal/core"
 	"github.com/go-authgate/authgate/internal/models"
+	"github.com/go-authgate/authgate/internal/store"
 	"github.com/go-authgate/authgate/internal/util"
 )
 
 var (
-	ErrInvalidClient        = errors.New("invalid client_id")
-	ErrClientInactive       = errors.New("client is inactive")
-	ErrDeviceFlowNotEnabled = errors.New("device flow not enabled for this client")
-	ErrDeviceCodeNotFound   = errors.New("device code not found")
-	ErrDeviceCodeExpired    = errors.New("device code expired")
-	ErrUserCodeNotFound     = errors.New("user code not found")
+	ErrInvalidClient               = errors.New("invalid client_id")
+	ErrClientInactive              = errors.New("client is inactive")
+	ErrDeviceFlowNotEnabled        = errors.New("device flow not enabled for this client")
+	ErrDeviceCodeNotFound          = errors.New("device code not found")
+	ErrDeviceCodeExpired           = errors.New("device code expired")
+	ErrUserCodeNotFound            = errors.New("user code not found")
+	ErrDeviceCodeAlreadyAuthorized = errors.New("device code already authorized")
 )
 
 type DeviceService struct {
@@ -199,12 +201,11 @@ func (s *DeviceService) AuthorizeDeviceCode(
 		return err
 	}
 
-	dc.UserID = userID
-	dc.Authorized = true
-	dc.AuthorizedAt = time.Now()
-
-	err = s.store.UpdateDeviceCode(dc)
+	err = s.store.AuthorizeDeviceCode(dc.ID, userID)
 	if err != nil {
+		if errors.Is(err, store.ErrDeviceCodeAlreadyAuthorized) {
+			return ErrDeviceCodeAlreadyAuthorized
+		}
 		return err
 	}
 

--- a/internal/store/device_code.go
+++ b/internal/store/device_code.go
@@ -1,6 +1,10 @@
 package store
 
-import "github.com/go-authgate/authgate/internal/models"
+import (
+	"time"
+
+	"github.com/go-authgate/authgate/internal/models"
+)
 
 // Device Code operations (implements core.DeviceCodeStore)
 
@@ -31,6 +35,27 @@ func (s *Store) GetDeviceCodeByUserCode(userCode string) (*models.DeviceCode, er
 // UpdateDeviceCode updates a device code
 func (s *Store) UpdateDeviceCode(dc *models.DeviceCode) error {
 	return s.db.Save(dc).Error
+}
+
+// AuthorizeDeviceCode atomically marks a device code as authorized by a user.
+// It uses a WHERE clause to ensure only one concurrent request wins; the loser
+// receives ErrDeviceCodeAlreadyAuthorized (0 rows updated).
+func (s *Store) AuthorizeDeviceCode(id int64, userID string) error {
+	now := time.Now()
+	result := s.db.Model(&models.DeviceCode{}).
+		Where("id = ? AND authorized = ?", id, false).
+		Updates(map[string]any{
+			"authorized":    true,
+			"authorized_at": now,
+			"user_id":       userID,
+		})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrDeviceCodeAlreadyAuthorized
+	}
+	return nil
 }
 
 // DeleteDeviceCodeByID deletes device code by ID (primary key)

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -9,4 +9,8 @@ var (
 	// ErrAuthCodeAlreadyUsed is returned by MarkAuthorizationCodeUsed when the
 	// code was already consumed by a concurrent request (0 rows updated).
 	ErrAuthCodeAlreadyUsed = errors.New("authorization code already used")
+
+	// ErrDeviceCodeAlreadyAuthorized is returned by AuthorizeDeviceCode when the
+	// device code was already authorized by a concurrent request (0 rows updated).
+	ErrDeviceCodeAlreadyAuthorized = errors.New("device code already authorized")
 )


### PR DESCRIPTION
## Summary

- **Fix information disclosure** (`err.Error()` leaked to OAuth error responses in device code and auth code exchange handlers) — replaced with generic messages + server-side logging
- **Fix device code authorization race condition** — added atomic `AuthorizeDeviceCode` store method using `WHERE authorized = false` to prevent TOCTOU vulnerability where concurrent requests could double-authorize the same device code
- **Reduce parameter sprawl** — introduced `CreateAuthorizationCodeParams` struct (9 params → 1), simplified `issueCodeAndRedirect` (8 params → 4), and fully populated `AuthorizationRequest` with `CodeChallenge` from `ValidateAuthorizationRequest`

## Security Findings

| ID | Severity | Issue | Status |
|----|----------|-------|--------|
| S1 | HIGH | `err.Error()` leaked internal details in OAuth responses | Fixed |
| S2 | MEDIUM | Device code TOCTOU race condition | Fixed |

### Verified False Positives (no action needed)
- AuthZ bypass in `RevokeAuthorization`: store properly uses `WHERE uuid = ? AND user_id = ?`
- PKCE plain method for public clients: `ValidateAuthorizationRequest` enforces S256 for public clients
- CORS `AllowCredentials` risk: origins come from config, not wildcards

## Test plan

- [x] `make generate` — templates and swagger docs up to date
- [x] `make test` — all 14 packages pass
- [x] `make lint` — 0 issues
- [ ] Verify device code flow works end-to-end (manual)
- [ ] Verify authorization code flow with PKCE works end-to-end (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)