### PR TITLE
feat(oidc): persist and expose email_verified from OAuth providers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -147,46 +147,46 @@ sequenceDiagram
 
 ## Key Endpoints
 
-| Endpoint                            | Method   | Auth Required | Purpose                                                                                           |
-| ----------------------------------- | -------- | ------------- | ------------------------------------------------------------------------------------------------- |
-| `/health`                           | GET      | No            | Health check with database connection test                                                        |
-| `/.well-known/openid-configuration` | GET      | No            | OIDC Discovery metadata (RFC 8414 / OIDC Discovery 1.0)                                           |
-| `/.well-known/jwks.json`            | GET      | No            | JWKS public keys for RS256/ES256 JWT verification (RFC 7517)                                      |
-| `/oauth/device/code`                | POST     | No            | Request device and user codes (CLI/device)                                                        |
-| `/oauth/authorize`                  | GET      | Yes (Session) | Authorization Code Flow consent page (web apps)                                                   |
-| `/oauth/authorize`                  | POST     | Yes (Session) | Submit consent decision (allow/deny)                                                              |
-| `/oauth/token`                      | POST     | No            | Token endpoint (grant_type=device_code, authorization_code, refresh_token, or client_credentials) |
-| `/oauth/tokeninfo`                  | GET      | No (Bearer)   | Verify token validity from Authorization: Bearer access token                                     |
-| `/oauth/userinfo`                   | GET/POST | No (Bearer)   | OIDC UserInfo — returns profile claims for authenticated user (OIDC Core §5.3)                    |
-| `/oauth/revoke`                     | POST     | No            | Revoke access token (RFC 7009)                                                                    |
-| `/oauth/register`                   | POST     | No            | Dynamic client registration (RFC 7591); optional Bearer token                                     |
-| `/oauth/introspect`                 | POST     | No            | Token introspection (RFC 7662); client auth via Basic or form                                     |
-| `/device`                           | GET      | Yes (Session) | User authorization page (browser)                                                                 |
-| `/device/verify`                    | POST     | Yes (Session) | Complete authorization (submit user_code)                                                         |
-| `/account/sessions`                 | GET      | Yes (Session) | View all active sessions                                                                          |
-| `/account/sessions/:id/revoke`      | POST     | Yes (Session) | Revoke specific session                                                                           |
-| `/account/sessions/revoke-all`      | POST     | Yes (Session) | Revoke all user sessions                                                                          |
-| `/account/authorizations`           | GET      | Yes (Session) | View apps authorized via Authorization Code Flow                                                  |
-| `/login`                            | GET/POST | No            | User login (creates session)                                                                      |
-| `/logout`                           | GET      | Yes (Session) | User logout (destroys session)                                                                    |
-| `/auth/login/:provider`             | GET      | No            | Initiate OAuth login (provider: github, gitea, microsoft)                                         |
-| `/auth/callback/:provider`          | GET      | No            | OAuth callback endpoint                                                                           |
-| `/admin/audit`                      | GET      | Yes (Admin)   | View audit logs (HTML interface)                                                                  |
-| `/admin/audit/export`               | GET      | Yes (Admin)   | Export audit logs as CSV                                                                          |
-| `/admin/audit/api`                  | GET      | Yes (Admin)   | List audit logs (JSON API)                                                                        |
-| `/admin/audit/api/stats`            | GET      | Yes (Admin)   | Get audit log statistics                                                                          |
-| `/admin/clients/:id/authorizations` | GET      | Yes (Admin)   | View all users who consented to a client                                                          |
-| `/admin/clients/:id/revoke-all`     | POST     | Yes (Admin)   | Revoke all tokens and consents for a client                                                       |
-| `/admin/users`                      | GET/POST | Yes (Admin)   | List users / create a user (auto-generates password if none supplied; `auth_source=local`)        |
-| `/admin/users/:id`                  | GET/POST | Yes (Admin)   | View / update user (cannot change own role)                                                       |
-| `/admin/users/:id/reset-password`   | POST     | Yes (Admin)   | Generate a new random password (local-auth users only)                                            |
-| `/admin/users/:id/delete`           | POST     | Yes (Admin)   | Delete user (blocked for self and last active admin)                                              |
-| `/admin/users/:id/disable`          | POST     | Yes (Admin)   | Disable user — revokes all tokens, clears any live session on next request                        |
-| `/admin/users/:id/enable`           | POST     | Yes (Admin)   | Re-enable a disabled user                                                                         |
-| `/admin/users/:id/connections`      | GET      | Yes (Admin)   | List the user's third-party OAuth connections (GitHub, Gitea, Microsoft)                          |
-| `/admin/users/:id/connections/:conn_id/delete` | POST | Yes (Admin) | Unlink a specific third-party OAuth connection                                                |
-| `/admin/users/:id/authorizations`   | GET      | Yes (Admin)   | List apps the user has authorized                                                                 |
-| `/admin/users/:id/authorizations/:uuid/revoke` | POST | Yes (Admin) | Revoke a single user authorization                                                            |
+| Endpoint                                       | Method   | Auth Required | Purpose                                                                                           |
+| ---------------------------------------------- | -------- | ------------- | ------------------------------------------------------------------------------------------------- |
+| `/health`                                      | GET      | No            | Health check with database connection test                                                        |
+| `/.well-known/openid-configuration`            | GET      | No            | OIDC Discovery metadata (RFC 8414 / OIDC Discovery 1.0)                                           |
+| `/.well-known/jwks.json`                       | GET      | No            | JWKS public keys for RS256/ES256 JWT verification (RFC 7517)                                      |
+| `/oauth/device/code`                           | POST     | No            | Request device and user codes (CLI/device)                                                        |
+| `/oauth/authorize`                             | GET      | Yes (Session) | Authorization Code Flow consent page (web apps)                                                   |
+| `/oauth/authorize`                             | POST     | Yes (Session) | Submit consent decision (allow/deny)                                                              |
+| `/oauth/token`                                 | POST     | No            | Token endpoint (grant_type=device_code, authorization_code, refresh_token, or client_credentials) |
+| `/oauth/tokeninfo`                             | GET      | No (Bearer)   | Verify token validity from Authorization: Bearer access token                                     |
+| `/oauth/userinfo`                              | GET/POST | No (Bearer)   | OIDC UserInfo — returns profile claims for authenticated user (OIDC Core §5.3)                    |
+| `/oauth/revoke`                                | POST     | No            | Revoke access token (RFC 7009)                                                                    |
+| `/oauth/register`                              | POST     | No            | Dynamic client registration (RFC 7591); optional Bearer token                                     |
+| `/oauth/introspect`                            | POST     | No            | Token introspection (RFC 7662); client auth via Basic or form                                     |
+| `/device`                                      | GET      | Yes (Session) | User authorization page (browser)                                                                 |
+| `/device/verify`                               | POST     | Yes (Session) | Complete authorization (submit user_code)                                                         |
+| `/account/sessions`                            | GET      | Yes (Session) | View all active sessions                                                                          |
+| `/account/sessions/:id/revoke`                 | POST     | Yes (Session) | Revoke specific session                                                                           |
+| `/account/sessions/revoke-all`                 | POST     | Yes (Session) | Revoke all user sessions                                                                          |
+| `/account/authorizations`                      | GET      | Yes (Session) | View apps authorized via Authorization Code Flow                                                  |
+| `/login`                                       | GET/POST | No            | User login (creates session)                                                                      |
+| `/logout`                                      | GET      | Yes (Session) | User logout (destroys session)                                                                    |
+| `/auth/login/:provider`                        | GET      | No            | Initiate OAuth login (provider: github, gitea, microsoft)                                         |
+| `/auth/callback/:provider`                     | GET      | No            | OAuth callback endpoint                                                                           |
+| `/admin/audit`                                 | GET      | Yes (Admin)   | View audit logs (HTML interface)                                                                  |
+| `/admin/audit/export`                          | GET      | Yes (Admin)   | Export audit logs as CSV                                                                          |
+| `/admin/audit/api`                             | GET      | Yes (Admin)   | List audit logs (JSON API)                                                                        |
+| `/admin/audit/api/stats`                       | GET      | Yes (Admin)   | Get audit log statistics                                                                          |
+| `/admin/clients/:id/authorizations`            | GET      | Yes (Admin)   | View all users who consented to a client                                                          |
+| `/admin/clients/:id/revoke-all`                | POST     | Yes (Admin)   | Revoke all tokens and consents for a client                                                       |
+| `/admin/users`                                 | GET/POST | Yes (Admin)   | List users / create a user (auto-generates password if none supplied; `auth_source=local`)        |
+| `/admin/users/:id`                             | GET/POST | Yes (Admin)   | View / update user (cannot change own role)                                                       |
+| `/admin/users/:id/reset-password`              | POST     | Yes (Admin)   | Generate a new random password (local-auth users only)                                            |
+| `/admin/users/:id/delete`                      | POST     | Yes (Admin)   | Delete user (blocked for self and last active admin)                                              |
+| `/admin/users/:id/disable`                     | POST     | Yes (Admin)   | Disable user — revokes all tokens, clears any live session on next request                        |
+| `/admin/users/:id/enable`                      | POST     | Yes (Admin)   | Re-enable a disabled user                                                                         |
+| `/admin/users/:id/connections`                 | GET      | Yes (Admin)   | List the user's third-party OAuth connections (GitHub, Gitea, Microsoft)                          |
+| `/admin/users/:id/connections/:conn_id/delete` | POST     | Yes (Admin)   | Unlink a specific third-party OAuth connection                                                    |
+| `/admin/users/:id/authorizations`              | GET      | Yes (Admin)   | List apps the user has authorized                                                                 |
+| `/admin/users/:id/authorizations/:uuid/revoke` | POST     | Yes (Admin)   | Revoke a single user authorization                                                                |
 
 ### Endpoint Details
 
@@ -228,10 +228,10 @@ sequenceDiagram
   - Returns `401` with `WWW-Authenticate: Bearer error="invalid_token"` on failure
   - Claims returned depend on the scopes granted when the token was issued:
 
-| Scope     | Claims returned                                                    |
-| --------- | ------------------------------------------------------------------ |
-| _(any)_   | `sub` (always present — user UUID)                                 |
-| `profile` | `name`, `preferred_username`, `picture` (if set), `updated_at`     |
+| Scope     | Claims returned                                                                             |
+| --------- | ------------------------------------------------------------------------------------------- |
+| _(any)_   | `sub` (always present — user UUID)                                                          |
+| `profile` | `name`, `preferred_username`, `picture` (if set), `updated_at`                              |
 | `email`   | `email`, `email_verified` (`true` only when a trusted OAuth provider confirmed the address) |
 
 Example request for `openid profile email` scopes:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -232,7 +232,7 @@ sequenceDiagram
 | --------- | ------------------------------------------------------------------ |
 | _(any)_   | `sub` (always present — user UUID)                                 |
 | `profile` | `name`, `preferred_username`, `picture` (if set), `updated_at`     |
-| `email`   | `email`, `email_verified` (always `false` — no email verification) |
+| `email`   | `email`, `email_verified` (`true` only when a trusted OAuth provider confirmed the address) |
 
 Example request for `openid profile email` scopes:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -324,11 +324,13 @@ db.AutoMigrate(
 
 **Production caveat:** AutoMigrate runs at process startup and will issue
 `ALTER TABLE` statements whenever a model adds or changes a column. On
-Postgres and MySQL this can take an `ACCESS EXCLUSIVE` lock and — for
-`NOT NULL` column additions with a default — rewrite the entire table
-before the server accepts traffic. Large deployments (hundreds of
-thousands of rows or more) should either run the equivalent migration
-out-of-band ahead of the rollout or tolerate the downtime window.
+Postgres, adding a `NOT NULL` column with a default can take an
+`ACCESS EXCLUSIVE` lock and — depending on the server version — rewrite
+the entire table before traffic is accepted. Other engines may take a
+comparable table lock or block writers for the duration of the change.
+Large deployments (hundreds of thousands of rows or more) should either
+run the equivalent migration out-of-band ahead of the rollout or tolerate
+the downtime window.
 Example using the recent `users.email_verified` column:
 
 ```sql

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -322,6 +322,21 @@ db.AutoMigrate(
 )
 ```
 
+**Production caveat:** AutoMigrate runs at process startup and will issue
+`ALTER TABLE` statements whenever a model adds or changes a column. On
+Postgres and MySQL this can take an `ACCESS EXCLUSIVE` lock and — for
+`NOT NULL` column additions with a default — rewrite the entire table
+before the server accepts traffic. Large deployments (hundreds of
+thousands of rows or more) should either run the equivalent migration
+out-of-band ahead of the rollout or tolerate the downtime window.
+Example using the recent `users.email_verified` column:
+
+```sql
+-- Run during a maintenance window BEFORE deploying the new binary to
+-- skip the startup ALTER TABLE on a large users table:
+ALTER TABLE users ADD COLUMN email_verified BOOLEAN NOT NULL DEFAULT FALSE;
+```
+
 ---
 
 ## Extending the Server

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -15,6 +15,14 @@ type UserReader interface {
 	GetUserByUsername(username string) (*models.User, error)
 	GetUserByID(id string) (*models.User, error)
 	GetUserByEmail(email string) (*models.User, error)
+	// FindUserByNormalizedEmail locates a user whose stored email matches the
+	// input after trimming whitespace on both sides, and returns an error when
+	// more than one legacy row ties to the same normalized value. Used by the
+	// OAuth auto-link path where picking a non-deterministic match would risk
+	// binding a verified provider to the wrong local user. Slower than
+	// GetUserByEmail because the fallback is not index-friendly — callers that
+	// don't need whitespace tolerance should keep using GetUserByEmail.
+	FindUserByNormalizedEmail(email string) (*models.User, error)
 	GetUserByExternalID(externalID, authSource string) (*models.User, error)
 	GetUsersByIDs(userIDs []string) (map[string]*models.User, error)
 	ListUsersPaginated(params types.PaginationParams) ([]models.User, types.PaginationResult, error)

--- a/internal/handlers/oauth_handler.go
+++ b/internal/handlers/oauth_handler.go
@@ -211,6 +211,12 @@ func (h *OAuthHandler) OAuthCallback(c *gin.Context) {
 				http.StatusForbidden,
 				"Account Disabled. Your account has been disabled by an administrator. Please contact your administrator for assistance.",
 			)
+		case errors.Is(err, services.ErrAmbiguousEmail):
+			renderErrorPage(
+				c,
+				http.StatusConflict,
+				"Duplicate Account Detected. Multiple local accounts share this email address. Please contact your administrator to merge or remove the duplicates before signing in via OAuth.",
+			)
 		default:
 			renderErrorPage(
 				c,

--- a/internal/handlers/oidc.go
+++ b/internal/handlers/oidc.go
@@ -198,7 +198,7 @@ func buildUserInfoClaims(userID, issuer, scopes string, user *models.User) map[s
 
 	if scopeSet["email"] {
 		claims["email"] = user.Email
-		claims["email_verified"] = false
+		claims["email_verified"] = user.EmailVerified
 	}
 
 	return claims

--- a/internal/handlers/oidc_test.go
+++ b/internal/handlers/oidc_test.go
@@ -22,10 +22,11 @@ import (
 func TestBuildUserInfoClaims_AllScopes(t *testing.T) {
 	updatedAt := time.Unix(1708646400, 0)
 	user := &models.User{
-		FullName:  "John Doe",
-		Username:  "johndoe",
-		AvatarURL: "https://example.com/avatar.jpg",
-		Email:     "john@example.com",
+		FullName:      "John Doe",
+		Username:      "johndoe",
+		AvatarURL:     "https://example.com/avatar.jpg",
+		Email:         "john@example.com",
+		EmailVerified: true,
 	}
 	user.UpdatedAt = updatedAt
 	claims := buildUserInfoClaims(
@@ -42,7 +43,7 @@ func TestBuildUserInfoClaims_AllScopes(t *testing.T) {
 	assert.Equal(t, "https://example.com/avatar.jpg", claims["picture"])
 	assert.Equal(t, int64(1708646400), claims["updated_at"])
 	assert.Equal(t, "john@example.com", claims["email"])
-	assert.Equal(t, false, claims["email_verified"])
+	assert.Equal(t, true, claims["email_verified"])
 }
 
 func TestBuildUserInfoClaims_OpenIDOnly(t *testing.T) {
@@ -84,10 +85,11 @@ func TestBuildUserInfoClaims_ProfileScopeOnly(t *testing.T) {
 
 func TestBuildUserInfoClaims_EmailScopeOnly(t *testing.T) {
 	user := &models.User{
-		FullName:  "Bob Builder",
-		Username:  "bob",
-		AvatarURL: "",
-		Email:     "bob@example.com",
+		FullName:      "Bob Builder",
+		Username:      "bob",
+		AvatarURL:     "",
+		Email:         "bob@example.com",
+		EmailVerified: false,
 	}
 	claims := buildUserInfoClaims("user-789", "https://auth.example.com", "email", user)
 
@@ -96,6 +98,15 @@ func TestBuildUserInfoClaims_EmailScopeOnly(t *testing.T) {
 	assert.Equal(t, false, claims["email_verified"])
 	// No profile claims
 	assert.Nil(t, claims["name"])
+}
+
+func TestBuildUserInfoClaims_EmailVerifiedMirrorsUserField(t *testing.T) {
+	user := &models.User{
+		Email:         "carol@example.com",
+		EmailVerified: true,
+	}
+	claims := buildUserInfoClaims("user-901", "https://auth.example.com", "email", user)
+	assert.Equal(t, true, claims["email_verified"])
 }
 
 func TestBuildUserInfoClaims_NoScopes(t *testing.T) {

--- a/internal/mocks/mock_store.go
+++ b/internal/mocks/mock_store.go
@@ -59,6 +59,21 @@ func (mr *MockUserReaderMockRecorder) CountUsersByRole(role any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountUsersByRole", reflect.TypeOf((*MockUserReader)(nil).CountUsersByRole), role)
 }
 
+// FindUserByNormalizedEmail mocks base method.
+func (m *MockUserReader) FindUserByNormalizedEmail(email string) (*models.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindUserByNormalizedEmail", email)
+	ret0, _ := ret[0].(*models.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindUserByNormalizedEmail indicates an expected call of FindUserByNormalizedEmail.
+func (mr *MockUserReaderMockRecorder) FindUserByNormalizedEmail(email any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindUserByNormalizedEmail", reflect.TypeOf((*MockUserReader)(nil).FindUserByNormalizedEmail), email)
+}
+
 // GetUserByEmail mocks base method.
 func (m *MockUserReader) GetUserByEmail(email string) (*models.User, error) {
 	m.ctrl.T.Helper()
@@ -1873,6 +1888,21 @@ func (m *MockStore) DeleteUser(id string) error {
 func (mr *MockStoreMockRecorder) DeleteUser(id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockStore)(nil).DeleteUser), id)
+}
+
+// FindUserByNormalizedEmail mocks base method.
+func (m *MockStore) FindUserByNormalizedEmail(email string) (*models.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindUserByNormalizedEmail", email)
+	ret0, _ := ret[0].(*models.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindUserByNormalizedEmail indicates an expected call of FindUserByNormalizedEmail.
+func (mr *MockStoreMockRecorder) FindUserByNormalizedEmail(email any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindUserByNormalizedEmail", reflect.TypeOf((*MockStore)(nil).FindUserByNormalizedEmail), email)
 }
 
 // GetAccessTokenByHash mocks base method.

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -17,14 +17,15 @@ const (
 )
 
 type User struct {
-	ID           string `gorm:"primaryKey"`
-	Username     string `gorm:"uniqueIndex;not null"`
-	Email        string `gorm:"uniqueIndex;not null"` // Email is unique and required
-	PasswordHash string // OAuth-only users have empty password
-	Role         string `gorm:"not null;default:'user'"` // "admin" or "user"
-	FullName     string // User full name
-	AvatarURL    string // User avatar URL (from OAuth or manual)
-	IsActive     bool   `gorm:"not null;default:true"` // false = disabled by admin
+	ID            string `gorm:"primaryKey"`
+	Username      string `gorm:"uniqueIndex;not null"`
+	Email         string `gorm:"uniqueIndex;not null"` // Email is unique and required
+	PasswordHash  string // OAuth-only users have empty password
+	Role          string `gorm:"not null;default:'user'"` // "admin" or "user"
+	FullName      string // User full name
+	AvatarURL     string // User avatar URL (from OAuth or manual)
+	IsActive      bool   `gorm:"not null;default:true"`  // false = disabled by admin
+	EmailVerified bool   `gorm:"not null;default:false"` // true when a trusted OAuth provider has verified the email
 
 	// External authentication support
 	ExternalID string `gorm:"index"`           // External user ID (e.g., from HTTP API)

--- a/internal/services/token_exchange.go
+++ b/internal/services/token_exchange.go
@@ -168,7 +168,7 @@ func (s *TokenService) ExchangeAuthorizationCode(
 					}
 					if scopeSet["email"] {
 						params.Email = user.Email
-						params.EmailVerified = false // AuthGate does not verify email addresses
+						params.EmailVerified = user.EmailVerified
 					}
 				} else {
 					log.Printf(

--- a/internal/services/token_test.go
+++ b/internal/services/token_test.go
@@ -932,6 +932,68 @@ func TestExchangeAuthorizationCode_IDToken_ContainsAtHash(t *testing.T) {
 		"at_hash in ID token must be the base64url-encoded left-half SHA-256 of the access token")
 }
 
+func TestExchangeAuthorizationCode_IDToken_EmailVerifiedMirrorsUser(t *testing.T) {
+	cases := []struct {
+		name     string
+		verified bool
+	}{
+		{name: "verified user", verified: true},
+		{name: "unverified user", verified: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := setupTestStore(t)
+			cfg := &config.Config{
+				JWTExpiration:          1 * time.Hour,
+				JWTSecret:              "test-secret",
+				BaseURL:                "http://localhost:8080",
+				EnableRefreshTokens:    true,
+				RefreshTokenExpiration: 30 * 24 * time.Hour,
+			}
+			tokenService := createTestTokenService(t, s, cfg)
+
+			client := createTestClient(t, s, true)
+			userID := uuid.New().String()
+			require.NoError(t, s.CreateUser(&models.User{
+				ID:            userID,
+				Username:      "verifieduser",
+				Email:         "verified@example.com",
+				FullName:      "Verified User",
+				EmailVerified: tc.verified,
+			}))
+
+			now := time.Now()
+			authCode := &models.AuthorizationCode{
+				UUID:          "test-uuid-" + uuid.New().String(),
+				CodeHash:      "hash-" + uuid.New().String(),
+				CodePrefix:    "testpfxv",
+				ApplicationID: client.ID,
+				ClientID:      client.ClientID,
+				UserID:        userID,
+				RedirectURI:   "https://app.example.com/callback",
+				Scopes:        "openid email",
+				ExpiresAt:     now.Add(10 * time.Minute),
+			}
+			require.NoError(t, s.CreateAuthorizationCode(authCode))
+
+			_, _, idToken, err := tokenService.ExchangeAuthorizationCode(
+				context.Background(),
+				authCode,
+				nil,
+			)
+			require.NoError(t, err)
+			require.NotEmpty(t, idToken)
+
+			localProvider, err := token.NewLocalTokenProvider(cfg)
+			require.NoError(t, err)
+			result, err := localProvider.ParseJWT(idToken)
+			require.NoError(t, err)
+			assert.Equal(t, tc.verified, result.Claims["email_verified"],
+				"email_verified claim must mirror User.EmailVerified")
+		})
+	}
+}
+
 // ============================================================
 // DisableToken / EnableToken — state transition checks
 // ============================================================

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -725,6 +725,11 @@ func (s *UserService) UpdateUserProfile(
 		return err
 	}
 
+	// Normalize inputs to match CreateUserAdmin and keep accidental whitespace
+	// from clearing EmailVerified or masking no-op edits.
+	req.Email = strings.TrimSpace(req.Email)
+	req.FullName = strings.TrimSpace(req.FullName)
+
 	// Validate role
 	if req.Role != "" && req.Role != models.UserRoleAdmin && req.Role != models.UserRoleUser {
 		return ErrInvalidRole

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -361,8 +361,11 @@ func (s *UserService) AuthenticateWithOAuth(
 		return s.updateOAuthConnectionAndGetUser(ctx, connection, oauthUserInfo, token)
 	}
 
-	// 2. Check if user exists with same email
-	user, err := s.store.GetUserByEmail(oauthUserInfo.Email)
+	// 2. Check if user exists with same email. Use the whitespace-tolerant
+	// normalized lookup so legacy rows are still found and any ambiguity
+	// between duplicate whitespace variants blocks auto-link instead of
+	// letting the provider bind to a non-deterministic row.
+	user, err := s.store.FindUserByNormalizedEmail(oauthUserInfo.Email)
 	if err == nil {
 		if !user.IsActive {
 			return nil, ErrAccountDisabled
@@ -786,12 +789,6 @@ func (s *UserService) UpdateUserProfile(
 	if req.Email != user.Email {
 		existing, lookupErr := s.store.GetUserByEmail(req.Email)
 		if lookupErr != nil {
-			// Ambiguous matches mean at least two other rows already share
-			// this normalized email — from the admin's perspective that's
-			// just a conflict, so surface the familiar error.
-			if errors.Is(lookupErr, store.ErrAmbiguousEmail) {
-				return ErrEmailConflict
-			}
 			if !errors.Is(lookupErr, gorm.ErrRecordNotFound) {
 				return fmt.Errorf("failed to check email uniqueness: %w", lookupErr)
 			}
@@ -1058,12 +1055,11 @@ func (s *UserService) CreateUserAdmin(
 		return nil, "", fmt.Errorf("failed to check username uniqueness: %w", err)
 	}
 
-	// Check email uniqueness. Ambiguous matches (legacy whitespace variants)
-	// also count as a conflict — the target email is already occupied by one
-	// or more rows, so the admin create must be rejected the same way.
+	// Check email uniqueness against the indexed exact value. Legacy
+	// whitespace-variant duplicates are not detected here by design —
+	// they'd show up for OAuth auto-link via FindUserByNormalizedEmail, but
+	// for admin creates a fast indexed check is the right trade-off.
 	if _, err := s.store.GetUserByEmail(req.Email); err == nil {
-		return nil, "", ErrEmailConflict
-	} else if errors.Is(err, store.ErrAmbiguousEmail) {
 		return nil, "", ErrEmailConflict
 	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, "", fmt.Errorf("failed to check email uniqueness: %w", err)
@@ -1098,11 +1094,9 @@ func (s *UserService) CreateUserAdmin(
 	if err := s.store.CreateUser(user); err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) {
 			// Re-query to determine which unique constraint was violated
-			// (race condition). ErrAmbiguousEmail also signals "email is
-			// in use" here — treat it the same as a normal email match
-			// instead of falling through to the username-conflict branch.
-			_, emailErr := s.store.GetUserByEmail(req.Email)
-			if emailErr == nil || errors.Is(emailErr, store.ErrAmbiguousEmail) {
+			// (race condition). An exact-email match means the email is
+			// the culprit; otherwise fall back to username conflict.
+			if _, emailErr := s.store.GetUserByEmail(req.Email); emailErr == nil {
 				return nil, "", ErrEmailConflict
 			}
 			return nil, "", ErrUsernameConflict

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -756,6 +756,11 @@ func (s *UserService) UpdateUserProfile(
 
 	oldRole := user.Role
 	user.FullName = req.FullName
+	if req.Email != user.Email {
+		// Admin edits do not verify the new address, so downgrade the claim
+		// until a trusted OAuth provider confirms it again.
+		user.EmailVerified = false
+	}
 	user.Email = req.Email
 	if req.Role != "" {
 		user.Role = req.Role

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -487,11 +487,22 @@ func (s *UserService) linkOAuthToExistingUser(
 		return nil, fmt.Errorf("failed to link OAuth: %w", err)
 	}
 
-	// Update user avatar if empty
+	// Update user avatar and email verification status.
+	// linkOAuthToExistingUser is only reached when the provider verified the
+	// email address (see AuthenticateWithOAuth), so we can safely promote the
+	// user's EmailVerified flag here.
+	updated := false
 	if user.AvatarURL == "" && oauthUserInfo.AvatarURL != "" {
 		user.AvatarURL = oauthUserInfo.AvatarURL
+		updated = true
+	}
+	if !user.EmailVerified && oauthUserInfo.EmailVerified {
+		user.EmailVerified = true
+		updated = true
+	}
+	if updated {
 		if err := s.store.UpdateUser(user); err != nil {
-			log.Printf("[OAuth] Failed to update user avatar: %v", err)
+			log.Printf("[OAuth] Failed to update user profile: %v", err)
 			// Continue with login even if update fails
 		}
 		s.InvalidateUserCache(user.ID)
@@ -530,15 +541,16 @@ func (s *UserService) createUserWithOAuth(
 
 	// Create user (no password)
 	user := &models.User{
-		ID:           uuid.New().String(),
-		Username:     username,
-		Email:        oauthUserInfo.Email,
-		FullName:     oauthUserInfo.FullName,
-		AvatarURL:    oauthUserInfo.AvatarURL,
-		Role:         models.UserRoleUser,
-		AuthSource:   models.AuthSourceLocal,
-		IsActive:     true,
-		PasswordHash: "", // OAuth users have no password
+		ID:            uuid.New().String(),
+		Username:      username,
+		Email:         oauthUserInfo.Email,
+		FullName:      oauthUserInfo.FullName,
+		AvatarURL:     oauthUserInfo.AvatarURL,
+		Role:          models.UserRoleUser,
+		AuthSource:    models.AuthSourceLocal,
+		IsActive:      true,
+		EmailVerified: oauthUserInfo.EmailVerified,
+		PasswordHash:  "", // OAuth users have no password
 	}
 
 	// Create OAuth connection

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -1058,8 +1058,12 @@ func (s *UserService) CreateUserAdmin(
 		return nil, "", fmt.Errorf("failed to check username uniqueness: %w", err)
 	}
 
-	// Check email uniqueness
+	// Check email uniqueness. Ambiguous matches (legacy whitespace variants)
+	// also count as a conflict — the target email is already occupied by one
+	// or more rows, so the admin create must be rejected the same way.
 	if _, err := s.store.GetUserByEmail(req.Email); err == nil {
+		return nil, "", ErrEmailConflict
+	} else if errors.Is(err, store.ErrAmbiguousEmail) {
 		return nil, "", ErrEmailConflict
 	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, "", fmt.Errorf("failed to check email uniqueness: %w", err)
@@ -1093,8 +1097,12 @@ func (s *UserService) CreateUserAdmin(
 
 	if err := s.store.CreateUser(user); err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) {
-			// Re-query to determine which unique constraint was violated (race condition).
-			if _, emailErr := s.store.GetUserByEmail(req.Email); emailErr == nil {
+			// Re-query to determine which unique constraint was violated
+			// (race condition). ErrAmbiguousEmail also signals "email is
+			// in use" here — treat it the same as a normal email match
+			// instead of falling through to the username-conflict branch.
+			_, emailErr := s.store.GetUserByEmail(req.Email)
+			if emailErr == nil || errors.Is(emailErr, store.ErrAmbiguousEmail) {
 				return nil, "", ErrEmailConflict
 			}
 			return nil, "", ErrUsernameConflict

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -51,6 +51,9 @@ var (
 	ErrUserAlreadyActive       = errors.New("user is already active")
 	ErrUserAlreadyDisabled     = errors.New("user is already disabled")
 	ErrOAuthConnectionNotFound = errors.New("OAuth connection not found")
+	ErrAmbiguousEmail          = errors.New(
+		"multiple local users share this email; please deduplicate before signing in via OAuth",
+	)
 )
 
 type UserService struct {
@@ -380,6 +383,17 @@ func (s *UserService) AuthenticateWithOAuth(
 			return nil, ErrOAuthEmailNotVerified
 		}
 		return s.createUserWithOAuth(ctx, provider, oauthUserInfo, token)
+	}
+	// Surface ambiguous-email errors explicitly: auto-registering would create
+	// yet another duplicate, and silently linking is unsafe because we cannot
+	// tell which of the existing rows the provider is vouching for.
+	if errors.Is(err, store.ErrAmbiguousEmail) {
+		log.Printf(
+			"[OAuth] Ambiguous email for provider=%s email=%s — manual dedup required",
+			provider,
+			oauthUserInfo.Email,
+		)
+		return nil, ErrAmbiguousEmail
 	}
 
 	// 3. Check if auto-registration is enabled

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -415,7 +415,10 @@ func (s *UserService) updateOAuthConnectionAndGetUser(
 		return nil, fmt.Errorf("failed to update OAuth connection: %w", err)
 	}
 
-	// Sync avatar and name if changed
+	// Sync avatar and name if changed. Also self-heal EmailVerified for
+	// existing connections so users migrated from before the column existed
+	// (or anyone whose earlier promotion write failed) eventually get their
+	// email verification flag set when the provider reports a verified match.
 	updated := false
 	if oauthUserInfo.AvatarURL != "" && user.AvatarURL != oauthUserInfo.AvatarURL {
 		user.AvatarURL = oauthUserInfo.AvatarURL
@@ -423,6 +426,14 @@ func (s *UserService) updateOAuthConnectionAndGetUser(
 	}
 	if oauthUserInfo.FullName != "" && user.FullName != oauthUserInfo.FullName {
 		user.FullName = oauthUserInfo.FullName
+		updated = true
+	}
+	// Only promote when the provider email still matches the stored email —
+	// otherwise a drifted provider account could assert verification for an
+	// address it does not own.
+	if !user.EmailVerified && oauthUserInfo.EmailVerified &&
+		oauthUserInfo.Email != "" && oauthUserInfo.Email == user.Email {
+		user.EmailVerified = true
 		updated = true
 	}
 	if updated {

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -776,13 +776,22 @@ func (s *UserService) UpdateUserProfile(
 		return ErrEmailRequired
 	}
 
-	// Check email conflict. Compare against the normalized stored value so a
-	// pre-existing row with incidental whitespace doesn't treat a no-op edit
-	// as a real change.
+	// Run the uniqueness check whenever the stored raw value differs from
+	// the (already trimmed) input, even if the two agree after trimming.
+	// A pure normalization edit ("  a@b  " → "a@b") still rewrites the DB
+	// value; if another user already owns the trimmed form exactly, this
+	// would collide at the UNIQUE constraint — catch it here with a
+	// deterministic ErrEmailConflict instead of a raw DB error.
 	storedEmail := strings.TrimSpace(user.Email)
-	if req.Email != storedEmail {
+	if req.Email != user.Email {
 		existing, lookupErr := s.store.GetUserByEmail(req.Email)
 		if lookupErr != nil {
+			// Ambiguous matches mean at least two other rows already share
+			// this normalized email — from the admin's perspective that's
+			// just a conflict, so surface the familiar error.
+			if errors.Is(lookupErr, store.ErrAmbiguousEmail) {
+				return ErrEmailConflict
+			}
 			if !errors.Is(lookupErr, gorm.ErrRecordNotFound) {
 				return fmt.Errorf("failed to check email uniqueness: %w", lookupErr)
 			}

--- a/internal/services/user.go
+++ b/internal/services/user.go
@@ -336,6 +336,13 @@ func (s *UserService) AuthenticateWithOAuth(
 	oauthUserInfo *auth.OAuthUserInfo,
 	token *oauth2.Token,
 ) (*models.User, error) {
+	// Normalize upstream fields once so downstream lookups, comparisons, and
+	// persistence are consistent and whitespace from the provider never causes
+	// spurious EmailVerified downgrades or unlinked duplicates.
+	oauthUserInfo.Email = strings.TrimSpace(oauthUserInfo.Email)
+	oauthUserInfo.Username = strings.TrimSpace(oauthUserInfo.Username)
+	oauthUserInfo.FullName = strings.TrimSpace(oauthUserInfo.FullName)
+
 	// Validate required fields
 	if oauthUserInfo.Email == "" {
 		return nil, errors.New("OAuth provider must return email")
@@ -430,9 +437,11 @@ func (s *UserService) updateOAuthConnectionAndGetUser(
 	}
 	// Only promote when the provider email still matches the stored email —
 	// otherwise a drifted provider account could assert verification for an
-	// address it does not own.
+	// address it does not own. Compare trimmed values so pre-existing rows
+	// with incidental whitespace still self-heal.
 	if !user.EmailVerified && oauthUserInfo.EmailVerified &&
-		oauthUserInfo.Email != "" && oauthUserInfo.Email == user.Email {
+		oauthUserInfo.Email != "" &&
+		oauthUserInfo.Email == strings.TrimSpace(user.Email) {
 		user.EmailVerified = true
 		updated = true
 	}
@@ -547,15 +556,23 @@ func (s *UserService) createUserWithOAuth(
 	oauthUserInfo *auth.OAuthUserInfo,
 	token *oauth2.Token,
 ) (*models.User, error) {
+	// Defensive trim: AuthenticateWithOAuth normalizes upstream fields before
+	// reaching here, but this function is also callable directly (tests, future
+	// callers), so re-trim to keep stored rows and duplicate-email lookups
+	// consistent regardless of entry point.
+	email := strings.TrimSpace(oauthUserInfo.Email)
+	fullName := strings.TrimSpace(oauthUserInfo.FullName)
+	rawUsername := strings.TrimSpace(oauthUserInfo.Username)
+
 	// Generate unique username
-	username := s.generateUniqueUsername(oauthUserInfo.Username, provider)
+	username := s.generateUniqueUsername(rawUsername, provider)
 
 	// Create user (no password)
 	user := &models.User{
 		ID:            uuid.New().String(),
 		Username:      username,
-		Email:         oauthUserInfo.Email,
-		FullName:      oauthUserInfo.FullName,
+		Email:         email,
+		FullName:      fullName,
 		AvatarURL:     oauthUserInfo.AvatarURL,
 		Role:          models.UserRoleUser,
 		AuthSource:    models.AuthSourceLocal,
@@ -570,8 +587,8 @@ func (s *UserService) createUserWithOAuth(
 		UserID:           user.ID,
 		Provider:         provider,
 		ProviderUserID:   oauthUserInfo.ProviderUserID,
-		ProviderUsername: oauthUserInfo.Username,
-		ProviderEmail:    oauthUserInfo.Email,
+		ProviderUsername: rawUsername,
+		ProviderEmail:    email,
 		AvatarURL:        oauthUserInfo.AvatarURL,
 		AccessToken:      token.AccessToken,
 		RefreshToken:     token.RefreshToken,
@@ -583,7 +600,7 @@ func (s *UserService) createUserWithOAuth(
 	err := s.store.RunInTransaction(func(tx core.Store) error {
 		if err := tx.CreateUser(user); err != nil {
 			if errors.Is(err, gorm.ErrDuplicatedKey) {
-				return fmt.Errorf("email already in use: %s", oauthUserInfo.Email)
+				return fmt.Errorf("email already in use: %s", email)
 			}
 			return fmt.Errorf("failed to create user: %w", err)
 		}
@@ -745,8 +762,11 @@ func (s *UserService) UpdateUserProfile(
 		return ErrEmailRequired
 	}
 
-	// Check email conflict
-	if req.Email != user.Email {
+	// Check email conflict. Compare against the normalized stored value so a
+	// pre-existing row with incidental whitespace doesn't treat a no-op edit
+	// as a real change.
+	storedEmail := strings.TrimSpace(user.Email)
+	if req.Email != storedEmail {
 		existing, lookupErr := s.store.GetUserByEmail(req.Email)
 		if lookupErr != nil {
 			if !errors.Is(lookupErr, gorm.ErrRecordNotFound) {
@@ -772,11 +792,13 @@ func (s *UserService) UpdateUserProfile(
 
 	oldRole := user.Role
 	user.FullName = req.FullName
-	if req.Email != user.Email {
+	if req.Email != storedEmail {
 		// Admin edits do not verify the new address, so downgrade the claim
 		// until a trusted OAuth provider confirms it again.
 		user.EmailVerified = false
 	}
+	// Always persist the normalized email so legacy rows with incidental
+	// whitespace self-heal on the next admin edit.
 	user.Email = req.Email
 	if req.Role != "" {
 		user.Role = req.Role

--- a/internal/services/user_oauth_test.go
+++ b/internal/services/user_oauth_test.go
@@ -220,6 +220,53 @@ func TestAuthenticateWithOAuth_ExistingConnection_PromotesEmailVerified(t *testi
 	)
 }
 
+// TestAuthenticateWithOAuth_ExistingConnection_LegacyWhitespaceEmail_Promotes
+// verifies that a pre-existing user row whose stored Email carries incidental
+// whitespace can still be promoted to EmailVerified=true when the (trimmed)
+// provider email matches — i.e. normalization is applied on both sides of
+// the comparison so legacy rows self-heal.
+func TestAuthenticateWithOAuth_ExistingConnection_LegacyWhitespaceEmail_Promotes(
+	t *testing.T,
+) {
+	svc := newOAuthUserService(t)
+
+	providerUserID := uuid.New().String()
+	// Seed user+connection via the normal (normalized) path.
+	user, err := svc.AuthenticateWithOAuth(
+		context.Background(),
+		"github",
+		&auth.OAuthUserInfo{
+			ProviderUserID: providerUserID,
+			Username:       "heidi",
+			Email:          "heidi@example.com",
+			EmailVerified:  false,
+		},
+		newOAuthToken(),
+	)
+	require.NoError(t, err)
+
+	// Simulate a legacy row whose stored email carries incidental whitespace.
+	user.Email = "  heidi@example.com  "
+	require.NoError(t, svc.store.UpdateUser(user))
+
+	// Re-authenticate with a verified flag; comparison must use trimmed
+	// values so the promotion path still fires.
+	promoted, err := svc.AuthenticateWithOAuth(
+		context.Background(),
+		"github",
+		&auth.OAuthUserInfo{
+			ProviderUserID: providerUserID,
+			Username:       "heidi",
+			Email:          "heidi@example.com",
+			EmailVerified:  true,
+		},
+		newOAuthToken(),
+	)
+	require.NoError(t, err)
+	assert.True(t, promoted.EmailVerified,
+		"legacy whitespace in stored email must not block promotion when trimmed values match")
+}
+
 // TestAuthenticateWithOAuth_ExistingConnection_DoesNotPromoteOnEmailMismatch
 // guards against a provider account whose email drifted away from the local
 // user's email: verification of a different address must not promote the

--- a/internal/services/user_oauth_test.go
+++ b/internal/services/user_oauth_test.go
@@ -170,6 +170,94 @@ func TestAuthenticateWithOAuth_ExistingConnection(t *testing.T) {
 	assert.Equal(t, user1.ID, user2.ID)
 }
 
+// TestAuthenticateWithOAuth_ExistingConnection_PromotesEmailVerified verifies
+// that re-authenticating via an already-linked OAuth connection promotes
+// User.EmailVerified to true when the provider reports a verified email that
+// matches the stored address. This covers the migration and steady-state case
+// where existing OAuth users default to EmailVerified=false (e.g., rows added
+// before the column existed) and must self-heal on next login.
+func TestAuthenticateWithOAuth_ExistingConnection_PromotesEmailVerified(t *testing.T) {
+	svc := newOAuthUserService(t)
+
+	providerUserID := uuid.New().String()
+	info := &auth.OAuthUserInfo{
+		ProviderUserID: providerUserID,
+		Username:       "frank",
+		Email:          "frank@example.com",
+		EmailVerified:  true,
+	}
+
+	// Seed a user + connection as if created via a provider that didn't yet
+	// expose verification, leaving EmailVerified=false.
+	user, err := svc.AuthenticateWithOAuth(
+		context.Background(),
+		"github",
+		&auth.OAuthUserInfo{
+			ProviderUserID: providerUserID,
+			Username:       "frank",
+			Email:          "frank@example.com",
+			EmailVerified:  false,
+		},
+		newOAuthToken(),
+	)
+	require.NoError(t, err)
+	require.False(t, user.EmailVerified)
+
+	// Re-authenticate via the same connection with a verified flag — the
+	// stored flag must be promoted.
+	promoted, err := svc.AuthenticateWithOAuth(
+		context.Background(),
+		"github",
+		info,
+		newOAuthToken(),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, user.ID, promoted.ID)
+	assert.True(
+		t,
+		promoted.EmailVerified,
+		"existing OAuth connection must promote EmailVerified when provider confirms the same email",
+	)
+}
+
+// TestAuthenticateWithOAuth_ExistingConnection_DoesNotPromoteOnEmailMismatch
+// guards against a provider account whose email drifted away from the local
+// user's email: verification of a different address must not promote the
+// local user's EmailVerified flag.
+func TestAuthenticateWithOAuth_ExistingConnection_DoesNotPromoteOnEmailMismatch(t *testing.T) {
+	svc := newOAuthUserService(t)
+
+	providerUserID := uuid.New().String()
+	user, err := svc.AuthenticateWithOAuth(
+		context.Background(),
+		"github",
+		&auth.OAuthUserInfo{
+			ProviderUserID: providerUserID,
+			Username:       "grace",
+			Email:          "grace@example.com",
+			EmailVerified:  false,
+		},
+		newOAuthToken(),
+	)
+	require.NoError(t, err)
+	require.False(t, user.EmailVerified)
+
+	// Provider now returns a verified flag but for a different email — the
+	// stored user's EmailVerified must stay false.
+	_, err = svc.AuthenticateWithOAuth(context.Background(), "github", &auth.OAuthUserInfo{
+		ProviderUserID: providerUserID,
+		Username:       "grace",
+		Email:          "other@example.com",
+		EmailVerified:  true,
+	}, newOAuthToken())
+	require.NoError(t, err)
+
+	reloaded, err := svc.store.GetUserByID(user.ID)
+	require.NoError(t, err)
+	assert.False(t, reloaded.EmailVerified,
+		"EmailVerified must not be promoted when the provider email drifted from the stored email")
+}
+
 // TestAuthenticateWithOAuth_AutoRegisterDisabled verifies that when
 // oauthAutoRegister is false, a new user is rejected.
 func TestAuthenticateWithOAuth_AutoRegisterDisabled(t *testing.T) {

--- a/internal/services/user_oauth_test.go
+++ b/internal/services/user_oauth_test.go
@@ -46,6 +46,7 @@ func TestAuthenticateWithOAuth_NewUser(t *testing.T) {
 		Username:       "alice",
 		Email:          "alice@example.com",
 		FullName:       "Alice Example",
+		EmailVerified:  true,
 	}
 
 	user, err := svc.AuthenticateWithOAuth(context.Background(), "github", info, newOAuthToken())
@@ -53,6 +54,65 @@ func TestAuthenticateWithOAuth_NewUser(t *testing.T) {
 	require.NotNil(t, user)
 	assert.Equal(t, "alice@example.com", user.Email)
 	assert.True(t, strings.HasPrefix(user.Username, "alice"))
+	assert.True(t, user.EmailVerified, "verified OAuth email must set User.EmailVerified")
+}
+
+// TestAuthenticateWithOAuth_NewUser_UnverifiedEmail verifies that a new OAuth
+// user from a provider that doesn't verify email is stored with
+// EmailVerified=false so ID tokens don't falsely assert verification.
+func TestAuthenticateWithOAuth_NewUser_UnverifiedEmail(t *testing.T) {
+	svc := newOAuthUserService(t)
+
+	info := &auth.OAuthUserInfo{
+		ProviderUserID: uuid.New().String(),
+		Username:       "dan",
+		Email:          "dan@example.com",
+		EmailVerified:  false,
+	}
+
+	user, err := svc.AuthenticateWithOAuth(context.Background(), "gitea", info, newOAuthToken())
+	require.NoError(t, err)
+	assert.False(t, user.EmailVerified)
+}
+
+// TestAuthenticateWithOAuth_LinkPromotesEmailVerified verifies that when an
+// unverified local user links to a provider that verifies the email, the
+// User.EmailVerified flag is promoted to true.
+func TestAuthenticateWithOAuth_LinkPromotesEmailVerified(t *testing.T) {
+	svc := newOAuthUserService(t)
+
+	// Start as an unverified-email local user created via a non-verifying provider.
+	unverified := &auth.OAuthUserInfo{
+		ProviderUserID: uuid.New().String(),
+		Username:       "eve",
+		Email:          "eve@example.com",
+		EmailVerified:  false,
+	}
+	created, err := svc.AuthenticateWithOAuth(
+		context.Background(),
+		"gitea",
+		unverified,
+		newOAuthToken(),
+	)
+	require.NoError(t, err)
+	require.False(t, created.EmailVerified)
+
+	// Same email comes back via a verifying provider: link + promote.
+	verified := &auth.OAuthUserInfo{
+		ProviderUserID: uuid.New().String(),
+		Username:       "eve",
+		Email:          "eve@example.com",
+		EmailVerified:  true,
+	}
+	linked, err := svc.AuthenticateWithOAuth(
+		context.Background(),
+		"github",
+		verified,
+		newOAuthToken(),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, linked.ID)
+	assert.True(t, linked.EmailVerified, "linking a verified provider must promote EmailVerified")
 }
 
 // TestCreateUserWithOAuth_DuplicateEmail verifies that calling createUserWithOAuth

--- a/internal/services/user_oauth_test.go
+++ b/internal/services/user_oauth_test.go
@@ -220,6 +220,45 @@ func TestAuthenticateWithOAuth_ExistingConnection_PromotesEmailVerified(t *testi
 	)
 }
 
+// TestAuthenticateWithOAuth_AmbiguousEmail_Rejects verifies that when two
+// legacy local rows share the same email modulo whitespace, an OAuth login
+// refuses to auto-link or auto-register rather than guessing which row to
+// bind — operators must deduplicate first.
+func TestAuthenticateWithOAuth_AmbiguousEmail_Rejects(t *testing.T) {
+	svc := newOAuthUserService(t)
+
+	require.NoError(t, svc.store.CreateUser(&models.User{
+		ID:         uuid.New().String(),
+		Username:   "dup-a",
+		Email:      " twin@example.com",
+		Role:       models.UserRoleUser,
+		IsActive:   true,
+		AuthSource: "local",
+	}))
+	require.NoError(t, svc.store.CreateUser(&models.User{
+		ID:         uuid.New().String(),
+		Username:   "dup-b",
+		Email:      "twin@example.com ",
+		Role:       models.UserRoleUser,
+		IsActive:   true,
+		AuthSource: "local",
+	}))
+
+	_, err := svc.AuthenticateWithOAuth(
+		context.Background(),
+		"github",
+		&auth.OAuthUserInfo{
+			ProviderUserID: uuid.New().String(),
+			Username:       "twin",
+			Email:          "twin@example.com",
+			EmailVerified:  true,
+		},
+		newOAuthToken(),
+	)
+	assert.ErrorIs(t, err, ErrAmbiguousEmail,
+		"ambiguous legacy duplicates must surface ErrAmbiguousEmail, not silently link or create")
+}
+
 // TestAuthenticateWithOAuth_ExistingConnection_LegacyWhitespaceEmail_Promotes
 // verifies that a pre-existing user row whose stored Email carries incidental
 // whitespace can still be promoted to EmailVerified=true when the (trimmed)

--- a/internal/services/user_test.go
+++ b/internal/services/user_test.go
@@ -476,6 +476,60 @@ func TestUpdateUserProfile_EmailConflict(t *testing.T) {
 	assert.ErrorIs(t, err, ErrEmailConflict)
 }
 
+func TestUpdateUserProfile_EmailChange_ClearsEmailVerified(t *testing.T) {
+	db := setupTestStore(t)
+	ctrl := gomock.NewController(t)
+	mockCache := mocks.NewMockCache[models.User](ctrl)
+
+	u := makeTestUser(t, db)
+	u.EmailVerified = true
+	require.NoError(t, db.UpdateUser(u))
+
+	actor := makeTestUser(t, db)
+
+	mockCache.EXPECT().Delete(gomock.Any(), "user:"+u.ID).Return(nil).Times(1)
+
+	svc := newUserServiceWithStore(db, mockCache)
+	err := svc.UpdateUserProfile(context.Background(), u.ID, actor.ID, UpdateUserProfileRequest{
+		FullName: u.FullName,
+		Email:    "new-" + u.Email,
+		Role:     u.Role,
+	})
+	require.NoError(t, err)
+
+	updated, err := db.GetUserByID(u.ID)
+	require.NoError(t, err)
+	assert.False(t, updated.EmailVerified,
+		"changing the email via admin edit must downgrade EmailVerified")
+}
+
+func TestUpdateUserProfile_EmailUnchanged_PreservesEmailVerified(t *testing.T) {
+	db := setupTestStore(t)
+	ctrl := gomock.NewController(t)
+	mockCache := mocks.NewMockCache[models.User](ctrl)
+
+	u := makeTestUser(t, db)
+	u.EmailVerified = true
+	require.NoError(t, db.UpdateUser(u))
+
+	actor := makeTestUser(t, db)
+
+	mockCache.EXPECT().Delete(gomock.Any(), "user:"+u.ID).Return(nil).Times(1)
+
+	svc := newUserServiceWithStore(db, mockCache)
+	err := svc.UpdateUserProfile(context.Background(), u.ID, actor.ID, UpdateUserProfileRequest{
+		FullName: "Renamed",
+		Email:    u.Email,
+		Role:     u.Role,
+	})
+	require.NoError(t, err)
+
+	updated, err := db.GetUserByID(u.ID)
+	require.NoError(t, err)
+	assert.True(t, updated.EmailVerified,
+		"EmailVerified must persist when the email is unchanged")
+}
+
 func TestUpdateUserProfile_CannotDemoteLastAdmin(t *testing.T) {
 	db := setupTestStore(t)
 	ctrl := gomock.NewController(t)

--- a/internal/services/user_test.go
+++ b/internal/services/user_test.go
@@ -504,6 +504,37 @@ func TestUpdateUserProfile_EmailChange_ClearsEmailVerified(t *testing.T) {
 		"changing the email via admin edit must downgrade EmailVerified")
 }
 
+func TestUpdateUserProfile_NormalizationEdit_DetectsConflict(t *testing.T) {
+	db := setupTestStore(t)
+	ctrl := gomock.NewController(t)
+	mockCache := mocks.NewMockCache[models.User](ctrl)
+
+	// u has a legacy whitespace email; another user already owns the trimmed form.
+	u := makeTestUser(t, db)
+	trimmed := u.Email
+	u.Email = "  " + trimmed + "  "
+	require.NoError(t, db.UpdateUser(u))
+
+	other := makeTestUser(t, db)
+	other.Email = trimmed
+	require.NoError(t, db.UpdateUser(other))
+
+	actor := makeTestUser(t, db)
+
+	svc := newUserServiceWithStore(db, mockCache)
+	err := svc.UpdateUserProfile(context.Background(), u.ID, actor.ID, UpdateUserProfileRequest{
+		FullName: u.FullName,
+		Email:    trimmed, // pure normalization edit
+		Role:     u.Role,
+	})
+	assert.ErrorIs(
+		t,
+		err,
+		ErrEmailConflict,
+		"normalization-only edit must surface a deterministic ErrEmailConflict instead of a DB error",
+	)
+}
+
 func TestUpdateUserProfile_LegacyUnnormalizedStoredEmail_SelfHeals(t *testing.T) {
 	db := setupTestStore(t)
 	ctrl := gomock.NewController(t)

--- a/internal/services/user_test.go
+++ b/internal/services/user_test.go
@@ -503,6 +503,35 @@ func TestUpdateUserProfile_EmailChange_ClearsEmailVerified(t *testing.T) {
 		"changing the email via admin edit must downgrade EmailVerified")
 }
 
+func TestUpdateUserProfile_EmailWhitespaceOnly_PreservesEmailVerified(t *testing.T) {
+	db := setupTestStore(t)
+	ctrl := gomock.NewController(t)
+	mockCache := mocks.NewMockCache[models.User](ctrl)
+
+	u := makeTestUser(t, db)
+	u.EmailVerified = true
+	require.NoError(t, db.UpdateUser(u))
+
+	actor := makeTestUser(t, db)
+
+	mockCache.EXPECT().Delete(gomock.Any(), "user:"+u.ID).Return(nil).Times(1)
+
+	svc := newUserServiceWithStore(db, mockCache)
+	err := svc.UpdateUserProfile(context.Background(), u.ID, actor.ID, UpdateUserProfileRequest{
+		FullName: u.FullName,
+		Email:    "  " + u.Email + "  ", // only whitespace differs
+		Role:     u.Role,
+	})
+	require.NoError(t, err)
+
+	updated, err := db.GetUserByID(u.ID)
+	require.NoError(t, err)
+	assert.Equal(t, u.Email, updated.Email,
+		"trimmed email must be stored; trailing whitespace must not leak")
+	assert.True(t, updated.EmailVerified,
+		"accidental whitespace in req.Email must not downgrade EmailVerified")
+}
+
 func TestUpdateUserProfile_EmailUnchanged_PreservesEmailVerified(t *testing.T) {
 	db := setupTestStore(t)
 	ctrl := gomock.NewController(t)

--- a/internal/services/user_test.go
+++ b/internal/services/user_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -501,6 +502,38 @@ func TestUpdateUserProfile_EmailChange_ClearsEmailVerified(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, updated.EmailVerified,
 		"changing the email via admin edit must downgrade EmailVerified")
+}
+
+func TestUpdateUserProfile_LegacyUnnormalizedStoredEmail_SelfHeals(t *testing.T) {
+	db := setupTestStore(t)
+	ctrl := gomock.NewController(t)
+	mockCache := mocks.NewMockCache[models.User](ctrl)
+
+	u := makeTestUser(t, db)
+	// Simulate a legacy row whose stored email carries incidental whitespace.
+	u.Email = "  " + u.Email + "  "
+	u.EmailVerified = true
+	require.NoError(t, db.UpdateUser(u))
+	normalizedEmail := strings.TrimSpace(u.Email)
+
+	actor := makeTestUser(t, db)
+
+	mockCache.EXPECT().Delete(gomock.Any(), "user:"+u.ID).Return(nil).Times(1)
+
+	svc := newUserServiceWithStore(db, mockCache)
+	err := svc.UpdateUserProfile(context.Background(), u.ID, actor.ID, UpdateUserProfileRequest{
+		FullName: u.FullName,
+		Email:    normalizedEmail, // admin re-enters same logical email
+		Role:     u.Role,
+	})
+	require.NoError(t, err)
+
+	updated, err := db.GetUserByID(u.ID)
+	require.NoError(t, err)
+	assert.Equal(t, normalizedEmail, updated.Email,
+		"stored email must be rewritten to the trimmed form")
+	assert.True(t, updated.EmailVerified,
+		"a no-op edit against a legacy whitespace row must not downgrade EmailVerified")
 }
 
 func TestUpdateUserProfile_EmailWhitespaceOnly_PreservesEmailVerified(t *testing.T) {

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -6,6 +6,11 @@ var (
 	// ErrUsernameConflict is returned when a username already exists
 	ErrUsernameConflict = errors.New("username already exists")
 
+	// ErrExternalUserMissingIdentity is returned by UpsertExternalUser when
+	// the upstream provider supplied a whitespace-only (or empty) username or
+	// email. Without a stable identity we cannot safely create or link a user.
+	ErrExternalUserMissingIdentity = errors.New("external user missing username or email")
+
 	// ErrAuthCodeAlreadyUsed is returned by MarkAuthorizationCodeUsed when the
 	// code was already consumed by a concurrent request (0 rows updated).
 	ErrAuthCodeAlreadyUsed = errors.New("authorization code already used")

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -14,10 +14,11 @@ var (
 		"external user missing required identity field (username, external_id, auth_source, or email)",
 	)
 
-	// ErrAmbiguousEmail is returned when GetUserByEmail's whitespace-tolerant
-	// fallback lookup matches more than one row — a signal that legacy data
-	// contains duplicate emails differing only in whitespace, which must be
-	// deduped manually before the caller can proceed.
+	// ErrAmbiguousEmail is returned by FindUserByNormalizedEmail when more
+	// than one row matches the whitespace-normalized email — a signal that
+	// legacy data contains duplicates differing only in incidental
+	// whitespace, which must be deduped manually before the caller can
+	// proceed. GetUserByEmail (exact indexed match) never returns this.
 	ErrAmbiguousEmail = errors.New(
 		"multiple users match the normalized email; manual deduplication required",
 	)

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -7,9 +7,20 @@ var (
 	ErrUsernameConflict = errors.New("username already exists")
 
 	// ErrExternalUserMissingIdentity is returned by UpsertExternalUser when
-	// the upstream provider supplied a whitespace-only (or empty) username or
-	// email. Without a stable identity we cannot safely create or link a user.
-	ErrExternalUserMissingIdentity = errors.New("external user missing username or email")
+	// one of the required identity fields (username, externalID, authSource,
+	// or — on create — email) is blank after trimming. Without a stable
+	// identity we cannot safely create or link a user.
+	ErrExternalUserMissingIdentity = errors.New(
+		"external user missing required identity field (username, external_id, auth_source, or email)",
+	)
+
+	// ErrAmbiguousEmail is returned when GetUserByEmail's whitespace-tolerant
+	// fallback lookup matches more than one row — a signal that legacy data
+	// contains duplicate emails differing only in whitespace, which must be
+	// deduped manually before the caller can proceed.
+	ErrAmbiguousEmail = errors.New(
+		"multiple users match the normalized email; manual deduplication required",
+	)
 
 	// ErrAuthCodeAlreadyUsed is returned by MarkAuthorizationCodeUsed when the
 	// code was already consumed by a concurrent request (0 rows updated).

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1619,12 +1619,13 @@ func TestUpsertExternalUser_EmptyAuthSource_Rejects(t *testing.T) {
 	assert.ErrorIs(t, err, ErrExternalUserMissingIdentity)
 }
 
-// TestGetUserByEmail_ExactMatchPlusLegacyDuplicate_ReturnsError verifies that
-// even when a properly normalized row exists, the presence of any legacy
-// whitespace-variant duplicate still surfaces ErrAmbiguousEmail. The exact
-// match alone is not safe to return because the OAuth auto-link path would
-// otherwise silently pick it while another row owns the same logical email.
-func TestGetUserByEmail_ExactMatchPlusLegacyDuplicate_ReturnsError(t *testing.T) {
+// TestFindUserByNormalizedEmail_ExactMatchPlusLegacyDuplicate_ReturnsError
+// verifies that even when a properly normalized row exists, the presence of
+// any legacy whitespace-variant duplicate still surfaces ErrAmbiguousEmail.
+// The exact match alone is not safe to return because the OAuth auto-link
+// path would otherwise silently pick it while another row owns the same
+// logical email.
+func TestFindUserByNormalizedEmail_ExactMatchPlusLegacyDuplicate_ReturnsError(t *testing.T) {
 	store, err := New(context.Background(), "sqlite", ":memory:", getTestConfig())
 	require.NoError(t, err)
 
@@ -1650,12 +1651,14 @@ func TestGetUserByEmail_ExactMatchPlusLegacyDuplicate_ReturnsError(t *testing.T)
 		"ambiguity must be surfaced even when an exact match exists alongside a legacy duplicate")
 }
 
-// TestGetUserByEmail_AmbiguousWhitespaceDuplicates_ReturnsError verifies that
-// when the TRIM fallback would match more than one legacy row the store
-// refuses to pick a non-deterministic winner and surfaces ErrAmbiguousEmail.
-// The OAuth auto-link path relies on this so it never links a verified
-// provider to the wrong local user.
-func TestGetUserByEmail_AmbiguousWhitespaceDuplicates_ReturnsError(t *testing.T) {
+// TestFindUserByNormalizedEmail_AmbiguousWhitespaceDuplicates_ReturnsError
+// verifies that when the TRIM-based lookup matches more than one legacy row
+// the store refuses to pick a non-deterministic winner and surfaces
+// ErrAmbiguousEmail. The OAuth auto-link path relies on this so it never
+// links a verified provider to the wrong local user.
+func TestFindUserByNormalizedEmail_AmbiguousWhitespaceDuplicates_ReturnsError(
+	t *testing.T,
+) {
 	store, err := New(context.Background(), "sqlite", ":memory:", getTestConfig())
 	require.NoError(t, err)
 
@@ -1681,12 +1684,12 @@ func TestGetUserByEmail_AmbiguousWhitespaceDuplicates_ReturnsError(t *testing.T)
 		"ambiguous whitespace-variant duplicates must surface ErrAmbiguousEmail")
 }
 
-// TestGetUserByEmail_LegacyWhitespace_FallbackMatches verifies that a legacy
-// row whose stored Email contains incidental whitespace is still returned
-// when the caller looks it up with the trimmed address. Without the
-// TRIM-based fallback, the next OAuth login would miss this row and create
-// a duplicate account.
-func TestGetUserByEmail_LegacyWhitespace_FallbackMatches(t *testing.T) {
+// TestFindUserByNormalizedEmail_LegacyWhitespace_Matches verifies that a
+// legacy row whose stored Email contains incidental whitespace is still
+// returned when the caller looks it up with the trimmed address. Without
+// this whitespace-tolerant lookup, the next OAuth login would miss the row
+// and create a duplicate account.
+func TestFindUserByNormalizedEmail_LegacyWhitespace_Matches(t *testing.T) {
 	store, err := New(context.Background(), "sqlite", ":memory:", getTestConfig())
 	require.NoError(t, err)
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1645,7 +1645,7 @@ func TestGetUserByEmail_ExactMatchPlusLegacyDuplicate_ReturnsError(t *testing.T)
 		AuthSource: "http_api",
 	}))
 
-	_, err = store.GetUserByEmail("mixed@example.com")
+	_, err = store.FindUserByNormalizedEmail("mixed@example.com")
 	assert.ErrorIs(t, err, ErrAmbiguousEmail,
 		"ambiguity must be surfaced even when an exact match exists alongside a legacy duplicate")
 }
@@ -1676,7 +1676,7 @@ func TestGetUserByEmail_AmbiguousWhitespaceDuplicates_ReturnsError(t *testing.T)
 		AuthSource: "http_api",
 	}))
 
-	_, err = store.GetUserByEmail("dup@example.com")
+	_, err = store.FindUserByNormalizedEmail("dup@example.com")
 	assert.ErrorIs(t, err, ErrAmbiguousEmail,
 		"ambiguous whitespace-variant duplicates must surface ErrAmbiguousEmail")
 }
@@ -1701,10 +1701,10 @@ func TestGetUserByEmail_LegacyWhitespace_FallbackMatches(t *testing.T) {
 	}
 	require.NoError(t, store.CreateUser(legacy))
 
-	got, err := store.GetUserByEmail("legacy@example.com")
+	got, err := store.FindUserByNormalizedEmail("legacy@example.com")
 	require.NoError(t, err)
 	assert.Equal(t, legacy.ID, got.ID,
-		"GetUserByEmail must fall back to TRIM(email) to locate legacy rows")
+		"FindUserByNormalizedEmail must match legacy rows via TRIM(email)")
 }
 
 // TestUpsertExternalUser_EmailUnchanged_PreservesEmailVerified verifies that

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1585,6 +1585,66 @@ func TestUpsertExternalUser_EmptyUsername_Rejects(t *testing.T) {
 	assert.ErrorIs(t, err, ErrExternalUserMissingIdentity)
 }
 
+// TestUpsertExternalUser_EmptyExternalID_Rejects verifies that a
+// whitespace-only externalID is rejected — otherwise the (external_id,
+// auth_source) lookup key would collapse unrelated accounts onto the same
+// row.
+func TestUpsertExternalUser_EmptyExternalID_Rejects(t *testing.T) {
+	store, err := New(context.Background(), "sqlite", ":memory:", getTestConfig())
+	require.NoError(t, err)
+
+	_, err = store.UpsertExternalUser(
+		"someone",
+		"   ",
+		"http_api",
+		"someone@example.com",
+		"Someone",
+	)
+	assert.ErrorIs(t, err, ErrExternalUserMissingIdentity)
+}
+
+// TestUpsertExternalUser_EmptyAuthSource_Rejects verifies that an empty
+// authSource is rejected alongside the other identity fields.
+func TestUpsertExternalUser_EmptyAuthSource_Rejects(t *testing.T) {
+	store, err := New(context.Background(), "sqlite", ":memory:", getTestConfig())
+	require.NoError(t, err)
+
+	_, err = store.UpsertExternalUser(
+		"someone",
+		"ext-someone",
+		"   ",
+		"someone@example.com",
+		"Someone",
+	)
+	assert.ErrorIs(t, err, ErrExternalUserMissingIdentity)
+}
+
+// TestGetUserByEmail_LegacyWhitespace_FallbackMatches verifies that a legacy
+// row whose stored Email contains incidental whitespace is still returned
+// when the caller looks it up with the trimmed address. Without the
+// TRIM-based fallback, the next OAuth login would miss this row and create
+// a duplicate account.
+func TestGetUserByEmail_LegacyWhitespace_FallbackMatches(t *testing.T) {
+	store, err := New(context.Background(), "sqlite", ":memory:", getTestConfig())
+	require.NoError(t, err)
+
+	legacy := &models.User{
+		ID:           uuid.New().String(),
+		Username:     "legacy-email",
+		Email:        "  legacy@example.com  ",
+		PasswordHash: "",
+		Role:         models.UserRoleUser,
+		IsActive:     true,
+		AuthSource:   "http_api",
+	}
+	require.NoError(t, store.CreateUser(legacy))
+
+	got, err := store.GetUserByEmail("legacy@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, legacy.ID, got.ID,
+		"GetUserByEmail must fall back to TRIM(email) to locate legacy rows")
+}
+
 // TestUpsertExternalUser_EmailUnchanged_PreservesEmailVerified verifies that
 // EmailVerified is preserved when the external sync keeps the same email.
 func TestUpsertExternalUser_EmailUnchanged_PreservesEmailVerified(t *testing.T) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1483,6 +1483,108 @@ func TestUpsertExternalUser_EmailWhitespaceOnly_PreservesEmailVerified(t *testin
 		"whitespace-only differences must not downgrade EmailVerified")
 }
 
+// TestUpsertExternalUser_LegacyUnnormalizedEmail_SelfHeals verifies that a
+// pre-existing row with incidental whitespace in its stored email does not
+// trigger a spurious EmailVerified downgrade on the next sync, and that the
+// stored email is rewritten to the trimmed form.
+func TestUpsertExternalUser_LegacyUnnormalizedEmail_SelfHeals(t *testing.T) {
+	store, err := New(context.Background(), "sqlite", ":memory:", getTestConfig())
+	require.NoError(t, err)
+
+	legacy := &models.User{
+		ID:            uuid.New().String(),
+		Username:      "legacy",
+		Email:         "  legacy@example.com  ", // legacy whitespace
+		PasswordHash:  "",
+		Role:          models.UserRoleUser,
+		IsActive:      true,
+		ExternalID:    "ext-legacy",
+		AuthSource:    "http_api",
+		EmailVerified: true,
+	}
+	require.NoError(t, store.CreateUser(legacy))
+
+	updated, err := store.UpsertExternalUser(
+		"legacy",
+		"ext-legacy",
+		"http_api",
+		"legacy@example.com",
+		"Legacy",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "legacy@example.com", updated.Email,
+		"trimmed email must overwrite a legacy value with whitespace")
+	assert.True(t, updated.EmailVerified,
+		"self-heal must not downgrade EmailVerified when only whitespace differs")
+}
+
+// TestUpsertExternalUser_EmptyEmailOnUpdate_KeepsStoredEmail verifies that
+// when an external provider omits the email on a subsequent login, the
+// stored email and EmailVerified are preserved instead of blanked.
+func TestUpsertExternalUser_EmptyEmailOnUpdate_KeepsStoredEmail(t *testing.T) {
+	store, err := New(context.Background(), "sqlite", ":memory:", getTestConfig())
+	require.NoError(t, err)
+
+	user, err := store.UpsertExternalUser(
+		"flora",
+		"ext-flora",
+		"http_api",
+		"flora@example.com",
+		"Flora",
+	)
+	require.NoError(t, err)
+	user.EmailVerified = true
+	require.NoError(t, store.UpdateUser(user))
+
+	updated, err := store.UpsertExternalUser(
+		"flora",
+		"ext-flora",
+		"http_api",
+		"",
+		"",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "flora@example.com", updated.Email,
+		"stored email must be preserved when upstream omits it")
+	assert.Equal(t, "Flora", updated.FullName,
+		"stored full name must be preserved when upstream omits it")
+	assert.True(t, updated.EmailVerified,
+		"EmailVerified must not be cleared when upstream omits the email")
+}
+
+// TestUpsertExternalUser_EmptyEmailOnCreate_Rejects verifies that creating a
+// new external user without an email is rejected — the UNIQUE NOT NULL email
+// column cannot hold blank rows.
+func TestUpsertExternalUser_EmptyEmailOnCreate_Rejects(t *testing.T) {
+	store, err := New(context.Background(), "sqlite", ":memory:", getTestConfig())
+	require.NoError(t, err)
+
+	_, err = store.UpsertExternalUser(
+		"ghost",
+		"ext-ghost",
+		"http_api",
+		"",
+		"",
+	)
+	assert.ErrorIs(t, err, ErrExternalUserMissingIdentity)
+}
+
+// TestUpsertExternalUser_EmptyUsername_Rejects verifies that a whitespace-only
+// username is rejected before reaching the DB.
+func TestUpsertExternalUser_EmptyUsername_Rejects(t *testing.T) {
+	store, err := New(context.Background(), "sqlite", ":memory:", getTestConfig())
+	require.NoError(t, err)
+
+	_, err = store.UpsertExternalUser(
+		"   ",
+		"ext-empty",
+		"http_api",
+		"foo@example.com",
+		"Foo",
+	)
+	assert.ErrorIs(t, err, ErrExternalUserMissingIdentity)
+}
+
 // TestUpsertExternalUser_EmailUnchanged_PreservesEmailVerified verifies that
 // EmailVerified is preserved when the external sync keeps the same email.
 func TestUpsertExternalUser_EmailUnchanged_PreservesEmailVerified(t *testing.T) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1619,6 +1619,37 @@ func TestUpsertExternalUser_EmptyAuthSource_Rejects(t *testing.T) {
 	assert.ErrorIs(t, err, ErrExternalUserMissingIdentity)
 }
 
+// TestGetUserByEmail_AmbiguousWhitespaceDuplicates_ReturnsError verifies that
+// when the TRIM fallback would match more than one legacy row the store
+// refuses to pick a non-deterministic winner and surfaces ErrAmbiguousEmail.
+// The OAuth auto-link path relies on this so it never links a verified
+// provider to the wrong local user.
+func TestGetUserByEmail_AmbiguousWhitespaceDuplicates_ReturnsError(t *testing.T) {
+	store, err := New(context.Background(), "sqlite", ":memory:", getTestConfig())
+	require.NoError(t, err)
+
+	require.NoError(t, store.CreateUser(&models.User{
+		ID:         uuid.New().String(),
+		Username:   "legacy-1",
+		Email:      "  dup@example.com  ",
+		Role:       models.UserRoleUser,
+		IsActive:   true,
+		AuthSource: "http_api",
+	}))
+	require.NoError(t, store.CreateUser(&models.User{
+		ID:         uuid.New().String(),
+		Username:   "legacy-2",
+		Email:      " dup@example.com", // differs by whitespace only
+		Role:       models.UserRoleUser,
+		IsActive:   true,
+		AuthSource: "http_api",
+	}))
+
+	_, err = store.GetUserByEmail("dup@example.com")
+	assert.ErrorIs(t, err, ErrAmbiguousEmail,
+		"ambiguous whitespace-variant duplicates must surface ErrAmbiguousEmail")
+}
+
 // TestGetUserByEmail_LegacyWhitespace_FallbackMatches verifies that a legacy
 // row whose stored Email contains incidental whitespace is still returned
 // when the caller looks it up with the trimmed address. Without the

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1415,6 +1415,71 @@ func TestUpsertExternalUser_Success_UpdateExisting(t *testing.T) {
 	assert.Equal(t, "Robert Builder", updatedUser.FullName)
 }
 
+// TestUpsertExternalUser_EmailChange_ClearsEmailVerified verifies that when an
+// external auth sync changes the user's email, EmailVerified is reset to false.
+// External systems can't prove the new address is verified, so ID tokens must
+// not continue asserting email_verified=true after the address changes.
+func TestUpsertExternalUser_EmailChange_ClearsEmailVerified(t *testing.T) {
+	store, err := New(context.Background(), "sqlite", ":memory:", getTestConfig())
+	require.NoError(t, err)
+
+	user, err := store.UpsertExternalUser(
+		"carol",
+		"ext-carol",
+		"http_api",
+		"carol@example.com",
+		"Carol",
+	)
+	require.NoError(t, err)
+
+	// Promote to verified, as if a trusted OAuth provider had confirmed it.
+	user.EmailVerified = true
+	require.NoError(t, store.UpdateUser(user))
+
+	// External sync returns a new email — verification must be downgraded.
+	updated, err := store.UpsertExternalUser(
+		"carol",
+		"ext-carol",
+		"http_api",
+		"carol.new@example.com",
+		"Carol",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "carol.new@example.com", updated.Email)
+	assert.False(t, updated.EmailVerified,
+		"changing the email via external sync must downgrade EmailVerified")
+}
+
+// TestUpsertExternalUser_EmailUnchanged_PreservesEmailVerified verifies that
+// EmailVerified is preserved when the external sync keeps the same email.
+func TestUpsertExternalUser_EmailUnchanged_PreservesEmailVerified(t *testing.T) {
+	store, err := New(context.Background(), "sqlite", ":memory:", getTestConfig())
+	require.NoError(t, err)
+
+	user, err := store.UpsertExternalUser(
+		"dave",
+		"ext-dave",
+		"http_api",
+		"dave@example.com",
+		"Dave",
+	)
+	require.NoError(t, err)
+
+	user.EmailVerified = true
+	require.NoError(t, store.UpdateUser(user))
+
+	updated, err := store.UpsertExternalUser(
+		"dave",
+		"ext-dave",
+		"http_api",
+		"dave@example.com",
+		"David",
+	)
+	require.NoError(t, err)
+	assert.True(t, updated.EmailVerified,
+		"EmailVerified must persist when the email is unchanged")
+}
+
 // TestDefaultAdminPassword_WhitespaceHandling tests that whitespace-only passwords are treated as empty
 func TestDefaultAdminPassword_WhitespaceHandling(t *testing.T) {
 	tests := []struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1450,6 +1450,39 @@ func TestUpsertExternalUser_EmailChange_ClearsEmailVerified(t *testing.T) {
 		"changing the email via external sync must downgrade EmailVerified")
 }
 
+// TestUpsertExternalUser_EmailWhitespaceOnly_PreservesEmailVerified verifies
+// that incidental whitespace from an external provider does not spuriously
+// clear EmailVerified. The trimmed email is what ends up stored.
+func TestUpsertExternalUser_EmailWhitespaceOnly_PreservesEmailVerified(t *testing.T) {
+	store, err := New(context.Background(), "sqlite", ":memory:", getTestConfig())
+	require.NoError(t, err)
+
+	user, err := store.UpsertExternalUser(
+		"erin",
+		"ext-erin",
+		"http_api",
+		"erin@example.com",
+		"Erin",
+	)
+	require.NoError(t, err)
+
+	user.EmailVerified = true
+	require.NoError(t, store.UpdateUser(user))
+
+	updated, err := store.UpsertExternalUser(
+		"erin",
+		"ext-erin",
+		"http_api",
+		"  erin@example.com  ",
+		"Erin",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "erin@example.com", updated.Email,
+		"trimmed email must be stored; trailing whitespace must not leak")
+	assert.True(t, updated.EmailVerified,
+		"whitespace-only differences must not downgrade EmailVerified")
+}
+
 // TestUpsertExternalUser_EmailUnchanged_PreservesEmailVerified verifies that
 // EmailVerified is preserved when the external sync keeps the same email.
 func TestUpsertExternalUser_EmailUnchanged_PreservesEmailVerified(t *testing.T) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1619,6 +1619,37 @@ func TestUpsertExternalUser_EmptyAuthSource_Rejects(t *testing.T) {
 	assert.ErrorIs(t, err, ErrExternalUserMissingIdentity)
 }
 
+// TestGetUserByEmail_ExactMatchPlusLegacyDuplicate_ReturnsError verifies that
+// even when a properly normalized row exists, the presence of any legacy
+// whitespace-variant duplicate still surfaces ErrAmbiguousEmail. The exact
+// match alone is not safe to return because the OAuth auto-link path would
+// otherwise silently pick it while another row owns the same logical email.
+func TestGetUserByEmail_ExactMatchPlusLegacyDuplicate_ReturnsError(t *testing.T) {
+	store, err := New(context.Background(), "sqlite", ":memory:", getTestConfig())
+	require.NoError(t, err)
+
+	require.NoError(t, store.CreateUser(&models.User{
+		ID:         uuid.New().String(),
+		Username:   "normal",
+		Email:      "mixed@example.com", // exact match
+		Role:       models.UserRoleUser,
+		IsActive:   true,
+		AuthSource: "http_api",
+	}))
+	require.NoError(t, store.CreateUser(&models.User{
+		ID:         uuid.New().String(),
+		Username:   "legacy",
+		Email:      "  mixed@example.com", // normalizes to the same value
+		Role:       models.UserRoleUser,
+		IsActive:   true,
+		AuthSource: "http_api",
+	}))
+
+	_, err = store.GetUserByEmail("mixed@example.com")
+	assert.ErrorIs(t, err, ErrAmbiguousEmail,
+		"ambiguity must be surfaced even when an exact match exists alongside a legacy duplicate")
+}
+
 // TestGetUserByEmail_AmbiguousWhitespaceDuplicates_ReturnsError verifies that
 // when the TRIM fallback would match more than one legacy row the store
 // refuses to pick a non-deterministic winner and surfaces ErrAmbiguousEmail.

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -189,60 +189,44 @@ func (s *Store) GetUsersByIDs(userIDs []string) (map[string]*models.User, error)
 	return userMap, nil
 }
 
-// GetUserByEmail finds a user by email address. The lookup is resilient to
-// incidental whitespace on either side: the argument is trimmed before
-// matching. If more than one row ties to the normalized value — whether via
-// exact match plus a legacy duplicate or purely through the fallback — the
-// function returns ErrAmbiguousEmail rather than picking a non-deterministic
-// winner. In the OAuth auto-link path this guarantees a verified provider
-// can never silently bind to the wrong local user when legacy whitespace
-// duplicates exist.
-//
-// Performance: the fast path is an indexed `email = ?` lookup. The
-// TRIM-based scan is only exercised when either (a) the exact match
-// returned nothing (so we fall back to legacy rows), or (b) an exact match
-// was found and we need to confirm no legacy whitespace duplicate exists.
-// The confirmation query is capped to one extra row (LIMIT 1 excluding the
-// exact-match ID) to keep scans bounded on large tables.
-//
-// Known limitation: Go's strings.TrimSpace strips Unicode whitespace (tabs,
-// newlines, NBSP, …) while SQL TRIM() only removes ASCII spaces by default
-// on the supported dialects (SQLite, Postgres). In practice OAuth providers
-// and admin forms return ASCII-space whitespace if any, so the divergence
-// only matters for pre-existing legacy rows whose stored email contains
-// exotic whitespace — those rows would miss this lookup. The write paths
-// in this package trim with strings.TrimSpace on insert/update, so newly
-// stored rows stay free of both kinds.
+// GetUserByEmail finds a user by the exact email address, using the UNIQUE
+// index on the column. The input is trimmed with strings.TrimSpace before
+// matching so callers can pass user-entered values safely, but the stored
+// side is not normalized — legacy rows whose stored email carries
+// incidental whitespace will NOT be found by this method. Callers that
+// must protect against ambiguous legacy duplicates (notably the OAuth
+// auto-link path) should use FindUserByNormalizedEmail instead; that path
+// pays for a non-indexed TRIM-based scan in exchange for whitespace
+// tolerance and ambiguity detection.
 func (s *Store) GetUserByEmail(email string) (*models.User, error) {
 	email = strings.TrimSpace(email)
 
-	// Fast path: indexed exact match on the UNIQUE email column.
-	var exact models.User
-	err := s.db.Where("email = ?", email).First(&exact).Error
-	if err == nil {
-		// Confirm there are no legacy whitespace-variant duplicates that
-		// would make this selection ambiguous. Bounded by LIMIT 1.
-		var dup models.User
-		dupErr := s.db.
-			Where("id != ? AND TRIM(email) = ?", exact.ID, email).
-			Limit(1).
-			Find(&dup).
-			Error
-		if dupErr != nil {
-			return nil, dupErr
-		}
-		if dup.ID != "" {
-			return nil, ErrAmbiguousEmail
-		}
-		return &exact, nil
-	}
-	if !errors.Is(err, gorm.ErrRecordNotFound) {
+	var user models.User
+	if err := s.db.Where("email = ?", email).First(&user).Error; err != nil {
 		return nil, err
 	}
+	return &user, nil
+}
 
-	// Fallback: no exact match — scan for legacy rows whose stored email
-	// carries incidental whitespace. Bounded by LIMIT 2 so we can
-	// distinguish a unique legacy match from an ambiguous duplicate.
+// FindUserByNormalizedEmail looks up a user by email with whitespace-
+// tolerant matching on the stored side. When more than one row ties to
+// the normalized value, it returns ErrAmbiguousEmail instead of picking a
+// non-deterministic winner. Intended for the OAuth auto-link flow where
+// binding a verified provider to the wrong local user must be prevented.
+//
+// Performance: the lookup is a `TRIM(email) = ?` scan bounded by LIMIT 2,
+// which is NOT backed by the UNIQUE email index. Callers that do not need
+// whitespace tolerance (the common case — admin uniqueness checks, etc.)
+// should use GetUserByEmail instead.
+//
+// Known limitation: Go's strings.TrimSpace strips Unicode whitespace while
+// SQL TRIM() only removes ASCII spaces by default on SQLite and Postgres.
+// The write paths in this package trim on insert/update, so newly stored
+// rows stay free of both kinds; only pre-existing legacy rows containing
+// exotic whitespace (tabs, NBSP, …) would miss this lookup.
+func (s *Store) FindUserByNormalizedEmail(email string) (*models.User, error) {
+	email = strings.TrimSpace(email)
+
 	var matches []models.User
 	if err := s.db.Where("TRIM(email) = ?", email).Limit(2).Find(&matches).Error; err != nil {
 		return nil, err

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -52,6 +52,12 @@ func (s *Store) UpsertExternalUser(
 	email = strings.TrimSpace(email)
 	fullName = strings.TrimSpace(fullName)
 
+	// Username is required as the primary identifier on every call; reject
+	// whitespace-only input before touching the DB.
+	if username == "" {
+		return nil, ErrExternalUserMissingIdentity
+	}
+
 	var user models.User
 
 	// Try to find existing user by external ID
@@ -79,15 +85,24 @@ func (s *Store) UpsertExternalUser(
 			// Username available, continue with update
 		}
 
-		// Update user fields. An external system has no way to prove that the
-		// new email address is verified, so downgrade EmailVerified whenever
-		// the stored email changes.
-		if user.Email != email {
-			user.EmailVerified = false
-		}
 		user.Username = username
-		user.Email = email
-		user.FullName = fullName
+		// Only overwrite email/fullName when upstream actually provided a
+		// value — some external auth responses (e.g. HTTP API) return only
+		// username+external_id, and blanking the stored email would break
+		// the UNIQUE/NOT NULL constraint and wipe verification state.
+		if email != "" {
+			// An external system has no way to prove that the new email is
+			// verified, so downgrade whenever the stored email changes.
+			// Compare trimmed values so a legacy row with incidental
+			// whitespace does not look like a real change.
+			if strings.TrimSpace(user.Email) != email {
+				user.EmailVerified = false
+			}
+			user.Email = email
+		}
+		if fullName != "" {
+			user.FullName = fullName
+		}
 		if err := s.db.Save(&user).Error; err != nil {
 			return nil, fmt.Errorf("failed to update external user: %w", err)
 		}
@@ -97,6 +112,14 @@ func (s *Store) UpsertExternalUser(
 	// Handle query error
 	if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, fmt.Errorf("failed to query external user: %w", err)
+	}
+
+	// Email is required to create a new external user — it's a UNIQUE NOT NULL
+	// column, and blank rows would collide with each other. (The update branch
+	// above is intentionally lenient, since older rows already carry a valid
+	// email even when upstream omits it on subsequent logins.)
+	if email == "" {
+		return nil, ErrExternalUserMissingIdentity
 	}
 
 	// User doesn't exist - check if username is available

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -190,30 +190,21 @@ func (s *Store) GetUsersByIDs(userIDs []string) (map[string]*models.User, error)
 }
 
 // GetUserByEmail finds a user by email address. The lookup is resilient to
-// incidental whitespace on either side: the argument is trimmed, and if no
-// indexed exact match is found, a fallback scan on TRIM(email) lets callers
-// still locate legacy rows written before email normalization was enforced.
-//
-// When the fallback matches more than one row (legacy duplicates differing
-// only in whitespace), the function returns ErrAmbiguousEmail instead of
-// picking a non-deterministic winner — in the OAuth auto-link path this
-// prevents silently linking a verified provider to the wrong local user.
+// incidental whitespace on either side: the argument is trimmed and the
+// store matches against TRIM(email). If more than one row matches the
+// normalized value — whether via exact match plus a legacy duplicate or
+// purely through the fallback — the function returns ErrAmbiguousEmail
+// rather than picking a non-deterministic winner. In the OAuth auto-link
+// path this guarantees a verified provider can never silently bind to the
+// wrong local user when legacy whitespace duplicates exist.
 func (s *Store) GetUserByEmail(email string) (*models.User, error) {
 	email = strings.TrimSpace(email)
 
-	var user models.User
-	err := s.db.Where("email = ?", email).First(&user).Error
-	if err == nil {
-		return &user, nil
-	}
-	if !errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, err
-	}
-
-	// Fallback: legacy rows may have incidental whitespace in the stored
-	// value. This query bypasses the unique index but is only reached on a
-	// primary miss, so the cost stays bounded. Fetch up to two rows so we
-	// can distinguish unique legacy match from an ambiguous duplicate.
+	// Fetch up to two matches against the normalized stored email. Using
+	// TRIM(email) for the comparison means a legacy row whose Email carries
+	// incidental whitespace is returned alongside a properly normalized row,
+	// so the ambiguity check below catches duplicates regardless of whether
+	// an exact match also exists.
 	var matches []models.User
 	if err := s.db.Where("TRIM(email) = ?", email).Limit(2).Find(&matches).Error; err != nil {
 		return nil, err

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -190,21 +190,50 @@ func (s *Store) GetUsersByIDs(userIDs []string) (map[string]*models.User, error)
 }
 
 // GetUserByEmail finds a user by email address. The lookup is resilient to
-// incidental whitespace on either side: the argument is trimmed and the
-// store matches against TRIM(email). If more than one row matches the
-// normalized value — whether via exact match plus a legacy duplicate or
-// purely through the fallback — the function returns ErrAmbiguousEmail
-// rather than picking a non-deterministic winner. In the OAuth auto-link
-// path this guarantees a verified provider can never silently bind to the
-// wrong local user when legacy whitespace duplicates exist.
+// incidental whitespace on either side: the argument is trimmed before
+// matching. If more than one row ties to the normalized value — whether via
+// exact match plus a legacy duplicate or purely through the fallback — the
+// function returns ErrAmbiguousEmail rather than picking a non-deterministic
+// winner. In the OAuth auto-link path this guarantees a verified provider
+// can never silently bind to the wrong local user when legacy whitespace
+// duplicates exist.
+//
+// Performance: the fast path is an indexed `email = ?` lookup. The
+// TRIM-based scan is only exercised when either (a) the exact match
+// returned nothing (so we fall back to legacy rows), or (b) an exact match
+// was found and we need to confirm no legacy whitespace duplicate exists.
+// The confirmation query is capped to one extra row (LIMIT 1 excluding the
+// exact-match ID) to keep scans bounded on large tables.
 func (s *Store) GetUserByEmail(email string) (*models.User, error) {
 	email = strings.TrimSpace(email)
 
-	// Fetch up to two matches against the normalized stored email. Using
-	// TRIM(email) for the comparison means a legacy row whose Email carries
-	// incidental whitespace is returned alongside a properly normalized row,
-	// so the ambiguity check below catches duplicates regardless of whether
-	// an exact match also exists.
+	// Fast path: indexed exact match on the UNIQUE email column.
+	var exact models.User
+	err := s.db.Where("email = ?", email).First(&exact).Error
+	if err == nil {
+		// Confirm there are no legacy whitespace-variant duplicates that
+		// would make this selection ambiguous. Bounded by LIMIT 1.
+		var dup models.User
+		dupErr := s.db.
+			Where("id != ? AND TRIM(email) = ?", exact.ID, email).
+			Limit(1).
+			Find(&dup).
+			Error
+		if dupErr != nil {
+			return nil, dupErr
+		}
+		if dup.ID != "" {
+			return nil, ErrAmbiguousEmail
+		}
+		return &exact, nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
+	// Fallback: no exact match — scan for legacy rows whose stored email
+	// carries incidental whitespace. Bounded by LIMIT 2 so we can
+	// distinguish a unique legacy match from an ambiguous duplicate.
 	var matches []models.User
 	if err := s.db.Where("TRIM(email) = ?", email).Limit(2).Find(&matches).Error; err != nil {
 		return nil, err

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -204,6 +204,15 @@ func (s *Store) GetUsersByIDs(userIDs []string) (map[string]*models.User, error)
 // was found and we need to confirm no legacy whitespace duplicate exists.
 // The confirmation query is capped to one extra row (LIMIT 1 excluding the
 // exact-match ID) to keep scans bounded on large tables.
+//
+// Known limitation: Go's strings.TrimSpace strips Unicode whitespace (tabs,
+// newlines, NBSP, …) while SQL TRIM() only removes ASCII spaces by default
+// on the supported dialects (SQLite, Postgres). In practice OAuth providers
+// and admin forms return ASCII-space whitespace if any, so the divergence
+// only matters for pre-existing legacy rows whose stored email contains
+// exotic whitespace — those rows would miss this lookup. The write paths
+// in this package trim with strings.TrimSpace on insert/update, so newly
+// stored rows stay free of both kinds.
 func (s *Store) GetUserByEmail(email string) (*models.User, error) {
 	email = strings.TrimSpace(email)
 

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -3,6 +3,7 @@ package store
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-authgate/authgate/internal/models"
 	"github.com/go-authgate/authgate/internal/store/types"
@@ -44,6 +45,13 @@ func (s *Store) GetUserByExternalID(externalID, authSource string) (*models.User
 func (s *Store) UpsertExternalUser(
 	username, externalID, authSource, email, fullName string,
 ) (*models.User, error) {
+	// Normalize inputs so incidental whitespace from upstream providers does
+	// not pollute storage or spuriously downgrade EmailVerified on the next
+	// login. Matches the trimming performed by the admin create/update paths.
+	username = strings.TrimSpace(username)
+	email = strings.TrimSpace(email)
+	fullName = strings.TrimSpace(fullName)
+
 	var user models.User
 
 	// Try to find existing user by external ID

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -71,7 +71,12 @@ func (s *Store) UpsertExternalUser(
 			// Username available, continue with update
 		}
 
-		// Update user fields
+		// Update user fields. An external system has no way to prove that the
+		// new email address is verified, so downgrade EmailVerified whenever
+		// the stored email changes.
+		if user.Email != email {
+			user.EmailVerified = false
+		}
 		user.Username = username
 		user.Email = email
 		user.FullName = fullName

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -193,6 +193,11 @@ func (s *Store) GetUsersByIDs(userIDs []string) (map[string]*models.User, error)
 // incidental whitespace on either side: the argument is trimmed, and if no
 // indexed exact match is found, a fallback scan on TRIM(email) lets callers
 // still locate legacy rows written before email normalization was enforced.
+//
+// When the fallback matches more than one row (legacy duplicates differing
+// only in whitespace), the function returns ErrAmbiguousEmail instead of
+// picking a non-deterministic winner — in the OAuth auto-link path this
+// prevents silently linking a verified provider to the wrong local user.
 func (s *Store) GetUserByEmail(email string) (*models.User, error) {
 	email = strings.TrimSpace(email)
 
@@ -207,11 +212,20 @@ func (s *Store) GetUserByEmail(email string) (*models.User, error) {
 
 	// Fallback: legacy rows may have incidental whitespace in the stored
 	// value. This query bypasses the unique index but is only reached on a
-	// primary miss, so the cost stays bounded.
-	if err := s.db.Where("TRIM(email) = ?", email).First(&user).Error; err != nil {
+	// primary miss, so the cost stays bounded. Fetch up to two rows so we
+	// can distinguish unique legacy match from an ambiguous duplicate.
+	var matches []models.User
+	if err := s.db.Where("TRIM(email) = ?", email).Limit(2).Find(&matches).Error; err != nil {
 		return nil, err
 	}
-	return &user, nil
+	switch len(matches) {
+	case 0:
+		return nil, gorm.ErrRecordNotFound
+	case 1:
+		return &matches[0], nil
+	default:
+		return nil, ErrAmbiguousEmail
+	}
 }
 
 // CreateUser creates a new user

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -49,12 +49,15 @@ func (s *Store) UpsertExternalUser(
 	// not pollute storage or spuriously downgrade EmailVerified on the next
 	// login. Matches the trimming performed by the admin create/update paths.
 	username = strings.TrimSpace(username)
+	externalID = strings.TrimSpace(externalID)
+	authSource = strings.TrimSpace(authSource)
 	email = strings.TrimSpace(email)
 	fullName = strings.TrimSpace(fullName)
 
-	// Username is required as the primary identifier on every call; reject
-	// whitespace-only input before touching the DB.
-	if username == "" {
+	// Username and the (externalID, authSource) lookup key are required on
+	// every call. A blank externalID would collapse unrelated external
+	// accounts onto whichever row it matched first, so reject early.
+	if username == "" || externalID == "" || authSource == "" {
 		return nil, ErrExternalUserMissingIdentity
 	}
 
@@ -186,10 +189,26 @@ func (s *Store) GetUsersByIDs(userIDs []string) (map[string]*models.User, error)
 	return userMap, nil
 }
 
-// GetUserByEmail finds a user by email address
+// GetUserByEmail finds a user by email address. The lookup is resilient to
+// incidental whitespace on either side: the argument is trimmed, and if no
+// indexed exact match is found, a fallback scan on TRIM(email) lets callers
+// still locate legacy rows written before email normalization was enforced.
 func (s *Store) GetUserByEmail(email string) (*models.User, error) {
+	email = strings.TrimSpace(email)
+
 	var user models.User
-	if err := s.db.Where("email = ?", email).First(&user).Error; err != nil {
+	err := s.db.Where("email = ?", email).First(&user).Error
+	if err == nil {
+		return &user, nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
+	// Fallback: legacy rows may have incidental whitespace in the stored
+	// value. This query bypasses the unique index but is only reached on a
+	// primary miss, so the cost stays bounded.
+	if err := s.db.Where("TRIM(email) = ?", email).First(&user).Error; err != nil {
 		return nil, err
 	}
 	return &user, nil


### PR DESCRIPTION
## Summary
- Add `User.EmailVerified` column (GORM AutoMigrate, default `false`) so per-user verification state can be persisted.
- Drive the `email_verified` claim in both ID Token (`token_exchange.go`) and UserInfo (`oidc.go`) off that field instead of always returning `false`.
- Propagate `OAuthUserInfo.EmailVerified` on OAuth auto-registration, and promote the flag to `true` when linking a trusted provider to an existing account.

### Behaviour by source
- Local / HTTP API / admin-created / seed admin → `false` (unchanged default).
- OAuth via GitHub or Microsoft Entra ID → `true`.
- OAuth via Gitea / GitLab → `false` (those APIs don't expose verification status).
- An unverified user who later links a verifying provider gets promoted to `true`.

### Why
Previously every ID Token advertised `email_verified: false` regardless of how the user signed in, which made the claim effectively useless for relying parties that want to decide whether to trust the email. Now it accurately reflects whether a trusted upstream OAuth provider confirmed the address.

## Test plan
- [x] `make generate`
- [x] `make fmt`
- [x] `make lint` (0 issues)
- [x] `make test` (all packages pass; added `TestBuildUserInfoClaims_EmailVerifiedMirrorsUserField`, `TestExchangeAuthorizationCode_IDToken_EmailVerifiedMirrorsUser`, `TestAuthenticateWithOAuth_NewUser_UnverifiedEmail`, `TestAuthenticateWithOAuth_LinkPromotesEmailVerified`)
- [x] `make build`
- [ ] Verify against a running instance: sign in via GitHub and confirm `email_verified=true` in the issued ID Token / `/oauth/userinfo`; sign in via local admin and confirm it stays `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
