### PR TITLE
feat(server): support optional HTTPS via TLS cert/key env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,13 @@
 SERVER_ADDR=:8080
 BASE_URL=http://localhost:8080
 
+# TLS / HTTPS (optional)
+# When both TLS_CERT_FILE and TLS_KEY_FILE are set, AuthGate serves HTTPS on SERVER_ADDR.
+# TLS_CERT_FILE should contain the full certificate chain; TLS_KEY_FILE the PEM-encoded private key.
+# Remember to update BASE_URL to https://... when enabling TLS.
+# TLS_CERT_FILE=/etc/authgate/tls/fullchain.pem
+# TLS_KEY_FILE=/etc/authgate/tls/privkey.pem
+
 # Environment Mode
 # Options: production, development (default)
 # In production mode: session cookies require HTTPS, stricter security headers

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -142,7 +142,7 @@ AUDIT_LOG_CLEANUP_INTERVAL=24h          # Cleanup frequency (default: 24h)
 
 ## TLS / HTTPS
 
-AuthGate can serve HTTPS directly by setting two environment variables. When both are configured, the server listens on `SERVER_ADDR` using TLS; when either is empty, it falls back to plain HTTP.
+AuthGate can serve HTTPS directly by setting two environment variables. When both are configured, the server listens on `SERVER_ADDR` using TLS. When both are empty (the default), it serves plain HTTP. Setting only one of the two is rejected at startup by `Config.Validate()` — this prevents silently falling back to HTTP when the operator meant to enable TLS.
 
 ```bash
 TLS_CERT_FILE=/etc/authgate/tls/fullchain.pem   # PEM-encoded certificate (full chain)
@@ -151,7 +151,7 @@ TLS_KEY_FILE=/etc/authgate/tls/privkey.pem      # PEM-encoded private key
 
 Notes:
 
-- **Both variables must be set.** Setting only one is treated as TLS disabled (plain HTTP).
+- **Both variables must be set together.** Setting only one causes `Config.Validate()` to fail at startup (prevents accidental HTTP fallback when TLS was intended). Leave both empty for plain HTTP.
 - **Use a full chain certificate** (leaf + intermediates). Clients often reject leaf-only certificates from non-root CAs.
 - **Update `BASE_URL`** to `https://...` so OAuth redirect URIs, `verification_uri`, and JWKS links use the correct scheme.
 - **Cipher suites / TLS versions** use Go's `crypto/tls` defaults — modern, secure, no tuning needed for typical deployments.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -5,6 +5,7 @@ This guide covers all configuration options for AuthGate, including environment 
 ## Table of Contents
 
 - [Environment Variables](#environment-variables)
+- [TLS / HTTPS](#tls--https)
 - [Bootstrap and Shutdown Timeouts](#bootstrap-and-shutdown-timeouts)
 - [Generate Strong Secrets](#generate-strong-secrets)
 - [Default Test Data](#default-test-data)
@@ -27,6 +28,10 @@ Create a `.env` file in the project root:
 # Server Configuration
 SERVER_ADDR=:8080                # Listen address (e.g., :8080, 0.0.0.0:8080)
 BASE_URL=http://localhost:8080   # Public URL for verification_uri
+
+# TLS / HTTPS (optional) — set both to serve HTTPS on SERVER_ADDR
+# TLS_CERT_FILE=/etc/authgate/tls/fullchain.pem
+# TLS_KEY_FILE=/etc/authgate/tls/privkey.pem
 
 # Security - CHANGE THESE IN PRODUCTION!
 JWT_SECRET=your-256-bit-secret-change-in-production       # HMAC-SHA256 signing key
@@ -131,6 +136,35 @@ ENABLE_AUDIT_LOGGING=true               # Enable audit logging (default: true)
 AUDIT_LOG_RETENTION=2160h               # Retention period: 90 days (default: 90 days = 2160h)
 AUDIT_LOG_BUFFER_SIZE=1000              # Async buffer size (default: 1000)
 AUDIT_LOG_CLEANUP_INTERVAL=24h          # Cleanup frequency (default: 24h)
+```
+
+---
+
+## TLS / HTTPS
+
+AuthGate can serve HTTPS directly by setting two environment variables. When both are configured, the server listens on `SERVER_ADDR` using TLS; when either is empty, it falls back to plain HTTP.
+
+```bash
+TLS_CERT_FILE=/etc/authgate/tls/fullchain.pem   # PEM-encoded certificate (full chain)
+TLS_KEY_FILE=/etc/authgate/tls/privkey.pem      # PEM-encoded private key
+```
+
+Notes:
+
+- **Both variables must be set.** Setting only one is treated as TLS disabled (plain HTTP).
+- **Use a full chain certificate** (leaf + intermediates). Clients often reject leaf-only certificates from non-root CAs.
+- **Update `BASE_URL`** to `https://...` so OAuth redirect URIs, `verification_uri`, and JWKS links use the correct scheme.
+- **Cipher suites / TLS versions** use Go's `crypto/tls` defaults — modern, secure, no tuning needed for typical deployments.
+- **No hot reload.** Renewed certificates require restarting AuthGate. For zero-downtime certificate rotation (ACME/Let's Encrypt), terminate TLS at a reverse proxy (nginx, Caddy, Cloudflare) instead.
+
+Quick local test with a self-signed certificate:
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem \
+  -days 1 -subj "/CN=localhost"
+TLS_CERT_FILE=cert.pem TLS_KEY_FILE=key.pem BASE_URL=https://localhost:8080 \
+  ./bin/authgate server
+curl -k https://localhost:8080/health
 ```
 
 ---

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -212,7 +212,7 @@ func (app *Application) startWithGracefulShutdown() {
 	m := app.manager // Use stored manager instance
 
 	// Add jobs
-	addServerRunningJob(m, app.Server)
+	addServerRunningJob(m, app.Server, app.Config)
 	addServerShutdownJob(m, app.Server, app.Config)
 	addAuditServiceShutdownJob(m, app.AuditService, app.Config)
 	addRedisClientShutdownJob(m, app.RateLimitRedisClient, app.Config)

--- a/internal/bootstrap/server.go
+++ b/internal/bootstrap/server.go
@@ -28,11 +28,24 @@ func createHTTPServer(cfg *config.Config, handler http.Handler) *http.Server {
 	}
 }
 
-// addServerRunningJob adds the HTTP server running job
-func addServerRunningJob(m *graceful.Manager, srv *http.Server) {
+// addServerRunningJob adds the HTTP server running job.
+// Serves HTTPS when cfg.TLSEnabled(); otherwise plain HTTP.
+func addServerRunningJob(m *graceful.Manager, srv *http.Server, cfg *config.Config) {
 	m.AddRunningJob(func(ctx context.Context) error {
 		go func() {
-			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			scheme := "HTTP"
+			if cfg.TLSEnabled() {
+				scheme = "HTTPS"
+			}
+			log.Printf("Starting %s server on %s", scheme, srv.Addr)
+
+			var err error
+			if cfg.TLSEnabled() {
+				err = srv.ListenAndServeTLS(cfg.TLSCertFile, cfg.TLSKeyFile)
+			} else {
+				err = srv.ListenAndServe()
+			}
+			if err != nil && err != http.ErrServerClosed {
 				log.Fatalf("Failed to start server: %v", err)
 			}
 		}()

--- a/internal/bootstrap/server.go
+++ b/internal/bootstrap/server.go
@@ -33,14 +33,15 @@ func createHTTPServer(cfg *config.Config, handler http.Handler) *http.Server {
 func addServerRunningJob(m *graceful.Manager, srv *http.Server, cfg *config.Config) {
 	m.AddRunningJob(func(ctx context.Context) error {
 		go func() {
+			tlsEnabled := cfg.TLSEnabled()
 			scheme := "HTTP"
-			if cfg.TLSEnabled() {
+			if tlsEnabled {
 				scheme = "HTTPS"
 			}
 			log.Printf("Starting %s server on %s", scheme, srv.Addr)
 
 			var err error
-			if cfg.TLSEnabled() {
+			if tlsEnabled {
 				err = srv.ListenAndServeTLS(cfg.TLSCertFile, cfg.TLSKeyFile)
 			} else {
 				err = srv.ListenAndServe()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -37,8 +38,10 @@ const (
 
 type Config struct {
 	// Server settings
-	ServerAddr string
-	BaseURL    string
+	ServerAddr  string
+	BaseURL     string
+	TLSCertFile string // Both TLSCertFile and TLSKeyFile must be set to serve HTTPS.
+	TLSKeyFile  string
 
 	// Environment detection
 	IsProduction bool
@@ -229,6 +232,12 @@ type Config struct {
 	DBCloseTimeout        time.Duration // Database close timeout (default: 5s)
 }
 
+// TLSEnabled reports whether TLS serving should be activated.
+// Both TLSCertFile and TLSKeyFile must be set for TLS to be enabled.
+func (c *Config) TLSEnabled() bool {
+	return c.TLSCertFile != "" && c.TLSKeyFile != ""
+}
+
 func Load() *Config {
 	// Load .env file if exists (ignore error if not found)
 	_ = godotenv.Load()
@@ -243,8 +252,10 @@ func Load() *Config {
 	}
 
 	return &Config{
-		ServerAddr: getEnv("SERVER_ADDR", ":8080"),
-		BaseURL:    getEnv("BASE_URL", "http://localhost:8080"),
+		ServerAddr:  getEnv("SERVER_ADDR", ":8080"),
+		BaseURL:     getEnv("BASE_URL", "http://localhost:8080"),
+		TLSCertFile: getEnv("TLS_CERT_FILE", ""),
+		TLSKeyFile:  getEnv("TLS_KEY_FILE", ""),
 		IsProduction: getEnvBool("ENVIRONMENT", false) ||
 			getEnv("ENVIRONMENT", "") == "production",
 		JWTSecret:           getEnv("JWT_SECRET", "your-256-bit-secret-change-in-production"),
@@ -558,6 +569,11 @@ func (c *Config) Validate() error {
 			"invalid JWT_SIGNING_ALGORITHM value: %q (must be \"HS256\", \"RS256\", or \"ES256\")",
 			c.JWTSigningAlgorithm,
 		)
+	}
+
+	// TLS cert/key must be set together — setting only one would silently fall back to HTTP.
+	if (c.TLSCertFile != "") != (c.TLSKeyFile != "") {
+		return errors.New("TLS_CERT_FILE and TLS_KEY_FILE must both be set or both be empty")
 	}
 
 	// Validate rate limit store type

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -763,3 +763,53 @@ func TestAuthCodeFlowConfigFields(t *testing.T) {
 	assert.True(t, cfg.PKCERequired)
 	assert.False(t, cfg.ConsentRemember)
 }
+
+func TestTLSEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		certFile string
+		keyFile  string
+		want     bool
+	}{
+		{"both empty", "", "", false},
+		{"only cert set", "cert.pem", "", false},
+		{"only key set", "", "key.pem", false},
+		{"both set", "cert.pem", "key.pem", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{TLSCertFile: tt.certFile, TLSKeyFile: tt.keyFile}
+			assert.Equal(t, tt.want, cfg.TLSEnabled())
+		})
+	}
+}
+
+func TestValidate_TLSPartialConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		certFile  string
+		keyFile   string
+		expectErr bool
+	}{
+		{"both empty passes", "", "", false},
+		{"both set passes", "cert.pem", "key.pem", false},
+		{"only cert set fails", "cert.pem", "", true},
+		{"only key set fails", "", "key.pem", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validBaseConfig()
+			cfg.TLSCertFile = tt.certFile
+			cfg.TLSKeyFile = tt.keyFile
+			err := cfg.Validate()
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "TLS_CERT_FILE and TLS_KEY_FILE")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add optional HTTPS serving: set `TLS_CERT_FILE` and `TLS_KEY_FILE` and AuthGate listens on `SERVER_ADDR` with TLS; otherwise plain HTTP as before.
- Reject partial TLS config (only one of cert/key set) in `Config.Validate()` — mirrors the existing JWT-key validation pattern — to prevent silent HTTP fallback.
- Updated `.env.example` and added a **TLS / HTTPS** subsection in `docs/CONFIGURATION.md` with rationale (full chain, `BASE_URL` scheme update, no hot reload) and a self-signed quick-test snippet.

## Implementation notes

- `addServerRunningJob` now branches on `cfg.TLSEnabled()` and calls `srv.ListenAndServeTLS` / `srv.ListenAndServe`. Graceful shutdown is unchanged — `srv.Shutdown()` handles both identically.
- TLS cipher suites / versions use Go's `crypto/tls` defaults (TLS 1.2+, modern ciphers). No manual tuning.
- No hot-reload: rotate certs via reverse proxy (nginx/Caddy/Cloudflare) or restart AuthGate.

## Test plan

- [x] `TestTLSEnabled` — covers all four cert/key combinations
- [x] `TestValidate_TLSPartialConfig` — covers four cases incl. error paths
- [x] `make fmt`, `make lint` (0 issues), `go test ./internal/config/... ./internal/bootstrap/...`
- [ ] Manual: generate a self-signed cert, start with `TLS_CERT_FILE` / `TLS_KEY_FILE`, confirm `curl -k https://localhost:8080/health` returns 200
- [ ] Manual: unset both env vars, confirm plain HTTP still works (log says "Starting HTTP server on :8080")
- [ ] Manual: set only one var, confirm startup aborts with the new `Validate()` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
