### PR TITLE
feat(oidc): add Cache-Control header to discovery endpoint

### DIFF
--- a/internal/handlers/oidc.go
+++ b/internal/handlers/oidc.go
@@ -124,6 +124,7 @@ func (h *OIDCHandler) Discovery(c *gin.Context) {
 		meta.JwksURI = h.issuerURL + "/.well-known/jwks.json"
 	}
 
+	c.Header("Cache-Control", "public, max-age=3600")
 	c.JSON(http.StatusOK, meta)
 }
 

--- a/internal/handlers/oidc_test.go
+++ b/internal/handlers/oidc_test.go
@@ -146,6 +146,7 @@ func TestDiscovery_ReturnsCorrectMetadata(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "public, max-age=3600", w.Header().Get("Cache-Control"))
 
 	var meta map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &meta))


### PR DESCRIPTION
## Summary
- Add `Cache-Control: public, max-age=3600` to `/.well-known/openid-configuration` endpoint
- The OIDC Discovery metadata is derived entirely from static config, matching the JWKS endpoint which already has this header
- Add test assertion to verify the header is present

## Test plan
- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues
- [ ] Verify `curl -I https://<host>/.well-known/openid-configuration` returns `Cache-Control: public, max-age=3600`

🤖 Generated with [Claude Code](https://claude.com/claude-code)