### PR TITLE
feat(admin): support newline input for redirect URIs via tag picker

### DIFF
--- a/internal/handlers/client.go
+++ b/internal/handlers/client.go
@@ -25,14 +25,14 @@ func NewClientHandler(
 	return &ClientHandler{clientService: cs, authorizationService: as}
 }
 
-// parseRedirectURIs parses a comma-separated string into a slice of trimmed URIs
 func parseRedirectURIs(input string) []string {
-	var redirectURIs []string
 	if strings.TrimSpace(input) == "" {
-		return redirectURIs
+		return nil
 	}
-
-	for uri := range strings.SplitSeq(input, ",") {
+	var redirectURIs []string
+	for _, uri := range strings.FieldsFunc(input, func(r rune) bool {
+		return r == ',' || r == '\n' || r == '\r'
+	}) {
 		if trimmed := strings.TrimSpace(uri); trimmed != "" {
 			redirectURIs = append(redirectURIs, trimmed)
 		}

--- a/internal/handlers/client.go
+++ b/internal/handlers/client.go
@@ -26,10 +26,7 @@ func NewClientHandler(
 }
 
 func parseRedirectURIs(input string) []string {
-	if strings.TrimSpace(input) == "" {
-		return nil
-	}
-	var redirectURIs []string
+	redirectURIs := make([]string, 0)
 	for _, uri := range strings.FieldsFunc(input, func(r rune) bool {
 		return r == ',' || r == '\n' || r == '\r'
 	}) {

--- a/internal/handlers/client_test.go
+++ b/internal/handlers/client_test.go
@@ -70,6 +70,35 @@ func Test_parseRedirectURIs(t *testing.T) {
 			input: "http://localhost:8080,http://127.0.0.1:3000",
 			want:  []string{"http://localhost:8080", "http://127.0.0.1:3000"},
 		},
+		{
+			name:  "newline separated",
+			input: "https://a.example.com/cb\nhttps://b.example.com/cb",
+			want:  []string{"https://a.example.com/cb", "https://b.example.com/cb"},
+		},
+		{
+			name:  "CRLF separated",
+			input: "https://a.example.com/cb\r\nhttps://b.example.com/cb",
+			want:  []string{"https://a.example.com/cb", "https://b.example.com/cb"},
+		},
+		{
+			name:  "mixed comma and newline",
+			input: "https://a.example.com/cb,\nhttps://b.example.com/cb\nhttps://c.example.com/cb",
+			want: []string{
+				"https://a.example.com/cb",
+				"https://b.example.com/cb",
+				"https://c.example.com/cb",
+			},
+		},
+		{
+			name:  "newline with surrounding spaces",
+			input: "  https://a.example.com/cb  \n  https://b.example.com/cb  \n",
+			want:  []string{"https://a.example.com/cb", "https://b.example.com/cb"},
+		},
+		{
+			name:  "blank lines between URIs",
+			input: "https://a.example.com/cb\n\n\nhttps://b.example.com/cb",
+			want:  []string{"https://a.example.com/cb", "https://b.example.com/cb"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/handlers/client_test.go
+++ b/internal/handlers/client_test.go
@@ -104,10 +104,6 @@ func Test_parseRedirectURIs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := parseRedirectURIs(tt.input)
-			// Handle nil vs empty slice comparison
-			if len(got) == 0 && len(tt.want) == 0 {
-				return
-			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("parseRedirectURIs() = %v, want %v", got, tt.want)
 			}

--- a/internal/handlers/utils.go
+++ b/internal/handlers/utils.go
@@ -77,7 +77,7 @@ func clientToDisplay(app *models.OAuthApplication) *templates.ClientDisplay {
 		UserID:                      app.UserID,
 		Scopes:                      app.Scopes,
 		GrantTypes:                  app.GrantTypes,
-		RedirectURIs:                app.RedirectURIs.Join("\n"),
+		RedirectURIs:                app.RedirectURIs.Join(", "),
 		ClientType:                  app.ClientType,
 		EnableDeviceFlow:            app.EnableDeviceFlow,
 		EnableAuthCodeFlow:          app.EnableAuthCodeFlow,

--- a/internal/handlers/utils.go
+++ b/internal/handlers/utils.go
@@ -77,7 +77,7 @@ func clientToDisplay(app *models.OAuthApplication) *templates.ClientDisplay {
 		UserID:                      app.UserID,
 		Scopes:                      app.Scopes,
 		GrantTypes:                  app.GrantTypes,
-		RedirectURIs:                app.RedirectURIs.Join(", "),
+		RedirectURIs:                app.RedirectURIs.Join("\n"),
 		ClientType:                  app.ClientType,
 		EnableDeviceFlow:            app.EnableDeviceFlow,
 		EnableAuthCodeFlow:          app.EnableAuthCodeFlow,

--- a/internal/templates/client_shared.templ
+++ b/internal/templates/client_shared.templ
@@ -285,7 +285,7 @@ templ ClientFormCommonFields(props ClientFormFieldsProps) {
 		</div>
 		<small class="admin-form-hint">
 			Press <kbd>Enter</kbd> to add a URI. You can also paste multiple URIs separated by
-			commas or new lines. Click <strong>&times;</strong> on a tag to remove it.
+			commas or newlines. Click <strong>&times;</strong> on a tag to remove it.
 			Required when Authorization Code Flow is enabled.
 		</small>
 	</div>
@@ -503,9 +503,7 @@ templ clientRedirectURIPickerScript() {
 				}
 			});
 			picker.addEventListener('click', function (e) {
-				if (e.target !== textInput && !e.target.classList.contains('admin-uri-tag-remove')) {
-					textInput.focus();
-				}
+				if (e.target !== textInput) { textInput.focus(); }
 			});
 
 			var form = picker.closest('form');

--- a/internal/templates/client_shared.templ
+++ b/internal/templates/client_shared.templ
@@ -490,7 +490,12 @@ templ clientRedirectURIPickerScript() {
 			});
 			textInput.addEventListener('blur', commitInput);
 			textInput.addEventListener('paste', function (e) {
-				var data = (e.clipboardData || window.clipboardData).getData('text');
+				var data = '';
+				if (e.clipboardData) {
+					data = e.clipboardData.getData('text/plain');
+				} else if (window.clipboardData) {
+					data = window.clipboardData.getData('Text');
+				}
 				if (data && /[,\r\n]/.test(data)) {
 					e.preventDefault();
 					addMany(data);

--- a/internal/templates/client_shared.templ
+++ b/internal/templates/client_shared.templ
@@ -265,21 +265,35 @@ templ ClientFormCommonFields(props ClientFormFieldsProps) {
 	</div>
 	<!-- Redirect URIs -->
 	<div class="admin-form-group">
-		<label for="redirect_uris" class="admin-form-label">Redirect URIs</label>
+		<label for="uriTextInput" class="admin-form-label">Redirect URIs</label>
 		if props.Client != nil {
-			<textarea id="redirect_uris" name="redirect_uris" class="admin-form-textarea" rows="3">{ props.Client.RedirectURIs }</textarea>
+			<input type="hidden" id="redirect_uris" name="redirect_uris" value={ props.Client.RedirectURIs }/>
 		} else {
-			<textarea id="redirect_uris" name="redirect_uris" class="admin-form-textarea" rows="3"></textarea>
+			<input type="hidden" id="redirect_uris" name="redirect_uris" value=""/>
 		}
+		<div class="admin-uri-picker" id="uriPicker">
+			<div class="admin-uri-tags" id="uriTags"></div>
+			<input
+				type="text"
+				class="admin-uri-text-input"
+				id="uriTextInput"
+				placeholder="https://app.example.com/callback"
+				autocomplete="off"
+				spellcheck="false"
+				inputmode="url"
+			/>
+		</div>
 		<small class="admin-form-hint">
-			Comma-separated redirect URIs. Required when Authorization Code Flow is enabled.
-			Example: <code>https://app.example.com/callback</code>
+			Press <kbd>Enter</kbd> to add a URI. You can also paste multiple URIs separated by
+			commas or new lines. Click <strong>&times;</strong> on a tag to remove it.
+			Required when Authorization Code Flow is enabled.
 		</small>
 	</div>
 	if props.ShowClientCredentials {
 		@clientCredentialsScript()
 	}
 	@clientScopePickerScript()
+	@clientRedirectURIPickerScript()
 }
 
 // clientCredentialsScript renders the JS that syncs the Client Credentials checkbox
@@ -395,6 +409,104 @@ templ clientScopePickerScript() {
 					if (!presetsOnly) { textInput.focus(); }
 				});
 			});
+
+			init();
+		})();
+	</script>
+}
+
+templ clientRedirectURIPickerScript() {
+	<script>
+		(function () {
+			var hiddenInput = document.getElementById('redirect_uris');
+			var picker      = document.getElementById('uriPicker');
+			var tagsEl      = document.getElementById('uriTags');
+			var textInput   = document.getElementById('uriTextInput');
+			var selected    = [];
+
+			function syncHidden() { hiddenInput.value = selected.join('\n'); }
+
+			function renderTags() {
+				tagsEl.innerHTML = '';
+				selected.forEach(function (uri) {
+					var tag = document.createElement('span');
+					tag.className = 'admin-uri-tag';
+					var label = document.createElement('span');
+					label.className = 'admin-uri-tag-label';
+					label.textContent = uri;
+					var btn = document.createElement('button');
+					btn.type = 'button';
+					btn.className = 'admin-uri-tag-remove';
+					btn.setAttribute('aria-label', 'Remove ' + uri);
+					btn.textContent = '×';
+					btn.addEventListener('click', function () { removeURI(uri); });
+					tag.appendChild(label);
+					tag.appendChild(btn);
+					tagsEl.appendChild(tag);
+				});
+			}
+
+			function render() { renderTags(); syncHidden(); }
+
+			function addURI(u) {
+				u = u.trim();
+				if (u && selected.indexOf(u) === -1) { selected.push(u); render(); }
+			}
+
+			function addMany(text) {
+				text.split(/[\s,]+/).forEach(function (u) {
+					if (u) { addURI(u); }
+				});
+			}
+
+			function removeURI(u) {
+				var i = selected.indexOf(u);
+				if (i !== -1) { selected.splice(i, 1); render(); }
+			}
+
+			function commitInput() {
+				var v = textInput.value;
+				if (v.trim()) { addMany(v); textInput.value = ''; }
+			}
+
+			function init() {
+				var v = hiddenInput.value;
+				if (v && v.trim()) {
+					v.split(/[\s,]+/).forEach(function (u) {
+						u = u.trim();
+						if (u && selected.indexOf(u) === -1) { selected.push(u); }
+					});
+				}
+				render();
+			}
+
+			textInput.addEventListener('keydown', function (e) {
+				if (e.key === 'Enter' || e.key === ',') {
+					e.preventDefault();
+					commitInput();
+				} else if (e.key === 'Backspace' && !textInput.value && selected.length) {
+					removeURI(selected[selected.length - 1]);
+				}
+			});
+			textInput.addEventListener('blur', commitInput);
+			textInput.addEventListener('paste', function (e) {
+				var data = (e.clipboardData || window.clipboardData).getData('text');
+				if (data && /[,\r\n]/.test(data)) {
+					e.preventDefault();
+					addMany(data);
+					textInput.value = '';
+				}
+			});
+			picker.addEventListener('click', function (e) {
+				if (e.target !== textInput && !e.target.classList.contains('admin-uri-tag-remove')) {
+					textInput.focus();
+				}
+			});
+
+			var form = picker.closest('form');
+			if (form) {
+				form.addEventListener('submit', function () { commitInput(); });
+			}
 
 			init();
 		})();

--- a/internal/templates/client_shared.templ
+++ b/internal/templates/client_shared.templ
@@ -454,7 +454,7 @@ templ clientRedirectURIPickerScript() {
 			}
 
 			function addMany(text) {
-				text.split(/[\s,]+/).forEach(function (u) {
+				text.split(/[,\r\n]+/).forEach(function (u) {
 					if (u) { addURI(u); }
 				});
 			}
@@ -472,7 +472,7 @@ templ clientRedirectURIPickerScript() {
 			function init() {
 				var v = hiddenInput.value;
 				if (v && v.trim()) {
-					v.split(/[\s,]+/).forEach(function (u) {
+					v.split(/[,\r\n]+/).forEach(function (u) {
 						u = u.trim();
 						if (u && selected.indexOf(u) === -1) { selected.push(u); }
 					});

--- a/internal/templates/static/css/pages/admin-forms.css
+++ b/internal/templates/static/css/pages/admin-forms.css
@@ -851,6 +851,96 @@ a.admin-user-stat-card-link:hover .admin-user-stat-label {
   color: var(--color-text-secondary);
   line-height: 1.5;
 }
+/* ============================================
+   Redirect URI Tag Picker
+   ============================================ */
+.admin-uri-picker {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  min-height: 52px;
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-bg-secondary);
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  cursor: text;
+  transition: all 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+  box-sizing: border-box;
+}
+.admin-uri-picker:hover {
+  border-color: var(--color-gray-400);
+  background: var(--color-bg-primary);
+}
+.admin-uri-picker:focus-within {
+  outline: none;
+  border-color: var(--color-primary);
+  background: var(--color-bg-primary);
+  box-shadow: 0 0 0 4px rgba(0, 114, 255, 0.1);
+}
+.admin-uri-tags { display: contents; }
+.admin-uri-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: 100%;
+  padding: 4px var(--space-3);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  animation: scopeTagIn 0.15s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.admin-uri-tag-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 48ch;
+}
+.admin-uri-tag-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--color-text-tertiary);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
+  flex-shrink: 0;
+}
+.admin-uri-tag-remove:hover {
+  opacity: 1;
+  color: var(--color-text-primary);
+  background: var(--color-bg-primary);
+}
+.admin-uri-text-input {
+  flex: 1 1 220px;
+  min-width: 180px;
+  padding: 0;
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text-primary);
+  background: transparent;
+  border: none;
+  outline: none;
+  line-height: 1.5;
+}
+.admin-uri-text-input::placeholder {
+  color: var(--color-text-tertiary);
+  font-family: var(--font-sans);
+  font-style: italic;
+}
 @media (prefers-reduced-motion: reduce) {
-  .admin-scope-tag { animation: none !important; }
+  .admin-scope-tag,
+  .admin-uri-tag { animation: none !important; }
 }


### PR DESCRIPTION
## Summary

- Convert the Redirect URIs field on `/admin/clients/new`, `/admin/clients/:id/edit`, `/apps/new`, and `/apps/:id` into a tag-based picker that matches the existing Scopes input.
- Accept commas **or** newlines as separators in `parseRedirectURIs`, so admins can paste multi-line lists from any source (previously only commas worked).
- Pasting comma- or newline-separated text splits automatically into multiple tags; individual tags can be removed with a × button.
- Extend `Test_parseRedirectURIs` with newline, CRLF, mixed comma+newline, blank-line, and surrounding-whitespace cases.

## Test plan

- [ ] `make generate && make fmt && make lint` — all green
- [ ] `make test` — `Test_parseRedirectURIs` passes all 16 cases
- [ ] `./bin/authgate server` → `/admin/clients/new`: enter a URI and press Enter; paste a comma-separated list; paste a newline-separated list; remove one with × — all produce the expected tag set and the created client stores every URI.
- [ ] `/admin/clients/:id/edit`: open an existing client with multiple URIs; confirm they render as tags; remove one and submit; DB reflects the change.
- [ ] `/apps/new` (regular user app form): same flow works.
- [ ] Visually verify the picker's border / focus glow / hover state matches the Scopes picker directly above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
