### PR TITLE
feat(token): add per-client token lifetime profiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,19 @@ SESSION_SECRET=session-secret-change-in-production
 # JWT_EXPIRATION_JITTER=30m        # Max random jitter added to access token expiry (default: 30m)
 #                                  # Prevents thundering herd when many tokens expire simultaneously
 #                                  # Example: JWT_EXPIRATION=8h + JWT_EXPIRATION_JITTER=30m → token lifetime [8h, 8h30m)
+# JWT_EXPIRATION_MAX=24h           # Hard cap on any token profile's access TTL (default: 24h). Startup fails if a profile exceeds this.
+# REFRESH_TOKEN_EXPIRATION_MAX=2160h # Hard cap on any token profile's refresh TTL (default: 2160h / 90 days).
+
+# Token Profiles — per-OAuthApplication TTL presets (short / standard / long).
+# Each OAuth client selects one profile via the "Token Lifetime" admin UI; tokens
+# issued for that client use the preset's access & refresh TTLs. The "standard"
+# profile inherits JWT_EXPIRATION / REFRESH_TOKEN_EXPIRATION by default.
+# TOKEN_PROFILE_SHORT_ACCESS_TTL=15m    # Short access token TTL (default: 15m)
+# TOKEN_PROFILE_SHORT_REFRESH_TTL=24h   # Short refresh token TTL (default: 24h)
+# TOKEN_PROFILE_STANDARD_ACCESS_TTL=    # Defaults to JWT_EXPIRATION
+# TOKEN_PROFILE_STANDARD_REFRESH_TTL=   # Defaults to REFRESH_TOKEN_EXPIRATION
+# TOKEN_PROFILE_LONG_ACCESS_TTL=24h     # Long access token TTL (default: 24h)
+# TOKEN_PROFILE_LONG_REFRESH_TTL=2160h  # Long refresh token TTL (default: 2160h / 90 days)
 
 # Database
 DATABASE_DRIVER=sqlite

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ In addition to Device Code Flow, AuthGate supports Authorization Code Flow with 
 
 - `OAuthApplication` - Supports both Device Flow and Auth Code Flow with per-client toggles (`EnableDeviceFlow`, `EnableAuthCodeFlow`)
 - `OAuthApplication.ClientType` - "confidential" (with secret) or "public" (PKCE only)
+- `OAuthApplication.TokenProfile` - Per-client token lifetime preset: `short` (15min / 1d), `standard` (default, 10h / 30d), or `long` (24h / 90d). Preset TTLs are defined in `config.TokenProfiles` and overridable via `TOKEN_PROFILE_*` env vars; hard caps are enforced via `JWT_EXPIRATION_MAX` / `REFRESH_TOKEN_EXPIRATION_MAX`. Changes to a client's profile take effect on the next token issuance and refresh.
 - `UserAuthorization` - Per-app consent grants (one record per user+app pair)
 - `AccessToken` - Unified storage for both access and refresh tokens (distinguished by `token_category` field)
 - `User.IsActive` - Boolean (default `true`) controlling whether a user may log in. Disabling revokes all of the user's tokens and `RequireAuth` clears any live session on the next request. Guards prevent self-disable and disabling the last *active* admin.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -339,6 +339,20 @@ AuthGate supports refresh tokens following RFC 6749 with configurable rotation m
 - `ENABLE_REFRESH_TOKENS=true` - Feature flag (default: enabled)
 - `ENABLE_TOKEN_ROTATION=false` - Enable rotation mode (default: disabled, uses fixed mode)
 
+### Per-Client Token Lifetime Profiles
+
+Each `OAuthApplication` carries a `token_profile` field (one of `short`, `standard`, `long`; defaults to `standard`) so admins can tune token lifetimes per client without editing base config. Resolution happens on every issuance and every refresh, so a profile change takes effect on the next token issued to that client — in-flight tokens keep the lifetime they were issued with.
+
+- **`short`** — 15m access / 24h refresh. For admin consoles and other high-value clients where a leaked token's blast radius must be tightly bounded.
+- **`standard`** — defaults to `JWT_EXPIRATION` / `REFRESH_TOKEN_EXPIRATION`. For typical web and SPA clients. Because it mirrors the base config by default, the token service returns `(0, 0)` from its TTL resolver here — which tells the local provider to take its normal issuance path, including `JWT_EXPIRATION_JITTER`. Explicit short/long profiles (and any `standard` that has been diverged from the base) bypass jitter and use the profile TTL exactly.
+- **`long`** — 24h access / 90d refresh. For CLI tools, IoT devices, and long-lived automation where frequent re-auth is user-hostile.
+
+All three profiles are bounded by `JWT_EXPIRATION_MAX` and `REFRESH_TOKEN_EXPIRATION_MAX`; the server refuses to start if any configured profile exceeds its cap.
+
+**Scope:** TokenProfile applies to access and refresh tokens issued through the device-code and authorization-code grants. The `client_credentials` grant is governed separately by `CLIENT_CREDENTIALS_TOKEN_EXPIRATION` so M2M token lifetimes can stay tight regardless of per-client profile choices made for user-facing flows.
+
+**Auditability:** Every profile change is logged at `WARNING` severity with the prior value (`previous_token_profile`) so incident response can trace lifetime changes across the fleet.
+
 ### Grant Type Support
 
 - `urn:ietf:params:oauth:grant-type:device_code` - Device authorization flow (returns access + refresh)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -8,6 +8,7 @@ This guide covers all configuration options for AuthGate, including environment 
 - [TLS / HTTPS](#tls--https)
 - [Bootstrap and Shutdown Timeouts](#bootstrap-and-shutdown-timeouts)
 - [Generate Strong Secrets](#generate-strong-secrets)
+- [Token Lifetime Profiles](#token-lifetime-profiles)
 - [Default Test Data](#default-test-data)
 - [OAuth Third-Party Login](#oauth-third-party-login)
 - [Service-to-Service Authentication](#service-to-service-authentication)
@@ -83,6 +84,22 @@ ENABLE_TOKEN_ROTATION=false         # Enable rotation mode (default: fixed mode)
 # Client Credentials Flow (RFC 6749 §4.4)
 # CLIENT_CREDENTIALS_TOKEN_EXPIRATION=1h  # Access token lifetime for client_credentials grant (default: 1h)
 #                                           # Keep short — no refresh token means no rotation mechanism
+#                                           # Governed independently from per-client TokenProfile (see below)
+
+# Per-Client Token Lifetime Profiles
+# Each OAuth client selects one of three presets: "short", "standard" (default), or "long".
+# "standard" defaults to JWT_EXPIRATION / REFRESH_TOKEN_EXPIRATION above; overrides below
+# let you tailor the short/long presets without touching the base defaults.
+# TOKEN_PROFILE_SHORT_ACCESS_TTL=15m       # Short profile access token lifetime (default: 15m)
+# TOKEN_PROFILE_SHORT_REFRESH_TTL=24h      # Short profile refresh token lifetime (default: 24h)
+# TOKEN_PROFILE_STANDARD_ACCESS_TTL=10h    # Standard profile access TTL (default: JWT_EXPIRATION)
+# TOKEN_PROFILE_STANDARD_REFRESH_TTL=720h  # Standard profile refresh TTL (default: REFRESH_TOKEN_EXPIRATION)
+# TOKEN_PROFILE_LONG_ACCESS_TTL=24h        # Long profile access TTL (default: 24h)
+# TOKEN_PROFILE_LONG_REFRESH_TTL=2160h     # Long profile refresh TTL (default: 90 days)
+#
+# Hard caps — enforced at startup. No profile may exceed these values.
+# JWT_EXPIRATION_MAX=24h                   # Upper bound for any access-token profile (default: 24h)
+# REFRESH_TOKEN_EXPIRATION_MAX=2160h       # Upper bound for any refresh-token profile (default: 90d)
 
 # OAuth Configuration (optional - for third-party login)
 # GitHub OAuth
@@ -351,6 +368,38 @@ Use `JWT_KEY_ID` to set an explicit `kid` (Key ID) header in JWTs. This enables 
 > Multi-key JWKS is not currently supported.
 
 If `JWT_KEY_ID` is not set, it is automatically derived from the SHA-256 hash of the DER-encoded public key (base64url-encoded, 43 characters). This derivation is deterministic — the same key always produces the same `kid`.
+
+---
+
+## Token Lifetime Profiles
+
+AuthGate assigns every OAuth client one of three **token lifetime presets** so admins can tune access and refresh token durations to each client's risk profile without touching the base JWT configuration. The preset is selectable from the admin UI (**Admin → OAuth Clients → Token Lifetime**) and recorded on the client as `token_profile`.
+
+### Profiles
+
+| Profile      | When to use                                                    | Default access TTL           | Default refresh TTL           |
+| ------------ | -------------------------------------------------------------- | ---------------------------- | ----------------------------- |
+| `short`      | High-security apps (admin consoles, financial dashboards)      | 15 min                       | 24 h                          |
+| `standard`   | Typical web/SPA clients (default for new clients)              | `JWT_EXPIRATION` (10 h)      | `REFRESH_TOKEN_EXPIRATION` (30 d) |
+| `long`       | CLI tools, IoT devices, long-lived background jobs             | 24 h                         | 90 d                          |
+
+Defaults are overridable per environment via the `TOKEN_PROFILE_*` variables listed in [Environment Variables](#environment-variables).
+
+### Hard caps
+
+`JWT_EXPIRATION_MAX` and `REFRESH_TOKEN_EXPIRATION_MAX` bound every profile's TTL. The server refuses to start if any configured profile exceeds its cap — this guarantees that a stray env override cannot issue tokens longer than the operator intends.
+
+### Jitter behavior
+
+`JWT_EXPIRATION_JITTER` is applied only when the resolved access-token TTL matches the base `JWT_EXPIRATION` (the `standard`-profile default). Explicit `short`/`long` overrides — and a `standard` profile that has been explicitly diverged from the base config — use the profile's TTL exactly, with no jitter added. This keeps jitter working for the high-volume default path (preventing refresh thundering herds) while respecting operator-chosen short/long lifetimes precisely.
+
+### Client Credentials independence
+
+The `client_credentials` grant is governed by `CLIENT_CREDENTIALS_TOKEN_EXPIRATION` and **ignores** the client's TokenProfile. M2M tokens carry a larger blast radius than user-delegated tokens (no refresh, no user-revoke UI), so their lifetime is managed separately and is typically kept much shorter than user-facing tokens. If you need per-client M2M TTLs, open an issue — it will require a dedicated field on TokenProfile rather than overloading the existing access TTL.
+
+### Changing a profile
+
+Updates take effect on the **next token issuance or refresh**. Existing tokens retain the lifetime they were originally issued with; AuthGate does not retroactively shorten live tokens. Every TokenProfile change is recorded in the audit log at `WARNING` severity with the previous value (`previous_token_profile`) for forensic traceability.
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-authgate/authgate/internal/models"
+
 	"github.com/joho/godotenv"
 )
 
@@ -35,6 +37,14 @@ const (
 	AlgRS256 = "RS256"
 	AlgES256 = "ES256"
 )
+
+// TokenProfile defines the access and refresh token lifetimes for a named preset.
+// Clients reference a profile by name via OAuthApplication.TokenProfile (see
+// models.TokenProfile* constants) and the TTL is resolved at token issuance.
+type TokenProfile struct {
+	AccessTokenTTL  time.Duration
+	RefreshTokenTTL time.Duration
+}
 
 type Config struct {
 	// Server settings
@@ -99,6 +109,17 @@ type Config struct {
 	RefreshTokenExpiration time.Duration // Refresh token lifetime (default: 720h = 30 days)
 	EnableRefreshTokens    bool          // Feature flag to enable/disable refresh tokens (default: true)
 	EnableTokenRotation    bool          // Enable token rotation mode (default: false, fixed mode)
+
+	// Token lifetime hard caps. Any TokenProfile value that exceeds these is rejected
+	// during Validate(). Prevents a misconfigured profile from silently extending token
+	// lifetime far beyond the security intent.
+	JWTExpirationMax          time.Duration // env: JWT_EXPIRATION_MAX (default: 24h)
+	RefreshTokenExpirationMax time.Duration // env: REFRESH_TOKEN_EXPIRATION_MAX (default: 2160h / 90d)
+
+	// TokenProfiles maps a profile name ("short" / "standard" / "long") to its TTLs.
+	// Populated in Load() from the TOKEN_PROFILE_*_ACCESS_TTL / TOKEN_PROFILE_*_REFRESH_TTL env
+	// vars; the "standard" profile falls back to JWTExpiration / RefreshTokenExpiration.
+	TokenProfiles map[string]TokenProfile
 
 	// Client Credentials Flow settings (RFC 6749 §4.4)
 	ClientCredentialsTokenExpiration time.Duration // Access token lifetime for client_credentials grant (default: 1h, same as JWTExpiration)
@@ -251,6 +272,31 @@ func Load() *Config {
 		dsn = getEnv("DATABASE_DSN", "")
 	}
 
+	// Resolve base JWT settings first — the "standard" profile inherits these,
+	// so the map must be built after the values are known.
+	jwtExpiration := getEnvDuration("JWT_EXPIRATION", 10*time.Hour)
+	refreshTokenExpiration := getEnvDuration("REFRESH_TOKEN_EXPIRATION", 720*time.Hour)
+	tokenProfiles := map[string]TokenProfile{
+		models.TokenProfileShort: {
+			AccessTokenTTL:  getEnvDuration("TOKEN_PROFILE_SHORT_ACCESS_TTL", 15*time.Minute),
+			RefreshTokenTTL: getEnvDuration("TOKEN_PROFILE_SHORT_REFRESH_TTL", 24*time.Hour),
+		},
+		models.TokenProfileStandard: {
+			AccessTokenTTL: getEnvDuration("TOKEN_PROFILE_STANDARD_ACCESS_TTL", jwtExpiration),
+			RefreshTokenTTL: getEnvDuration(
+				"TOKEN_PROFILE_STANDARD_REFRESH_TTL",
+				refreshTokenExpiration,
+			),
+		},
+		models.TokenProfileLong: {
+			AccessTokenTTL: getEnvDuration("TOKEN_PROFILE_LONG_ACCESS_TTL", 24*time.Hour),
+			RefreshTokenTTL: getEnvDuration(
+				"TOKEN_PROFILE_LONG_REFRESH_TTL",
+				2160*time.Hour,
+			), // 90 days
+		},
+	}
+
 	return &Config{
 		ServerAddr:  getEnv("SERVER_ADDR", ":8080"),
 		BaseURL:     getEnv("BASE_URL", "http://localhost:8080"),
@@ -259,7 +305,7 @@ func Load() *Config {
 		IsProduction: getEnvBool("ENVIRONMENT", false) ||
 			getEnv("ENVIRONMENT", "") == "production",
 		JWTSecret:           getEnv("JWT_SECRET", "your-256-bit-secret-change-in-production"),
-		JWTExpiration:       getEnvDuration("JWT_EXPIRATION", 10*time.Hour),
+		JWTExpiration:       jwtExpiration,
 		JWTSigningAlgorithm: getEnv("JWT_SIGNING_ALGORITHM", AlgHS256),
 		JWTPrivateKeyPath:   getEnv("JWT_PRIVATE_KEY_PATH", ""),
 		JWTKeyID:            getEnv("JWT_KEY_ID", ""),
@@ -302,12 +348,12 @@ func Load() *Config {
 		HTTPAPIMaxRetryDelay:      getEnvDuration("HTTP_API_MAX_RETRY_DELAY", 10*time.Second),
 
 		// Refresh Token settings
-		RefreshTokenExpiration: getEnvDuration(
-			"REFRESH_TOKEN_EXPIRATION",
-			720*time.Hour,
-		), // 30 days
-		EnableRefreshTokens: getEnvBool("ENABLE_REFRESH_TOKENS", true),
-		EnableTokenRotation: getEnvBool("ENABLE_TOKEN_ROTATION", false),
+		RefreshTokenExpiration:    refreshTokenExpiration,
+		EnableRefreshTokens:       getEnvBool("ENABLE_REFRESH_TOKENS", true),
+		EnableTokenRotation:       getEnvBool("ENABLE_TOKEN_ROTATION", false),
+		JWTExpirationMax:          getEnvDuration("JWT_EXPIRATION_MAX", 24*time.Hour),
+		RefreshTokenExpirationMax: getEnvDuration("REFRESH_TOKEN_EXPIRATION_MAX", 2160*time.Hour),
+		TokenProfiles:             tokenProfiles,
 
 		// Client Credentials Flow settings
 		ClientCredentialsTokenExpiration: getEnvDuration(
@@ -680,5 +726,67 @@ func (c *Config) Validate() error {
 		)
 	}
 
+	return c.validateTokenProfiles()
+}
+
+// validateTokenProfiles checks that every profile has positive TTLs and that
+// no profile's TTL exceeds the configured hard caps (JWT_EXPIRATION_MAX /
+// REFRESH_TOKEN_EXPIRATION_MAX). The standard / short / long profiles must all
+// be present. When TokenProfiles and both caps are left at their zero values
+// (e.g. a hand-built *Config used in an ad-hoc unit test) validation is
+// skipped — Load() always populates these, so this gate only affects real
+// startup, not consumers who only care about unrelated fields.
+func (c *Config) validateTokenProfiles() error {
+	if len(c.TokenProfiles) == 0 && c.JWTExpirationMax == 0 && c.RefreshTokenExpirationMax == 0 {
+		return nil
+	}
+	if c.JWTExpirationMax <= 0 {
+		return fmt.Errorf(
+			"JWT_EXPIRATION_MAX must be a positive duration (got %s)",
+			c.JWTExpirationMax,
+		)
+	}
+	if c.RefreshTokenExpirationMax <= 0 {
+		return fmt.Errorf(
+			"REFRESH_TOKEN_EXPIRATION_MAX must be a positive duration (got %s)",
+			c.RefreshTokenExpirationMax,
+		)
+	}
+
+	requiredProfiles := []string{
+		models.TokenProfileShort,
+		models.TokenProfileStandard,
+		models.TokenProfileLong,
+	}
+	for _, name := range requiredProfiles {
+		profile, ok := c.TokenProfiles[name]
+		if !ok {
+			return fmt.Errorf("token profile %q is missing from TokenProfiles", name)
+		}
+		if profile.AccessTokenTTL <= 0 {
+			return fmt.Errorf(
+				"token profile %q access TTL must be a positive duration (got %s)",
+				name, profile.AccessTokenTTL,
+			)
+		}
+		if profile.RefreshTokenTTL <= 0 {
+			return fmt.Errorf(
+				"token profile %q refresh TTL must be a positive duration (got %s)",
+				name, profile.RefreshTokenTTL,
+			)
+		}
+		if profile.AccessTokenTTL > c.JWTExpirationMax {
+			return fmt.Errorf(
+				"token profile %q access TTL %s exceeds JWT_EXPIRATION_MAX %s",
+				name, profile.AccessTokenTTL, c.JWTExpirationMax,
+			)
+		}
+		if profile.RefreshTokenTTL > c.RefreshTokenExpirationMax {
+			return fmt.Errorf(
+				"token profile %q refresh TTL %s exceeds REFRESH_TOKEN_EXPIRATION_MAX %s",
+				name, profile.RefreshTokenTTL, c.RefreshTokenExpirationMax,
+			)
+		}
+	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-authgate/authgate/internal/models"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -783,6 +785,119 @@ func TestTLSEnabled(t *testing.T) {
 			assert.Equal(t, tt.want, cfg.TLSEnabled())
 		})
 	}
+}
+
+func TestLoad_PopulatesTokenProfiles(t *testing.T) {
+	// Load() reads from env vars; we want deterministic defaults in this test.
+	t.Setenv("JWT_EXPIRATION", "2h")
+	t.Setenv("REFRESH_TOKEN_EXPIRATION", "48h")
+
+	cfg := Load()
+
+	require.NotNil(t, cfg.TokenProfiles)
+	short := cfg.TokenProfiles[models.TokenProfileShort]
+	standard := cfg.TokenProfiles[models.TokenProfileStandard]
+	long := cfg.TokenProfiles[models.TokenProfileLong]
+
+	assert.Equal(t, 15*time.Minute, short.AccessTokenTTL)
+	assert.Equal(t, 24*time.Hour, short.RefreshTokenTTL)
+	// standard inherits the base JWT/refresh expirations
+	assert.Equal(t, 2*time.Hour, standard.AccessTokenTTL)
+	assert.Equal(t, 48*time.Hour, standard.RefreshTokenTTL)
+	assert.Equal(t, 24*time.Hour, long.AccessTokenTTL)
+	assert.Equal(t, 2160*time.Hour, long.RefreshTokenTTL)
+
+	assert.Equal(t, 24*time.Hour, cfg.JWTExpirationMax)
+	assert.Equal(t, 2160*time.Hour, cfg.RefreshTokenExpirationMax)
+}
+
+func TestLoad_TokenProfileEnvOverride(t *testing.T) {
+	t.Setenv("TOKEN_PROFILE_SHORT_ACCESS_TTL", "5m")
+	t.Setenv("TOKEN_PROFILE_LONG_REFRESH_TTL", "720h") // 30d
+
+	cfg := Load()
+
+	assert.Equal(t, 5*time.Minute, cfg.TokenProfiles[models.TokenProfileShort].AccessTokenTTL)
+	assert.Equal(t, 720*time.Hour, cfg.TokenProfiles[models.TokenProfileLong].RefreshTokenTTL)
+}
+
+func TestValidate_TokenProfileExceedsMax(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(*Config)
+		expectedMsg string
+	}{
+		{
+			name: "access TTL exceeds JWT_EXPIRATION_MAX",
+			mutate: func(c *Config) {
+				c.TokenProfiles[models.TokenProfileLong] = TokenProfile{
+					AccessTokenTTL:  48 * time.Hour, // > cap
+					RefreshTokenTTL: 24 * time.Hour,
+				}
+			},
+			expectedMsg: "exceeds JWT_EXPIRATION_MAX",
+		},
+		{
+			name: "refresh TTL exceeds REFRESH_TOKEN_EXPIRATION_MAX",
+			mutate: func(c *Config) {
+				c.TokenProfiles[models.TokenProfileLong] = TokenProfile{
+					AccessTokenTTL:  time.Hour,
+					RefreshTokenTTL: 5000 * time.Hour, // > cap
+				}
+			},
+			expectedMsg: "exceeds REFRESH_TOKEN_EXPIRATION_MAX",
+		},
+		{
+			name: "zero access TTL is rejected",
+			mutate: func(c *Config) {
+				c.TokenProfiles[models.TokenProfileShort] = TokenProfile{
+					AccessTokenTTL:  0,
+					RefreshTokenTTL: time.Hour,
+				}
+			},
+			expectedMsg: `"short" access TTL must be a positive duration`,
+		},
+		{
+			name: "missing profile is rejected",
+			mutate: func(c *Config) {
+				delete(c.TokenProfiles, models.TokenProfileLong)
+			},
+			expectedMsg: `token profile "long" is missing`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validBaseConfig()
+			cfg.JWTExpirationMax = 24 * time.Hour
+			cfg.RefreshTokenExpirationMax = 2160 * time.Hour
+			cfg.TokenProfiles = map[string]TokenProfile{
+				models.TokenProfileShort: {
+					AccessTokenTTL:  15 * time.Minute,
+					RefreshTokenTTL: 24 * time.Hour,
+				},
+				models.TokenProfileStandard: {
+					AccessTokenTTL:  time.Hour,
+					RefreshTokenTTL: 720 * time.Hour,
+				},
+				models.TokenProfileLong: {
+					AccessTokenTTL:  8 * time.Hour,
+					RefreshTokenTTL: 2160 * time.Hour,
+				},
+			}
+			tt.mutate(&cfg)
+			err := cfg.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedMsg)
+		})
+	}
+}
+
+func TestValidate_TokenProfileSkippedWhenZeroValue(t *testing.T) {
+	// Hand-built test configs that don't care about token profiles must still pass
+	// Validate() (used by many pre-existing tests).
+	cfg := validBaseConfig()
+	// TokenProfiles, JWTExpirationMax, RefreshTokenExpirationMax all zero
+	require.NoError(t, cfg.Validate())
 }
 
 func TestValidate_TLSPartialConfig(t *testing.T) {

--- a/internal/core/token.go
+++ b/internal/core/token.go
@@ -56,19 +56,32 @@ type TokenRefreshResult struct {
 }
 
 // TokenProvider is the interface that token-generation backends must implement.
+// A ttl of 0 on any Generate* method means "use the provider's default expiry"
+// (typically derived from config). A non-zero ttl overrides the default and
+// disables any jitter the provider would normally apply.
 type TokenProvider interface {
-	GenerateToken(ctx context.Context, userID, clientID, scopes string) (*TokenResult, error)
-	GenerateRefreshToken(ctx context.Context, userID, clientID, scopes string) (*TokenResult, error)
+	GenerateToken(
+		ctx context.Context,
+		userID, clientID, scopes string,
+		ttl time.Duration,
+	) (*TokenResult, error)
+	GenerateRefreshToken(
+		ctx context.Context,
+		userID, clientID, scopes string,
+		ttl time.Duration,
+	) (*TokenResult, error)
 	// GenerateClientCredentialsToken generates a token for the client_credentials grant.
 	// May apply a different expiry or claim set than GenerateToken.
 	GenerateClientCredentialsToken(
 		ctx context.Context,
 		userID, clientID, scopes string,
+		ttl time.Duration,
 	) (*TokenResult, error)
 	ValidateToken(ctx context.Context, tokenString string) (*TokenValidationResult, error)
 	RefreshAccessToken(
 		ctx context.Context,
 		refreshToken string,
+		accessTTL, refreshTTL time.Duration,
 	) (*TokenRefreshResult, error)
 	Name() string
 }

--- a/internal/handlers/client.go
+++ b/internal/handlers/client.go
@@ -119,6 +119,7 @@ func (h *ClientHandler) CreateClient(c *gin.Context) {
 		EnableDeviceFlow:            c.PostForm("enable_device_flow") == queryValueTrue,
 		EnableAuthCodeFlow:          c.PostForm("enable_auth_code_flow") == queryValueTrue,
 		EnableClientCredentialsFlow: c.PostForm("enable_client_credentials_flow") == queryValueTrue,
+		TokenProfile:                c.PostForm("token_profile"),
 		IsAdminCreated:              true, // admin-created clients are immediately active
 	}
 
@@ -136,6 +137,7 @@ func (h *ClientHandler) CreateClient(c *gin.Context) {
 			EnableDeviceFlow:            req.EnableDeviceFlow,
 			EnableAuthCodeFlow:          req.EnableAuthCodeFlow,
 			EnableClientCredentialsFlow: req.EnableClientCredentialsFlow,
+			TokenProfile:                req.TokenProfile,
 		}
 
 		templates.RenderTempl(
@@ -212,6 +214,7 @@ func (h *ClientHandler) UpdateClient(c *gin.Context) {
 		EnableDeviceFlow:            c.PostForm("enable_device_flow") == queryValueTrue,
 		EnableAuthCodeFlow:          c.PostForm("enable_auth_code_flow") == queryValueTrue,
 		EnableClientCredentialsFlow: c.PostForm("enable_client_credentials_flow") == queryValueTrue,
+		TokenProfile:                c.PostForm("token_profile"),
 	}
 
 	userID := getUserIDFromContext(c)
@@ -234,6 +237,7 @@ func (h *ClientHandler) UpdateClient(c *gin.Context) {
 			EnableAuthCodeFlow:          req.EnableAuthCodeFlow,
 			EnableClientCredentialsFlow: req.EnableClientCredentialsFlow,
 			Status:                      req.Status,
+			TokenProfile:                req.TokenProfile,
 			CreatedAt:                   client.CreatedAt,
 			UpdatedAt:                   client.UpdatedAt,
 		}

--- a/internal/handlers/token_introspect_test.go
+++ b/internal/handlers/token_introspect_test.go
@@ -308,7 +308,7 @@ func TestIntrospect_UserToken_IncludesUsername(t *testing.T) {
 	})
 	require.NoError(t, err)
 	tokenResult, err := localProvider.GenerateToken(
-		context.Background(), testUser.ID, client.ClientID, "read",
+		context.Background(), testUser.ID, client.ClientID, "read", 0,
 	)
 	require.NoError(t, err)
 

--- a/internal/handlers/utils.go
+++ b/internal/handlers/utils.go
@@ -83,6 +83,7 @@ func clientToDisplay(app *models.OAuthApplication) *templates.ClientDisplay {
 		EnableAuthCodeFlow:          app.EnableAuthCodeFlow,
 		EnableClientCredentialsFlow: app.EnableClientCredentialsFlow,
 		Status:                      app.Status,
+		TokenProfile:                app.TokenProfile,
 		CreatedAt:                   app.CreatedAt,
 		UpdatedAt:                   app.UpdatedAt,
 	}

--- a/internal/mocks/mock_token.go
+++ b/internal/mocks/mock_token.go
@@ -12,6 +12,7 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	core "github.com/go-authgate/authgate/internal/core"
 	gomock "go.uber.org/mock/gomock"
@@ -81,48 +82,48 @@ func (m *MockTokenProvider) EXPECT() *MockTokenProviderMockRecorder {
 }
 
 // GenerateClientCredentialsToken mocks base method.
-func (m *MockTokenProvider) GenerateClientCredentialsToken(ctx context.Context, userID, clientID, scopes string) (*core.TokenResult, error) {
+func (m *MockTokenProvider) GenerateClientCredentialsToken(ctx context.Context, userID, clientID, scopes string, ttl time.Duration) (*core.TokenResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateClientCredentialsToken", ctx, userID, clientID, scopes)
+	ret := m.ctrl.Call(m, "GenerateClientCredentialsToken", ctx, userID, clientID, scopes, ttl)
 	ret0, _ := ret[0].(*core.TokenResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GenerateClientCredentialsToken indicates an expected call of GenerateClientCredentialsToken.
-func (mr *MockTokenProviderMockRecorder) GenerateClientCredentialsToken(ctx, userID, clientID, scopes any) *gomock.Call {
+func (mr *MockTokenProviderMockRecorder) GenerateClientCredentialsToken(ctx, userID, clientID, scopes, ttl any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateClientCredentialsToken", reflect.TypeOf((*MockTokenProvider)(nil).GenerateClientCredentialsToken), ctx, userID, clientID, scopes)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateClientCredentialsToken", reflect.TypeOf((*MockTokenProvider)(nil).GenerateClientCredentialsToken), ctx, userID, clientID, scopes, ttl)
 }
 
 // GenerateRefreshToken mocks base method.
-func (m *MockTokenProvider) GenerateRefreshToken(ctx context.Context, userID, clientID, scopes string) (*core.TokenResult, error) {
+func (m *MockTokenProvider) GenerateRefreshToken(ctx context.Context, userID, clientID, scopes string, ttl time.Duration) (*core.TokenResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateRefreshToken", ctx, userID, clientID, scopes)
+	ret := m.ctrl.Call(m, "GenerateRefreshToken", ctx, userID, clientID, scopes, ttl)
 	ret0, _ := ret[0].(*core.TokenResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GenerateRefreshToken indicates an expected call of GenerateRefreshToken.
-func (mr *MockTokenProviderMockRecorder) GenerateRefreshToken(ctx, userID, clientID, scopes any) *gomock.Call {
+func (mr *MockTokenProviderMockRecorder) GenerateRefreshToken(ctx, userID, clientID, scopes, ttl any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateRefreshToken", reflect.TypeOf((*MockTokenProvider)(nil).GenerateRefreshToken), ctx, userID, clientID, scopes)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateRefreshToken", reflect.TypeOf((*MockTokenProvider)(nil).GenerateRefreshToken), ctx, userID, clientID, scopes, ttl)
 }
 
 // GenerateToken mocks base method.
-func (m *MockTokenProvider) GenerateToken(ctx context.Context, userID, clientID, scopes string) (*core.TokenResult, error) {
+func (m *MockTokenProvider) GenerateToken(ctx context.Context, userID, clientID, scopes string, ttl time.Duration) (*core.TokenResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateToken", ctx, userID, clientID, scopes)
+	ret := m.ctrl.Call(m, "GenerateToken", ctx, userID, clientID, scopes, ttl)
 	ret0, _ := ret[0].(*core.TokenResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GenerateToken indicates an expected call of GenerateToken.
-func (mr *MockTokenProviderMockRecorder) GenerateToken(ctx, userID, clientID, scopes any) *gomock.Call {
+func (mr *MockTokenProviderMockRecorder) GenerateToken(ctx, userID, clientID, scopes, ttl any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateToken", reflect.TypeOf((*MockTokenProvider)(nil).GenerateToken), ctx, userID, clientID, scopes)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateToken", reflect.TypeOf((*MockTokenProvider)(nil).GenerateToken), ctx, userID, clientID, scopes, ttl)
 }
 
 // Name mocks base method.
@@ -140,18 +141,18 @@ func (mr *MockTokenProviderMockRecorder) Name() *gomock.Call {
 }
 
 // RefreshAccessToken mocks base method.
-func (m *MockTokenProvider) RefreshAccessToken(ctx context.Context, refreshToken string) (*core.TokenRefreshResult, error) {
+func (m *MockTokenProvider) RefreshAccessToken(ctx context.Context, refreshToken string, accessTTL, refreshTTL time.Duration) (*core.TokenRefreshResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RefreshAccessToken", ctx, refreshToken)
+	ret := m.ctrl.Call(m, "RefreshAccessToken", ctx, refreshToken, accessTTL, refreshTTL)
 	ret0, _ := ret[0].(*core.TokenRefreshResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RefreshAccessToken indicates an expected call of RefreshAccessToken.
-func (mr *MockTokenProviderMockRecorder) RefreshAccessToken(ctx, refreshToken any) *gomock.Call {
+func (mr *MockTokenProviderMockRecorder) RefreshAccessToken(ctx, refreshToken, accessTTL, refreshTTL any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshAccessToken", reflect.TypeOf((*MockTokenProvider)(nil).RefreshAccessToken), ctx, refreshToken)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshAccessToken", reflect.TypeOf((*MockTokenProvider)(nil).RefreshAccessToken), ctx, refreshToken, accessTTL, refreshTTL)
 }
 
 // ValidateToken mocks base method.

--- a/internal/models/oauth_application.go
+++ b/internal/models/oauth_application.go
@@ -40,15 +40,17 @@ func IsValidTokenProfile(v string) bool {
 	return false
 }
 
-// ResolveTokenProfile normalizes a stored or form-submitted profile name, treating
-// empty input as "standard" (the rule for pre-migration rows and older callers).
-// Unknown values pass through unchanged so callers can distinguish legitimate
-// defaults from bad data.
+// ResolveTokenProfile normalizes a stored or form-submitted profile name:
+// surrounding whitespace is trimmed (common from form posts and API clients),
+// empty input becomes "standard" (the rule for pre-migration rows and older
+// callers). Unknown values pass through unchanged so callers can distinguish
+// legitimate defaults from bad data.
 func ResolveTokenProfile(v string) string {
-	if strings.TrimSpace(v) == "" {
+	trimmed := strings.TrimSpace(v)
+	if trimmed == "" {
 		return TokenProfileStandard
 	}
-	return v
+	return trimmed
 }
 
 // Base32 characters, but lowercased.

--- a/internal/models/oauth_application.go
+++ b/internal/models/oauth_application.go
@@ -40,6 +40,17 @@ func IsValidTokenProfile(v string) bool {
 	return false
 }
 
+// ResolveTokenProfile normalizes a stored or form-submitted profile name, treating
+// empty input as "standard" (the rule for pre-migration rows and older callers).
+// Unknown values pass through unchanged so callers can distinguish legitimate
+// defaults from bad data.
+func ResolveTokenProfile(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return TokenProfileStandard
+	}
+	return v
+}
+
 // Base32 characters, but lowercased.
 const lowerBase32Chars = "abcdefghijklmnopqrstuvwxyz234567"
 

--- a/internal/models/oauth_application.go
+++ b/internal/models/oauth_application.go
@@ -23,6 +23,23 @@ const (
 	ClientStatusInactive ClientStatus = "inactive" // Admin rejected or disabled
 )
 
+// TokenProfile selects a named preset of access/refresh token lifetimes for a client.
+// The effective TTLs are resolved at token issuance via config.TokenProfiles.
+const (
+	TokenProfileShort    = "short"
+	TokenProfileStandard = "standard"
+	TokenProfileLong     = "long"
+)
+
+// IsValidTokenProfile reports whether v is a recognised token profile name.
+func IsValidTokenProfile(v string) bool {
+	switch v {
+	case TokenProfileShort, TokenProfileStandard, TokenProfileLong:
+		return true
+	}
+	return false
+}
+
 // Base32 characters, but lowercased.
 const lowerBase32Chars = "abcdefghijklmnopqrstuvwxyz234567"
 
@@ -42,8 +59,9 @@ type OAuthApplication struct {
 	ClientType                  string      `gorm:"not null;default:'public'"` // "confidential" or "public"
 	EnableDeviceFlow            bool        `gorm:"not null;default:true"`
 	EnableAuthCodeFlow          bool        `gorm:"not null;default:false"`
-	EnableClientCredentialsFlow bool        `gorm:"not null;default:false"`    // Client Credentials Grant (RFC 6749 §4.4); confidential clients only
-	Status                      string      `gorm:"not null;default:'active'"` // ClientStatusPending / ClientStatusActive / ClientStatusInactive
+	EnableClientCredentialsFlow bool        `gorm:"not null;default:false"`              // Client Credentials Grant (RFC 6749 §4.4); confidential clients only
+	Status                      string      `gorm:"not null;default:'active'"`           // ClientStatusPending / ClientStatusActive / ClientStatusInactive
+	TokenProfile                string      `gorm:"not null;default:'standard';size:20"` // "short" / "standard" / "long"; resolves to a TTL preset in config
 	CreatedBy                   string
 	CreatedAt                   time.Time
 	UpdatedAt                   time.Time

--- a/internal/models/oauth_application_test.go
+++ b/internal/models/oauth_application_test.go
@@ -273,3 +273,27 @@ func TestIsValidTokenProfile(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveTokenProfile(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty defaults to standard", in: "", want: TokenProfileStandard},
+		{name: "whitespace defaults to standard", in: "   ", want: TokenProfileStandard},
+		{name: "short passes through", in: TokenProfileShort, want: TokenProfileShort},
+		{name: "long passes through", in: TokenProfileLong, want: TokenProfileLong},
+		{name: "surrounding whitespace trimmed", in: "  standard  ", want: TokenProfileStandard},
+		{name: "leading whitespace trimmed", in: "\tshort", want: TokenProfileShort},
+		{name: "trailing whitespace trimmed", in: "long\n", want: TokenProfileLong},
+		{name: "unknown value passes through trimmed", in: " custom ", want: "custom"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolveTokenProfile(tt.in); got != tt.want {
+				t.Errorf("ResolveTokenProfile(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/models/oauth_application_test.go
+++ b/internal/models/oauth_application_test.go
@@ -252,3 +252,24 @@ func TestOAuthApplication_IsActive(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidTokenProfile(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{in: TokenProfileShort, want: true},
+		{in: TokenProfileStandard, want: true},
+		{in: TokenProfileLong, want: true},
+		{in: "", want: false},
+		{in: "SHORT", want: false}, // case-sensitive
+		{in: "custom", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := IsValidTokenProfile(tt.in); got != tt.want {
+				t.Errorf("IsValidTokenProfile(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/services/client.go
+++ b/internal/services/client.go
@@ -164,15 +164,17 @@ type UpdateClientRequest struct {
 
 // normalizeTokenProfile validates and defaults an incoming token profile value.
 // Empty input is treated as "standard" to keep behavior predictable for older
-// callers and migrated rows.
+// callers and migrated rows. Surrounding whitespace (common from form posts
+// and API clients) is trimmed before validation.
 func normalizeTokenProfile(p string) (string, error) {
-	if strings.TrimSpace(p) == "" {
+	trimmed := strings.TrimSpace(p)
+	if trimmed == "" {
 		return models.TokenProfileStandard, nil
 	}
-	if !models.IsValidTokenProfile(p) {
+	if !models.IsValidTokenProfile(trimmed) {
 		return "", ErrInvalidTokenProfile
 	}
-	return p, nil
+	return trimmed, nil
 }
 
 type ClientResponse struct {
@@ -379,7 +381,15 @@ func (s *ClientService) UpdateClient(
 
 	// Log client update. A TokenProfile change is security-relevant (it can
 	// extend or shorten every future token issued to this client) so flag it
-	// at WARNING severity when it differs from the previous value.
+	// at WARNING severity when the effective profile changes. Pre-migration
+	// rows may have previousTokenProfile == ""; normalize it the same way as
+	// the rest of the system ("" => standard) before comparing so "" → short/long
+	// still produces a WARNING. The raw previous value is recorded so the audit
+	// trail reflects actual stored data.
+	previousNormalized := previousTokenProfile
+	if previousNormalized == "" {
+		previousNormalized = models.TokenProfileStandard
+	}
 	severity := models.SeverityInfo
 	details := models.AuditDetails{
 		"client_name":   client.ClientName,
@@ -388,7 +398,7 @@ func (s *ClientService) UpdateClient(
 		"scopes":        client.Scopes,
 		"token_profile": client.TokenProfile,
 	}
-	if previousTokenProfile != "" && previousTokenProfile != client.TokenProfile {
+	if previousNormalized != client.TokenProfile {
 		severity = models.SeverityWarning
 		details["previous_token_profile"] = previousTokenProfile
 	}

--- a/internal/services/client.go
+++ b/internal/services/client.go
@@ -63,8 +63,11 @@ var (
 	ErrInvalidClientStatus = errors.New(
 		"status must be \"active\", \"inactive\", or \"pending\"",
 	)
-	ErrInvalidTokenProfile = errors.New(
-		"token profile must be \"short\", \"standard\", or \"long\"",
+	ErrInvalidTokenProfile = fmt.Errorf(
+		"token profile must be %q, %q, or %q",
+		models.TokenProfileShort,
+		models.TokenProfileStandard,
+		models.TokenProfileLong,
 	)
 )
 
@@ -163,18 +166,14 @@ type UpdateClientRequest struct {
 }
 
 // normalizeTokenProfile validates and defaults an incoming token profile value.
-// Empty input is treated as "standard" to keep behavior predictable for older
-// callers and migrated rows. Surrounding whitespace (common from form posts
-// and API clients) is trimmed before validation.
+// Surrounding whitespace (common from form posts and API clients) is trimmed
+// before validation.
 func normalizeTokenProfile(p string) (string, error) {
-	trimmed := strings.TrimSpace(p)
-	if trimmed == "" {
-		return models.TokenProfileStandard, nil
-	}
-	if !models.IsValidTokenProfile(trimmed) {
+	resolved := models.ResolveTokenProfile(p)
+	if !models.IsValidTokenProfile(resolved) {
 		return "", ErrInvalidTokenProfile
 	}
-	return trimmed, nil
+	return resolved, nil
 }
 
 type ClientResponse struct {
@@ -379,17 +378,12 @@ func (s *ClientService) UpdateClient(
 		s.invalidatePendingCount(ctx)
 	}
 
-	// Log client update. A TokenProfile change is security-relevant (it can
-	// extend or shorten every future token issued to this client) so flag it
-	// at WARNING severity when the effective profile changes. Pre-migration
-	// rows may have previousTokenProfile == ""; normalize it the same way as
-	// the rest of the system ("" => standard) before comparing so "" → short/long
-	// still produces a WARNING. The raw previous value is recorded so the audit
-	// trail reflects actual stored data.
-	previousNormalized := previousTokenProfile
-	if previousNormalized == "" {
-		previousNormalized = models.TokenProfileStandard
-	}
+	// A TokenProfile change is security-relevant — it can extend or shorten
+	// every future token issued to this client — so flag it at WARNING when
+	// the effective value changes. Normalize the previous value the same way
+	// as the rest of the system so a pre-migration row moving "" → short/long
+	// still audits cleanly.
+	previousNormalized := models.ResolveTokenProfile(previousTokenProfile)
 	severity := models.SeverityInfo
 	details := models.AuditDetails{
 		"client_name":   client.ClientName,
@@ -400,7 +394,7 @@ func (s *ClientService) UpdateClient(
 	}
 	if previousNormalized != client.TokenProfile {
 		severity = models.SeverityWarning
-		details["previous_token_profile"] = previousTokenProfile
+		details["previous_token_profile"] = previousNormalized
 	}
 
 	s.auditService.Log(ctx, core.AuditLogEntry{

--- a/internal/services/client.go
+++ b/internal/services/client.go
@@ -63,6 +63,9 @@ var (
 	ErrInvalidClientStatus = errors.New(
 		"status must be \"active\", \"inactive\", or \"pending\"",
 	)
+	ErrInvalidTokenProfile = errors.New(
+		"token profile must be \"short\", \"standard\", or \"long\"",
+	)
 )
 
 // validateRedirectURIs checks that every URI in the slice is an absolute http/https
@@ -139,10 +142,11 @@ type CreateClientRequest struct {
 	RedirectURIs                []string
 	CreatedBy                   string
 	ClientType                  core.ClientType
-	EnableDeviceFlow            bool // Enable Device Authorization Grant (RFC 8628)
-	EnableAuthCodeFlow          bool // Enable Authorization Code Flow (RFC 6749)
-	EnableClientCredentialsFlow bool // Enable Client Credentials Grant (RFC 6749 §4.4); confidential clients only
-	IsAdminCreated              bool // When true: Status=active; when false: Status=pending
+	EnableDeviceFlow            bool   // Enable Device Authorization Grant (RFC 8628)
+	EnableAuthCodeFlow          bool   // Enable Authorization Code Flow (RFC 6749)
+	EnableClientCredentialsFlow bool   // Enable Client Credentials Grant (RFC 6749 §4.4); confidential clients only
+	IsAdminCreated              bool   // When true: Status=active; when false: Status=pending
+	TokenProfile                string // "short" / "standard" / "long"; empty = standard
 }
 
 type UpdateClientRequest struct {
@@ -154,7 +158,21 @@ type UpdateClientRequest struct {
 	ClientType                  core.ClientType
 	EnableDeviceFlow            bool
 	EnableAuthCodeFlow          bool
-	EnableClientCredentialsFlow bool // Enable Client Credentials Grant (RFC 6749 §4.4); confidential clients only
+	EnableClientCredentialsFlow bool   // Enable Client Credentials Grant (RFC 6749 §4.4); confidential clients only
+	TokenProfile                string // "short" / "standard" / "long"; empty = standard
+}
+
+// normalizeTokenProfile validates and defaults an incoming token profile value.
+// Empty input is treated as "standard" to keep behavior predictable for older
+// callers and migrated rows.
+func normalizeTokenProfile(p string) (string, error) {
+	if strings.TrimSpace(p) == "" {
+		return models.TokenProfileStandard, nil
+	}
+	if !models.IsValidTokenProfile(p) {
+		return "", ErrInvalidTokenProfile
+	}
+	return p, nil
 }
 
 type ClientResponse struct {
@@ -187,6 +205,11 @@ func (s *ClientService) CreateClient(
 	}
 
 	if err := validateRedirectURIs(req.RedirectURIs); err != nil {
+		return nil, err
+	}
+
+	tokenProfile, err := normalizeTokenProfile(req.TokenProfile)
+	if err != nil {
 		return nil, err
 	}
 
@@ -231,6 +254,7 @@ func (s *ClientService) CreateClient(
 		EnableAuthCodeFlow:          enableAuthCode,
 		EnableClientCredentialsFlow: enableClientCredentials,
 		Status:                      clientStatus,
+		TokenProfile:                tokenProfile,
 		CreatedBy:                   req.CreatedBy,
 	}
 
@@ -259,9 +283,10 @@ func (s *ClientService) CreateClient(
 		ResourceName: client.ClientName,
 		Action:       "OAuth client created",
 		Details: models.AuditDetails{
-			"client_name": client.ClientName,
-			"grant_types": client.GrantTypes,
-			"scopes":      client.Scopes,
+			"client_name":   client.ClientName,
+			"grant_types":   client.GrantTypes,
+			"scopes":        client.Scopes,
+			"token_profile": client.TokenProfile,
 		},
 		Success: true,
 	})
@@ -299,6 +324,11 @@ func (s *ClientService) UpdateClient(
 		return err
 	}
 
+	tokenProfile, err := normalizeTokenProfile(req.TokenProfile)
+	if err != nil {
+		return err
+	}
+
 	client, err := s.store.GetClient(clientID)
 	if err != nil {
 		return ErrClientNotFound
@@ -315,12 +345,15 @@ func (s *ClientService) UpdateClient(
 	pendingCountAffected := client.Status == models.ClientStatusPending ||
 		req.Status == models.ClientStatusPending
 
+	previousTokenProfile := client.TokenProfile
+
 	client.ClientName = strings.TrimSpace(req.ClientName)
 	client.Description = strings.TrimSpace(req.Description)
 	client.Scopes = strings.TrimSpace(req.Scopes)
 	client.RedirectURIs = models.StringArray(req.RedirectURIs)
 	client.Status = req.Status
 	client.ClientType = clientType.String()
+	client.TokenProfile = tokenProfile
 
 	// Rebuild GrantTypes from enablement flags
 	enableClientCredentials := req.EnableClientCredentialsFlow
@@ -344,22 +377,32 @@ func (s *ClientService) UpdateClient(
 		s.invalidatePendingCount(ctx)
 	}
 
-	// Log client update
+	// Log client update. A TokenProfile change is security-relevant (it can
+	// extend or shorten every future token issued to this client) so flag it
+	// at WARNING severity when it differs from the previous value.
+	severity := models.SeverityInfo
+	details := models.AuditDetails{
+		"client_name":   client.ClientName,
+		"status":        client.Status,
+		"grant_types":   client.GrantTypes,
+		"scopes":        client.Scopes,
+		"token_profile": client.TokenProfile,
+	}
+	if previousTokenProfile != "" && previousTokenProfile != client.TokenProfile {
+		severity = models.SeverityWarning
+		details["previous_token_profile"] = previousTokenProfile
+	}
+
 	s.auditService.Log(ctx, core.AuditLogEntry{
 		EventType:    models.EventClientUpdated,
-		Severity:     models.SeverityInfo,
+		Severity:     severity,
 		ActorUserID:  actorUserID,
 		ResourceType: models.ResourceClient,
 		ResourceID:   clientID,
 		ResourceName: client.ClientName,
 		Action:       "OAuth client updated",
-		Details: models.AuditDetails{
-			"client_name": client.ClientName,
-			"status":      client.Status,
-			"grant_types": client.GrantTypes,
-			"scopes":      client.Scopes,
-		},
-		Success: true,
+		Details:      details,
+		Success:      true,
 	})
 
 	return nil

--- a/internal/services/token.go
+++ b/internal/services/token.go
@@ -188,18 +188,24 @@ func (s *TokenService) ttlForClient(
 			client.ClientID,
 			client.TokenProfile,
 		)
-		profile, ok = s.config.TokenProfiles[models.TokenProfileStandard]
+		name = models.TokenProfileStandard
+		profile, ok = s.config.TokenProfiles[name]
 		if !ok {
 			return 0, 0
 		}
 	}
 	accessTTL = profile.AccessTokenTTL
 	refreshTTL = profile.RefreshTokenTTL
-	if accessTTL == s.config.JWTExpiration {
-		accessTTL = 0
-	}
-	if refreshTTL == s.config.RefreshTokenExpiration {
-		refreshTTL = 0
+	// Only the standard profile zeroes out to let jitter apply. Short/long are
+	// explicit admin choices and must use their TTLs exactly, even if they
+	// coincidentally match the base JWT config.
+	if name == models.TokenProfileStandard {
+		if accessTTL == s.config.JWTExpiration {
+			accessTTL = 0
+		}
+		if refreshTTL == s.config.RefreshTokenExpiration {
+			refreshTTL = 0
+		}
 	}
 	return accessTTL, refreshTTL
 }

--- a/internal/services/token.go
+++ b/internal/services/token.go
@@ -155,32 +155,43 @@ type tokenPairParams struct {
 	ClientID        string
 	Scopes          string
 	AuthorizationID *uint // nil when not linked to a UserAuthorization (e.g. device flow)
-	// Client is optional: when the caller already loaded it (e.g. for an
-	// active-status check), passing it here avoids a second cached lookup
-	// when resolving the TokenProfile TTLs.
+	// Client is the already-loaded OAuth client, used to resolve the
+	// TokenProfile TTLs without an extra cached lookup. Both issuance callers
+	// (device flow, auth-code flow) load the client up front for other
+	// validation, so this is always populated.
 	Client *models.OAuthApplication
 }
 
 // ttlForClient returns the access/refresh TTLs dictated by the given client's
-// TokenProfile. A zero value means "fall back to provider default" — returned
-// when the client is nil, its profile name is unknown, or the profile's TTL
-// matches the base JWT/refresh config. The last case is important: the local
-// provider only applies JWT_EXPIRATION_JITTER when ttl == 0, so returning 0
-// for "standard" (which by default mirrors the base config) preserves jitter
-// for the common case while still honoring explicit short/long overrides.
+// TokenProfile. Zero means "fall back to provider default" — returned when the
+// profile's TTL matches the base JWT/refresh config so that the local provider
+// still applies JWT_EXPIRATION_JITTER on the common path. Explicit short/long
+// overrides (and a standard profile diverged from base config) return the
+// profile's TTL exactly, no jitter.
+//
+// An unknown profile name on the client row is a data-integrity issue (GORM
+// default + admin UI should prevent it). We log a WARNING so the bad row can
+// be traced and fall back to the standard profile's TTLs; that's more
+// conservative than returning zero, which would silently grant base JWT
+// lifetime to a client the admin intended to restrict.
 func (s *TokenService) ttlForClient(
 	client *models.OAuthApplication,
 ) (accessTTL, refreshTTL time.Duration) {
 	if client == nil {
 		return 0, 0
 	}
-	name := client.TokenProfile
-	if name == "" {
-		name = models.TokenProfileStandard
-	}
+	name := models.ResolveTokenProfile(client.TokenProfile)
 	profile, ok := s.config.TokenProfiles[name]
 	if !ok {
-		return 0, 0
+		log.Printf(
+			"[Token] client %s has unknown token_profile=%q; falling back to standard",
+			client.ClientID,
+			client.TokenProfile,
+		)
+		profile, ok = s.config.TokenProfiles[models.TokenProfileStandard]
+		if !ok {
+			return 0, 0
+		}
 	}
 	accessTTL = profile.AccessTokenTTL
 	refreshTTL = profile.RefreshTokenTTL

--- a/internal/services/token.go
+++ b/internal/services/token.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/go-authgate/authgate/internal/cache"
 	"github.com/go-authgate/authgate/internal/config"
@@ -154,16 +155,67 @@ type tokenPairParams struct {
 	ClientID        string
 	Scopes          string
 	AuthorizationID *uint // nil when not linked to a UserAuthorization (e.g. device flow)
+	// Client is optional: when the caller already loaded it (e.g. for an
+	// active-status check), passing it here avoids a second cached lookup
+	// when resolving the TokenProfile TTLs.
+	Client *models.OAuthApplication
+}
+
+// ttlForClient returns the access/refresh TTLs dictated by the given client's
+// TokenProfile. A zero value means "fall back to provider default" — used when
+// the client is nil or its profile name is unknown (shouldn't normally happen,
+// but keeps issuance resilient to bad data).
+func (s *TokenService) ttlForClient(
+	client *models.OAuthApplication,
+) (accessTTL, refreshTTL time.Duration) {
+	if client == nil {
+		return 0, 0
+	}
+	name := client.TokenProfile
+	if name == "" {
+		name = models.TokenProfileStandard
+	}
+	profile, ok := s.config.TokenProfiles[name]
+	if !ok {
+		return 0, 0
+	}
+	return profile.AccessTokenTTL, profile.RefreshTokenTTL
+}
+
+// resolveClientTTL fetches the client by ID and returns its profile TTLs.
+// Use ttlForClient directly when the caller already has the client loaded.
+func (s *TokenService) resolveClientTTL(
+	ctx context.Context,
+	clientID string,
+) (accessTTL, refreshTTL time.Duration) {
+	if s.clientService == nil {
+		return 0, 0
+	}
+	client, err := s.clientService.GetClient(ctx, clientID)
+	if err != nil {
+		return 0, 0
+	}
+	return s.ttlForClient(client)
 }
 
 // generateAndPersistTokenPair generates access and refresh tokens via the
 // configured provider, builds database records, and persists them atomically.
+// The per-client TokenProfile is resolved here so that all issuance paths
+// (device flow, auth code flow) honor the current profile at issuance time.
 func (s *TokenService) generateAndPersistTokenPair(
 	ctx context.Context,
 	p tokenPairParams,
 ) (*models.AccessToken, *models.AccessToken, error) {
-	// Generate tokens via provider
-	accessResult, err := s.tokenProvider.GenerateToken(ctx, p.UserID, p.ClientID, p.Scopes)
+	var accessTTL, refreshTTL time.Duration
+	if p.Client != nil {
+		accessTTL, refreshTTL = s.ttlForClient(p.Client)
+	} else {
+		accessTTL, refreshTTL = s.resolveClientTTL(ctx, p.ClientID)
+	}
+
+	accessResult, err := s.tokenProvider.GenerateToken(
+		ctx, p.UserID, p.ClientID, p.Scopes, accessTTL,
+	)
 	if err != nil {
 		log.Printf(
 			"[Token] Access token generation failed provider=%s: %v",
@@ -172,7 +224,9 @@ func (s *TokenService) generateAndPersistTokenPair(
 		)
 		return nil, nil, fmt.Errorf("token generation failed: %w", err)
 	}
-	refreshResult, err := s.tokenProvider.GenerateRefreshToken(ctx, p.UserID, p.ClientID, p.Scopes)
+	refreshResult, err := s.tokenProvider.GenerateRefreshToken(
+		ctx, p.UserID, p.ClientID, p.Scopes, refreshTTL,
+	)
 	if err != nil {
 		log.Printf(
 			"[Token] Refresh token generation failed provider=%s: %v",

--- a/internal/services/token.go
+++ b/internal/services/token.go
@@ -162,9 +162,12 @@ type tokenPairParams struct {
 }
 
 // ttlForClient returns the access/refresh TTLs dictated by the given client's
-// TokenProfile. A zero value means "fall back to provider default" — used when
-// the client is nil or its profile name is unknown (shouldn't normally happen,
-// but keeps issuance resilient to bad data).
+// TokenProfile. A zero value means "fall back to provider default" — returned
+// when the client is nil, its profile name is unknown, or the profile's TTL
+// matches the base JWT/refresh config. The last case is important: the local
+// provider only applies JWT_EXPIRATION_JITTER when ttl == 0, so returning 0
+// for "standard" (which by default mirrors the base config) preserves jitter
+// for the common case while still honoring explicit short/long overrides.
 func (s *TokenService) ttlForClient(
 	client *models.OAuthApplication,
 ) (accessTTL, refreshTTL time.Duration) {
@@ -179,7 +182,15 @@ func (s *TokenService) ttlForClient(
 	if !ok {
 		return 0, 0
 	}
-	return profile.AccessTokenTTL, profile.RefreshTokenTTL
+	accessTTL = profile.AccessTokenTTL
+	refreshTTL = profile.RefreshTokenTTL
+	if accessTTL == s.config.JWTExpiration {
+		accessTTL = 0
+	}
+	if refreshTTL == s.config.RefreshTokenExpiration {
+		refreshTTL = 0
+	}
+	return accessTTL, refreshTTL
 }
 
 // resolveClientTTL fetches the client by ID and returns its profile TTLs.

--- a/internal/services/token_cache_bench_test.go
+++ b/internal/services/token_cache_bench_test.go
@@ -71,7 +71,7 @@ func newBenchEnv(b *testing.B, withCache bool) *benchTokenEnv {
 	)
 
 	ctx := context.Background()
-	result, err := localProvider.GenerateToken(ctx, "bench-user", "bench-client", "read")
+	result, err := localProvider.GenerateToken(ctx, "bench-user", "bench-client", "read", 0)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/services/token_cache_test.go
+++ b/internal/services/token_cache_test.go
@@ -68,7 +68,7 @@ func TestValidateToken_CacheHit(t *testing.T) {
 	ctx := context.Background()
 
 	// Generate a real JWT token
-	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read")
+	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read", 0)
 	require.NoError(t, err)
 
 	// Store token in DB
@@ -105,7 +105,7 @@ func TestValidateToken_CacheInvalidatedOnRevoke(t *testing.T) {
 	ctx := context.Background()
 
 	// Generate a real JWT token
-	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read")
+	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read", 0)
 	require.NoError(t, err)
 
 	// Store token in DB
@@ -145,7 +145,7 @@ func TestValidateToken_CacheInvalidatedOnDisable(t *testing.T) {
 	ctx := context.Background()
 
 	// Generate a real JWT token
-	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read")
+	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read", 0)
 	require.NoError(t, err)
 
 	// Store token in DB
@@ -201,7 +201,7 @@ func TestValidateToken_NoopCache(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read")
+	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read", 0)
 	require.NoError(t, err)
 
 	tok := &models.AccessToken{
@@ -232,7 +232,7 @@ func TestValidateToken_CacheExpiredTokenRejected(t *testing.T) {
 	ctx := context.Background()
 
 	// Generate a real JWT token
-	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read")
+	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read", 0)
 	require.NoError(t, err)
 
 	// Store token with past expiration
@@ -260,7 +260,7 @@ func TestRevokeTokenByStatus_CacheInvalidated(t *testing.T) {
 	ctx := context.Background()
 
 	// Generate a real JWT token
-	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read")
+	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read", 0)
 	require.NoError(t, err)
 
 	// Store token in DB
@@ -300,7 +300,7 @@ func TestRevokeTokenByID_CacheInvalidated(t *testing.T) {
 	ctx := context.Background()
 
 	// Generate a real JWT token
-	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read")
+	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read", 0)
 	require.NoError(t, err)
 
 	// Store token in DB
@@ -340,7 +340,7 @@ func TestEnableToken_CacheInvalidated(t *testing.T) {
 	ctx := context.Background()
 
 	// Generate a real JWT token
-	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read")
+	result, err := svc.tokenProvider.GenerateToken(ctx, "test-user", "test-client", "read", 0)
 	require.NoError(t, err)
 
 	// Store token in DB
@@ -382,9 +382,9 @@ func TestRevokeAllUserTokens_CacheInvalidated(t *testing.T) {
 	userID := "test-user-bulk"
 
 	// Generate two tokens for the same user
-	result1, err := svc.tokenProvider.GenerateToken(ctx, userID, "client-1", "read")
+	result1, err := svc.tokenProvider.GenerateToken(ctx, userID, "client-1", "read", 0)
 	require.NoError(t, err)
-	result2, err := svc.tokenProvider.GenerateToken(ctx, userID, "client-2", "write")
+	result2, err := svc.tokenProvider.GenerateToken(ctx, userID, "client-2", "write", 0)
 	require.NoError(t, err)
 
 	tok1 := &models.AccessToken{

--- a/internal/services/token_client_credentials.go
+++ b/internal/services/token_client_credentials.go
@@ -68,15 +68,17 @@ func (s *TokenService) IssueClientCredentialsToken(
 	start := time.Now()
 	machineUserID := "client:" + clientID
 
-	// Reuse the client loaded above via GetClientWithSecret rather than letting
-	// resolveClientTTL trigger a second cached lookup.
-	ccTTL, _ := s.ttlForClient(client)
+	// TokenProfile governs user-delegated access/refresh tokens only.
+	// Passing ttl=0 here keeps CLIENT_CREDENTIALS_TOKEN_EXPIRATION as the
+	// dedicated authority for M2M token lifetime (independently constrained —
+	// typically shorter than user tokens because M2M secrets have a larger
+	// blast radius if leaked).
 	accessTokenResult, providerErr := s.tokenProvider.GenerateClientCredentialsToken(
 		ctx,
 		machineUserID,
 		clientID,
 		effectiveScopes,
-		ccTTL,
+		0,
 	)
 	if providerErr != nil {
 		log.Printf(

--- a/internal/services/token_client_credentials.go
+++ b/internal/services/token_client_credentials.go
@@ -68,11 +68,15 @@ func (s *TokenService) IssueClientCredentialsToken(
 	start := time.Now()
 	machineUserID := "client:" + clientID
 
+	// Reuse the client loaded above via GetClientWithSecret rather than letting
+	// resolveClientTTL trigger a second cached lookup.
+	ccTTL, _ := s.ttlForClient(client)
 	accessTokenResult, providerErr := s.tokenProvider.GenerateClientCredentialsToken(
 		ctx,
 		machineUserID,
 		clientID,
 		effectiveScopes,
+		ccTTL,
 	)
 	if providerErr != nil {
 		log.Printf(

--- a/internal/services/token_client_credentials_test.go
+++ b/internal/services/token_client_credentials_test.go
@@ -258,6 +258,55 @@ func TestIssueClientCredentialsToken_TokenPersisted(t *testing.T) {
 	assert.Equal(t, client.ClientID, result.ClientID)
 }
 
+// TestIssueClientCredentialsToken_IgnoresClientTokenProfile ensures M2M tokens
+// remain governed by CLIENT_CREDENTIALS_TOKEN_EXPIRATION even when the client
+// row declares a "short"/"long" TokenProfile. TokenProfile scopes user-delegated
+// tokens (device + authorization code flows); client_credentials is independent
+// so that M2M token lifetimes can be kept tight regardless of per-client
+// profile choices made for user-facing flows.
+func TestIssueClientCredentialsToken_IgnoresClientTokenProfile(t *testing.T) {
+	s := setupTestStore(t)
+	cfg := &config.Config{
+		JWTExpiration:                    10 * time.Hour,
+		RefreshTokenExpiration:           720 * time.Hour,
+		ClientCredentialsTokenExpiration: 30 * time.Minute,
+		JWTSecret:                        "test-secret",
+		BaseURL:                          "http://localhost:8080",
+		TokenProfiles: map[string]config.TokenProfile{
+			models.TokenProfileShort: {
+				AccessTokenTTL: 15 * time.Minute, RefreshTokenTTL: 24 * time.Hour,
+			},
+			models.TokenProfileStandard: {
+				AccessTokenTTL: 10 * time.Hour, RefreshTokenTTL: 720 * time.Hour,
+			},
+			models.TokenProfileLong: {
+				AccessTokenTTL: 24 * time.Hour, RefreshTokenTTL: 2160 * time.Hour,
+			},
+		},
+	}
+	localProvider, err := token.NewLocalTokenProvider(cfg)
+	require.NoError(t, err)
+	clientService := NewClientService(s, nil, nil, 0, nil, 0)
+	svc := NewTokenService(
+		s, cfg, nil, localProvider,
+		NewNoopAuditService(), metrics.NewNoopMetrics(),
+		cache.NewNoopCache[models.AccessToken](), clientService,
+	)
+
+	client, plainSecret := createConfidentialClientWithCCFlow(t, s, true)
+	client.TokenProfile = models.TokenProfileShort
+	require.NoError(t, s.UpdateClient(client))
+
+	tok, err := svc.IssueClientCredentialsToken(
+		context.Background(), client.ClientID, plainSecret, "",
+	)
+	require.NoError(t, err)
+
+	// Expires ~30m from now (CLIENT_CREDENTIALS_TOKEN_EXPIRATION), NOT ~15m
+	// from the short profile's AccessTokenTTL.
+	assert.WithinDuration(t, time.Now().Add(30*time.Minute), tok.ExpiresAt, 5*time.Second)
+}
+
 // --- Verify machine UserID prefix ---
 
 func TestIssueClientCredentialsToken_MachineUserIDPrefix(t *testing.T) {

--- a/internal/services/token_exchange.go
+++ b/internal/services/token_exchange.go
@@ -127,12 +127,22 @@ func (s *TokenService) ExchangeAuthorizationCode(
 	start := time.Now()
 	providerName := s.tokenProvider.Name()
 
+	// Load the client once and thread it through token-pair issuance so
+	// generateAndPersistTokenPair's TTL resolver doesn't do a second lookup.
+	// Failure here is surfaced to the caller — an auth code cannot be
+	// exchanged without its client record.
+	client, err := s.clientService.GetClient(ctx, authCode.ClientID)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
 	// Generate and persist token pair (linked to UserAuthorization for cascade-revoke)
 	accessToken, refreshToken, err := s.generateAndPersistTokenPair(ctx, tokenPairParams{
 		UserID:          authCode.UserID,
 		ClientID:        authCode.ClientID,
 		Scopes:          authCode.Scopes,
 		AuthorizationID: authorizationID,
+		Client:          client,
 	})
 	if err != nil {
 		return nil, nil, "", err

--- a/internal/services/token_exchange.go
+++ b/internal/services/token_exchange.go
@@ -63,6 +63,7 @@ func (s *TokenService) ExchangeDeviceCode(
 		UserID:   dc.UserID,
 		ClientID: dc.ClientID,
 		Scopes:   dc.Scopes,
+		Client:   client,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/internal/services/token_profile_test.go
+++ b/internal/services/token_profile_test.go
@@ -89,14 +89,41 @@ func TestResolveClientTTL_EmptyProfileDefaultsToStandard(t *testing.T) {
 	s := setupTestStore(t)
 	svc := createTestTokenService(t, s, cfg)
 
-	// A client with TokenProfile == "" (e.g. pre-migration row) must resolve
-	// to the "standard" preset, matching what the GORM default would apply.
+	// A client with TokenProfile == "" (e.g. pre-migration row) resolves to
+	// the "standard" preset. When standard mirrors the base JWT/refresh config
+	// (the common case) ttlForClient returns 0,0 so the local provider takes
+	// its default path — including JWT_EXPIRATION_JITTER. Any explicit per-
+	// client override (short/long) still produces a non-zero TTL.
 	client := createTestClientWithProfile(t, svc, "")
 
 	accessTTL, refreshTTL := svc.resolveClientTTL(context.Background(), client.ClientID)
-	standard := cfg.TokenProfiles[models.TokenProfileStandard]
-	assert.Equal(t, standard.AccessTokenTTL, accessTTL)
-	assert.Equal(t, standard.RefreshTokenTTL, refreshTTL)
+	assert.Equal(
+		t, time.Duration(0), accessTTL,
+		"standard profile matching base JWTExpiration returns 0 to preserve jitter",
+	)
+	assert.Equal(
+		t, time.Duration(0), refreshTTL,
+		"standard profile matching base RefreshTokenExpiration returns 0",
+	)
+}
+
+func TestResolveClientTTL_StandardProfileDivergentFromBaseConfig(t *testing.T) {
+	// When TOKEN_PROFILE_STANDARD_* is explicitly set to values that diverge
+	// from JWT_EXPIRATION / REFRESH_TOKEN_EXPIRATION, the profile TTL takes
+	// effect (admins have opted into a specific lifetime for the preset).
+	cfg := configWithTokenProfiles()
+	cfg.TokenProfiles[models.TokenProfileStandard] = config.TokenProfile{
+		AccessTokenTTL:  5 * time.Hour,
+		RefreshTokenTTL: 500 * time.Hour,
+	}
+	s := setupTestStore(t)
+	svc := createTestTokenService(t, s, cfg)
+
+	client := createTestClientWithProfile(t, svc, models.TokenProfileStandard)
+
+	accessTTL, refreshTTL := svc.resolveClientTTL(context.Background(), client.ClientID)
+	assert.Equal(t, 5*time.Hour, accessTTL, "divergent standard access TTL")
+	assert.Equal(t, 500*time.Hour, refreshTTL, "divergent standard refresh TTL")
 }
 
 func TestResolveClientTTL_UnknownClientFallsBackToZero(t *testing.T) {
@@ -143,7 +170,10 @@ func TestResolveClientTTL_ReflectsLatestProfileFromStore(t *testing.T) {
 	client := createTestClientWithProfile(t, svc, models.TokenProfileStandard)
 
 	accessTTL, _ := svc.resolveClientTTL(context.Background(), client.ClientID)
-	assert.Equal(t, 10*time.Hour, accessTTL, "initial profile is standard")
+	assert.Equal(
+		t, time.Duration(0), accessTTL,
+		"standard profile matching base config returns 0 to preserve jitter",
+	)
 
 	// Update profile and invalidate the cache the way UpdateClient would.
 	client.TokenProfile = models.TokenProfileShort

--- a/internal/services/token_profile_test.go
+++ b/internal/services/token_profile_test.go
@@ -126,6 +126,26 @@ func TestResolveClientTTL_StandardProfileDivergentFromBaseConfig(t *testing.T) {
 	assert.Equal(t, 500*time.Hour, refreshTTL, "divergent standard refresh TTL")
 }
 
+func TestResolveClientTTL_ShortProfileNeverZeroes(t *testing.T) {
+	// If an operator happens to configure TOKEN_PROFILE_SHORT_ACCESS_TTL equal
+	// to JWT_EXPIRATION, the short profile must still return an explicit TTL
+	// (no jitter) so the admin's "short" choice is honored precisely. Zeroing
+	// is a standard-only affordance to preserve jitter on the default path.
+	cfg := configWithTokenProfiles()
+	cfg.TokenProfiles[models.TokenProfileShort] = config.TokenProfile{
+		AccessTokenTTL:  cfg.JWTExpiration,          // intentionally equal to base
+		RefreshTokenTTL: cfg.RefreshTokenExpiration, // intentionally equal to base
+	}
+	s := setupTestStore(t)
+	svc := createTestTokenService(t, s, cfg)
+
+	client := createTestClientWithProfile(t, svc, models.TokenProfileShort)
+
+	accessTTL, refreshTTL := svc.resolveClientTTL(context.Background(), client.ClientID)
+	assert.Equal(t, cfg.JWTExpiration, accessTTL, "short profile must not be zeroed out")
+	assert.Equal(t, cfg.RefreshTokenExpiration, refreshTTL, "short profile must not be zeroed out")
+}
+
 func TestResolveClientTTL_UnknownClientFallsBackToZero(t *testing.T) {
 	cfg := configWithTokenProfiles()
 	s := setupTestStore(t)

--- a/internal/services/token_profile_test.go
+++ b/internal/services/token_profile_test.go
@@ -1,0 +1,160 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-authgate/authgate/internal/config"
+	"github.com/go-authgate/authgate/internal/models"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestClientWithProfile creates an active client seeded with the given
+// TokenProfile. The test helpers in device_test.go only support the common path,
+// so this mirrors them for token-profile-specific tests.
+func createTestClientWithProfile(
+	t *testing.T,
+	svc *TokenService,
+	profile string,
+) *models.OAuthApplication {
+	t.Helper()
+	client := &models.OAuthApplication{
+		ClientID:         uuid.New().String(),
+		ClientSecret:     "secret",
+		ClientName:       "Profile Test Client",
+		UserID:           uuid.New().String(),
+		Scopes:           "read write",
+		GrantTypes:       "device_code",
+		RedirectURIs:     models.StringArray{},
+		EnableDeviceFlow: true,
+		Status:           models.ClientStatusActive,
+		TokenProfile:     profile,
+	}
+	require.NoError(t, svc.store.CreateClient(client))
+	return client
+}
+
+// configWithTokenProfiles builds a *config.Config that defines the three named
+// profiles with distinctive TTL values so tests can assert which one was picked.
+func configWithTokenProfiles() *config.Config {
+	return &config.Config{
+		JWTSecret:                        "test-secret-that-is-at-least-32b",
+		JWTExpiration:                    10 * time.Hour, // standard default
+		RefreshTokenExpiration:           720 * time.Hour,
+		ClientCredentialsTokenExpiration: time.Hour,
+		BaseURL:                          "http://localhost:8080",
+		DeviceCodeExpiration:             30 * time.Minute,
+		PollingInterval:                  5,
+		TokenProfiles: map[string]config.TokenProfile{
+			models.TokenProfileShort: {
+				AccessTokenTTL:  15 * time.Minute,
+				RefreshTokenTTL: 24 * time.Hour,
+			},
+			models.TokenProfileStandard: {
+				AccessTokenTTL:  10 * time.Hour,
+				RefreshTokenTTL: 720 * time.Hour,
+			},
+			models.TokenProfileLong: {
+				AccessTokenTTL:  24 * time.Hour,
+				RefreshTokenTTL: 2160 * time.Hour,
+			},
+		},
+	}
+}
+
+func TestResolveClientTTL_UsesClientProfile(t *testing.T) {
+	cfg := configWithTokenProfiles()
+	s := setupTestStore(t)
+	svc := createTestTokenService(t, s, cfg)
+
+	shortClient := createTestClientWithProfile(t, svc, models.TokenProfileShort)
+	longClient := createTestClientWithProfile(t, svc, models.TokenProfileLong)
+
+	ctx := context.Background()
+	accessTTL, refreshTTL := svc.resolveClientTTL(ctx, shortClient.ClientID)
+	assert.Equal(t, 15*time.Minute, accessTTL, "short profile access TTL")
+	assert.Equal(t, 24*time.Hour, refreshTTL, "short profile refresh TTL")
+
+	accessTTL, refreshTTL = svc.resolveClientTTL(ctx, longClient.ClientID)
+	assert.Equal(t, 24*time.Hour, accessTTL, "long profile access TTL")
+	assert.Equal(t, 2160*time.Hour, refreshTTL, "long profile refresh TTL")
+}
+
+func TestResolveClientTTL_EmptyProfileDefaultsToStandard(t *testing.T) {
+	cfg := configWithTokenProfiles()
+	s := setupTestStore(t)
+	svc := createTestTokenService(t, s, cfg)
+
+	// A client with TokenProfile == "" (e.g. pre-migration row) must resolve
+	// to the "standard" preset, matching what the GORM default would apply.
+	client := createTestClientWithProfile(t, svc, "")
+
+	accessTTL, refreshTTL := svc.resolveClientTTL(context.Background(), client.ClientID)
+	standard := cfg.TokenProfiles[models.TokenProfileStandard]
+	assert.Equal(t, standard.AccessTokenTTL, accessTTL)
+	assert.Equal(t, standard.RefreshTokenTTL, refreshTTL)
+}
+
+func TestResolveClientTTL_UnknownClientFallsBackToZero(t *testing.T) {
+	cfg := configWithTokenProfiles()
+	s := setupTestStore(t)
+	svc := createTestTokenService(t, s, cfg)
+
+	// Returning 0,0 tells the provider to use its config default — a safe
+	// fallback for an issuance path with an unknown or deleted client.
+	accessTTL, refreshTTL := svc.resolveClientTTL(context.Background(), "nonexistent")
+	assert.Equal(t, time.Duration(0), accessTTL)
+	assert.Equal(t, time.Duration(0), refreshTTL)
+}
+
+func TestExchangeDeviceCode_HonorsShortProfile(t *testing.T) {
+	cfg := configWithTokenProfiles()
+	s := setupTestStore(t)
+	tokenService := createTestTokenService(t, s, cfg)
+
+	client := createTestClientWithProfile(t, tokenService, models.TokenProfileShort)
+	dc := createAuthorizedDeviceCode(t, s, client.ClientID)
+
+	access, refresh, err := tokenService.ExchangeDeviceCode(
+		context.Background(),
+		dc.DeviceCode,
+		client.ClientID,
+	)
+	require.NoError(t, err)
+
+	// The short profile is 15m access / 24h refresh — check within tolerance.
+	assert.WithinDuration(t, time.Now().Add(15*time.Minute), access.ExpiresAt, 5*time.Second)
+	assert.WithinDuration(t, time.Now().Add(24*time.Hour), refresh.ExpiresAt, 5*time.Second)
+}
+
+func TestResolveClientTTL_ReflectsLatestProfileFromStore(t *testing.T) {
+	// The refresh-token path re-calls resolveClientTTL at refresh time so that
+	// a profile change takes effect on the next issuance. This test bypasses
+	// the clientService cache (by using a fresh service with zero cache TTL
+	// via a cleared cache) to assert the resolver reads the up-to-date row.
+	cfg := configWithTokenProfiles()
+	s := setupTestStore(t)
+	svc := createTestTokenService(t, s, cfg)
+
+	client := createTestClientWithProfile(t, svc, models.TokenProfileStandard)
+
+	accessTTL, _ := svc.resolveClientTTL(context.Background(), client.ClientID)
+	assert.Equal(t, 10*time.Hour, accessTTL, "initial profile is standard")
+
+	// Update profile and invalidate the cache the way UpdateClient would.
+	client.TokenProfile = models.TokenProfileShort
+	require.NoError(t, s.UpdateClient(client))
+	svc.clientService.invalidateClientCache(context.Background(), client.ClientID)
+
+	accessTTL, _ = svc.resolveClientTTL(context.Background(), client.ClientID)
+	assert.Equal(
+		t,
+		15*time.Minute,
+		accessTTL,
+		"profile change is picked up after cache invalidation",
+	)
+}

--- a/internal/services/token_refresh.go
+++ b/internal/services/token_refresh.go
@@ -116,10 +116,16 @@ func (s *TokenService) RefreshAccessToken(
 		return nil, nil, token.ErrInvalidScope
 	}
 
-	// 6. Use provider to generate new tokens
+	// 6. Use provider to generate new tokens.
+	// Re-resolve TTLs at refresh time so that admin changes to the client's
+	// TokenProfile take effect immediately on the next refresh rather than
+	// being pinned to the TTL used when the original refresh token was issued.
+	accessTTL, refreshTTL := s.resolveClientTTL(ctx, refreshToken.ClientID)
 	refreshResult, providerErr := s.tokenProvider.RefreshAccessToken(
 		ctx,
 		refreshTokenString,
+		accessTTL,
+		refreshTTL,
 	)
 	if providerErr != nil {
 		log.Printf("[Token] Refresh failed provider=%s: %v", s.tokenProvider.Name(), providerErr)

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -226,6 +226,7 @@ func (s *Store) seedData(ctx context.Context, cfg *config.Config) error {
 			EnableAuthCodeFlow: true,
 			EnableDeviceFlow:   true,
 			Status:             models.ClientStatusActive,
+			TokenProfile:       models.TokenProfileStandard,
 		}
 		clientSecret, err := client.GenerateClientSecret(ctx)
 		if err != nil {

--- a/internal/templates/admin_client_detail.templ
+++ b/internal/templates/admin_client_detail.templ
@@ -57,6 +57,16 @@ templ AdminClientDetail(props ClientDetailPageProps) {
 							<div class="admin-detail-label">Grant Types</div>
 							<div class="admin-detail-value">{ props.Client.GrantTypes }</div>
 						</div>
+						<div class="admin-detail-row">
+							<div class="admin-detail-label">Token Lifetime</div>
+							<div class="admin-detail-value">
+								if props.Client.TokenProfile == "" {
+									standard
+								} else {
+									{ props.Client.TokenProfile }
+								}
+							</div>
+						</div>
 						if len(props.Client.RedirectURIs) > 0 {
 							<div class="admin-detail-row">
 								<div class="admin-detail-label">Redirect URIs</div>

--- a/internal/templates/admin_client_form.templ
+++ b/internal/templates/admin_client_form.templ
@@ -30,16 +30,16 @@ templ AdminClientForm(props ClientFormPageProps) {
 							<label for="token_profile" class="admin-form-label">Token Lifetime</label>
 							<select id="token_profile" name="token_profile" class="admin-form-select">
 								<option value={ models.TokenProfileShort } selected?={ props.Client != nil && props.Client.TokenProfile == models.TokenProfileShort }>
-									Short — 15 min access / 1 day refresh (high-security apps)
+									Short — shorter configured lifetimes (high-security apps)
 								</option>
 								<option value={ models.TokenProfileStandard } selected?={ props.Client == nil || props.Client.TokenProfile == "" || props.Client.TokenProfile == models.TokenProfileStandard }>
-									Standard — default access / 30 day refresh (typical web/SPA)
+									Standard — uses configured defaults (typical web/SPA)
 								</option>
 								<option value={ models.TokenProfileLong } selected?={ props.Client != nil && props.Client.TokenProfile == models.TokenProfileLong }>
-									Long — 24 hr access / 90 day refresh (CLI, IoT, background jobs)
+									Long — longer configured lifetimes (CLI, IoT, background jobs)
 								</option>
 							</select>
-							<small class="admin-form-hint">Controls how long access and refresh tokens remain valid for this client. Changes take effect for tokens issued after saving.</small>
+							<small class="admin-form-hint">Controls how long access and refresh tokens remain valid for this client. Actual durations depend on server configuration, and changes take effect for tokens issued after saving.</small>
 						</div>
 						<!-- Status (edit only) -->
 						if props.IsEdit {

--- a/internal/templates/admin_client_form.templ
+++ b/internal/templates/admin_client_form.templ
@@ -1,5 +1,7 @@
 package templates
 
+import "github.com/go-authgate/authgate/internal/models"
+
 templ AdminClientForm(props ClientFormPageProps) {
 	@Layout(props.Title, LayoutAdminNavbar, &props.NavbarProps) {
 		<div class="main-content">
@@ -23,6 +25,22 @@ templ AdminClientForm(props ClientFormPageProps) {
 							ShowClientCredentials: true,
 							ScopePresetsOnly:      false,
 						})
+						<!-- Token Profile -->
+						<div class="admin-form-group">
+							<label for="token_profile" class="admin-form-label">Token Lifetime</label>
+							<select id="token_profile" name="token_profile" class="admin-form-select">
+								<option value={ models.TokenProfileShort } selected?={ props.Client != nil && props.Client.TokenProfile == models.TokenProfileShort }>
+									Short — 15 min access / 1 day refresh (high-security apps)
+								</option>
+								<option value={ models.TokenProfileStandard } selected?={ props.Client == nil || props.Client.TokenProfile == "" || props.Client.TokenProfile == models.TokenProfileStandard }>
+									Standard — default access / 30 day refresh (typical web/SPA)
+								</option>
+								<option value={ models.TokenProfileLong } selected?={ props.Client != nil && props.Client.TokenProfile == models.TokenProfileLong }>
+									Long — 24 hr access / 90 day refresh (CLI, IoT, background jobs)
+								</option>
+							</select>
+							<small class="admin-form-hint">Controls how long access and refresh tokens remain valid for this client. Changes take effect for tokens issued after saving.</small>
+						</div>
 						<!-- Status (edit only) -->
 						if props.IsEdit {
 							<div class="admin-form-group">

--- a/internal/templates/props.go
+++ b/internal/templates/props.go
@@ -158,6 +158,7 @@ type ClientDisplay struct {
 	EnableAuthCodeFlow          bool
 	EnableClientCredentialsFlow bool
 	Status                      string // "pending", "active", "inactive"
+	TokenProfile                string // "short", "standard", or "long"
 	CreatedAt                   time.Time
 	UpdatedAt                   time.Time
 }

--- a/internal/token/local.go
+++ b/internal/token/local.go
@@ -276,14 +276,22 @@ func (p *LocalTokenProvider) keyFunc(token *jwt.Token) (any, error) {
 	return p.verifyKey, nil
 }
 
-// GenerateToken creates a JWT token using local signing
+// GenerateToken creates a JWT access token using local signing.
+// If ttl > 0 it overrides p.config.JWTExpiration and no jitter is applied
+// (the caller has chosen an explicit lifetime per client profile).
 func (p *LocalTokenProvider) GenerateToken(
 	ctx context.Context,
 	userID, clientID, scopes string,
+	ttl time.Duration,
 ) (*Result, error) {
-	expiry := p.config.JWTExpiration
-	if p.config.JWTExpirationJitter > 0 {
-		expiry += time.Duration(rand.Int64N(int64(p.config.JWTExpirationJitter)))
+	var expiry time.Duration
+	if ttl > 0 {
+		expiry = ttl
+	} else {
+		expiry = p.config.JWTExpiration
+		if p.config.JWTExpirationJitter > 0 {
+			expiry += time.Duration(rand.Int64N(int64(p.config.JWTExpirationJitter)))
+		}
 	}
 	expiresAt := time.Now().Add(expiry)
 	return p.generateJWT(userID, clientID, scopes, TokenCategoryAccess, expiresAt)
@@ -313,23 +321,34 @@ func (p *LocalTokenProvider) Name() string {
 	return "local"
 }
 
-// GenerateClientCredentialsToken creates an access token for the client_credentials grant
-// using its own configurable expiry (CLIENT_CREDENTIALS_TOKEN_EXPIRATION).
+// GenerateClientCredentialsToken creates an access token for the client_credentials grant.
+// If ttl > 0 it overrides the default CLIENT_CREDENTIALS_TOKEN_EXPIRATION.
 // The userID field carries the synthetic machine identity "client:<clientID>".
 func (p *LocalTokenProvider) GenerateClientCredentialsToken(
 	ctx context.Context,
 	userID, clientID, scopes string,
+	ttl time.Duration,
 ) (*Result, error) {
-	expiresAt := time.Now().Add(p.config.ClientCredentialsTokenExpiration)
+	expiry := ttl
+	if expiry <= 0 {
+		expiry = p.config.ClientCredentialsTokenExpiration
+	}
+	expiresAt := time.Now().Add(expiry)
 	return p.generateJWT(userID, clientID, scopes, TokenCategoryAccess, expiresAt)
 }
 
-// GenerateRefreshToken creates a refresh token JWT with longer expiration
+// GenerateRefreshToken creates a refresh token JWT. If ttl > 0 it overrides
+// the default REFRESH_TOKEN_EXPIRATION.
 func (p *LocalTokenProvider) GenerateRefreshToken(
 	ctx context.Context,
 	userID, clientID, scopes string,
+	ttl time.Duration,
 ) (*Result, error) {
-	expiresAt := time.Now().Add(p.config.RefreshTokenExpiration)
+	expiry := ttl
+	if expiry <= 0 {
+		expiry = p.config.RefreshTokenExpiration
+	}
+	expiresAt := time.Now().Add(expiry)
 	return p.generateJWT(userID, clientID, scopes, TokenCategoryRefresh, expiresAt)
 }
 
@@ -355,10 +374,14 @@ func (p *LocalTokenProvider) ValidateRefreshToken(
 	return result, nil
 }
 
-// RefreshAccessToken generates new access token (and optionally new refresh token in rotation mode)
+// RefreshAccessToken generates new access token (and optionally new refresh token in rotation mode).
+// accessTTL and refreshTTL override the default expirations when > 0, allowing
+// the caller (TokenService) to apply the client's current TokenProfile at
+// refresh time rather than reusing the TTL the original tokens were issued with.
 func (p *LocalTokenProvider) RefreshAccessToken(
 	ctx context.Context,
 	refreshToken string,
+	accessTTL, refreshTTL time.Duration,
 ) (*RefreshResult, error) {
 	enableRotation := p.config.EnableTokenRotation
 	// Validate the refresh token
@@ -373,6 +396,7 @@ func (p *LocalTokenProvider) RefreshAccessToken(
 		validationResult.UserID,
 		validationResult.ClientID,
 		validationResult.Scopes,
+		accessTTL,
 	)
 	if err != nil {
 		return nil, err
@@ -391,6 +415,7 @@ func (p *LocalTokenProvider) RefreshAccessToken(
 			validationResult.UserID,
 			validationResult.ClientID,
 			validationResult.Scopes,
+			refreshTTL,
 		)
 		if err != nil {
 			return nil, err

--- a/internal/token/local_test.go
+++ b/internal/token/local_test.go
@@ -72,6 +72,7 @@ func TestLocalTokenProvider_GenerateToken(t *testing.T) {
 		"user123",
 		"client456",
 		"read write",
+		0,
 	)
 
 	require.NoError(t, err)
@@ -99,6 +100,7 @@ func TestLocalTokenProvider_ValidateToken_Success(t *testing.T) {
 		"user123",
 		"client456",
 		"read write",
+		0,
 	)
 	require.NoError(t, err)
 
@@ -150,6 +152,7 @@ func TestLocalTokenProvider_ValidateToken_WrongSecret(t *testing.T) {
 		"user123",
 		"client456",
 		"read write",
+		0,
 	)
 	require.NoError(t, err)
 
@@ -185,6 +188,7 @@ func TestLocalTokenProvider_ValidateToken_ExpiredToken(t *testing.T) {
 		"user123",
 		"client456",
 		"read write",
+		0,
 	)
 	require.NoError(t, err)
 
@@ -238,6 +242,7 @@ func TestLocalTokenProvider_GenerateToken_VariousExpirations(t *testing.T) {
 				"user123",
 				"client456",
 				"read",
+				0,
 			)
 
 			require.NoError(t, err)
@@ -245,6 +250,44 @@ func TestLocalTokenProvider_GenerateToken_VariousExpirations(t *testing.T) {
 			assert.WithinDuration(t, expectedExpiry, result.ExpiresAt, 1*time.Second)
 		})
 	}
+}
+
+// An explicit ttl > 0 must override the config default and skip jitter so that
+// per-client TokenProfile values are honored exactly.
+func TestLocalTokenProvider_GenerateToken_TTLOverride(t *testing.T) {
+	cfg := &config.Config{
+		JWTSecret:           "test-secret-that-is-at-least-32b",
+		JWTExpiration:       10 * time.Hour,   // config default
+		JWTExpirationJitter: 30 * time.Minute, // jitter only applies to default
+		BaseURL:             "http://localhost:8080",
+	}
+	provider, err := NewLocalTokenProvider(cfg)
+	require.NoError(t, err)
+
+	// Explicit 15-minute TTL must be applied verbatim (no jitter, no config).
+	result, err := provider.GenerateToken(
+		context.Background(), "u", "c", "s", 15*time.Minute,
+	)
+	require.NoError(t, err)
+	expected := time.Now().Add(15 * time.Minute)
+	assert.WithinDuration(t, expected, result.ExpiresAt, 2*time.Second)
+}
+
+func TestLocalTokenProvider_GenerateRefreshToken_TTLOverride(t *testing.T) {
+	cfg := &config.Config{
+		JWTSecret:              "test-secret-that-is-at-least-32b",
+		JWTExpiration:          time.Hour,
+		RefreshTokenExpiration: 720 * time.Hour,
+		BaseURL:                "http://localhost:8080",
+	}
+	provider, err := NewLocalTokenProvider(cfg)
+	require.NoError(t, err)
+
+	result, err := provider.GenerateRefreshToken(
+		context.Background(), "u", "c", "s", 24*time.Hour,
+	)
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now().Add(24*time.Hour), result.ExpiresAt, 2*time.Second)
 }
 
 // ============================================================
@@ -263,7 +306,7 @@ func TestValidateToken_RejectsRefreshToken(t *testing.T) {
 
 	// Generate a refresh token
 	refreshResult, err := provider.GenerateRefreshToken(
-		context.Background(), "user1", "client1", "read",
+		context.Background(), "user1", "client1", "read", 0,
 	)
 	require.NoError(t, err)
 
@@ -313,7 +356,7 @@ func TestValidateRefreshToken_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	genResult, err := provider.GenerateRefreshToken(
-		context.Background(), "user1", "client1", "read write",
+		context.Background(), "user1", "client1", "read write", 0,
 	)
 	require.NoError(t, err)
 
@@ -339,7 +382,7 @@ func TestValidateRefreshToken_RejectsAccessToken(t *testing.T) {
 
 	// Generate an access token
 	accessResult, err := provider.GenerateToken(
-		context.Background(), "user1", "client1", "read",
+		context.Background(), "user1", "client1", "read", 0,
 	)
 	require.NoError(t, err)
 
@@ -363,7 +406,7 @@ func TestValidateRefreshToken_ExpiredReturnsRefreshError(t *testing.T) {
 	require.NoError(t, err)
 
 	genResult, err := provider.GenerateRefreshToken(
-		context.Background(), "user1", "client1", "read",
+		context.Background(), "user1", "client1", "read", 0,
 	)
 	require.NoError(t, err)
 
@@ -656,7 +699,7 @@ func TestLocalTokenProvider_RS256_GenerateAndValidate(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	result, err := provider.GenerateToken(context.Background(), "user1", "client1", "read write")
+	result, err := provider.GenerateToken(context.Background(), "user1", "client1", "read write", 0)
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.TokenString)
 
@@ -683,7 +726,7 @@ func TestLocalTokenProvider_ES256_GenerateAndValidate(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	result, err := provider.GenerateToken(context.Background(), "user2", "client2", "email")
+	result, err := provider.GenerateToken(context.Background(), "user2", "client2", "email", 0)
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.TokenString)
 
@@ -734,14 +777,14 @@ func TestLocalTokenProvider_HS256_BackwardCompatible(t *testing.T) {
 	require.NoError(t, err)
 
 	// Access token
-	result, err := provider.GenerateToken(context.Background(), "u1", "c1", "r")
+	result, err := provider.GenerateToken(context.Background(), "u1", "c1", "r", 0)
 	require.NoError(t, err)
 	valResult, err := provider.ValidateToken(context.Background(), result.TokenString)
 	require.NoError(t, err)
 	assert.True(t, valResult.Valid)
 
 	// Refresh token
-	refreshResult, err := provider.GenerateRefreshToken(context.Background(), "u1", "c1", "r")
+	refreshResult, err := provider.GenerateRefreshToken(context.Background(), "u1", "c1", "r", 0)
 	require.NoError(t, err)
 	refreshVal, err := provider.ValidateRefreshToken(
 		context.Background(),
@@ -775,7 +818,7 @@ func TestLocalTokenProvider_KidHeader(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	result, err := provider.GenerateToken(context.Background(), "user1", "client1", "read")
+	result, err := provider.GenerateToken(context.Background(), "user1", "client1", "read", 0)
 	require.NoError(t, err)
 
 	// Parse the raw JWT to inspect header
@@ -795,7 +838,7 @@ func TestLocalTokenProvider_HS256_NoKidHeader(t *testing.T) {
 	provider, err := NewLocalTokenProvider(cfg)
 	require.NoError(t, err)
 
-	result, err := provider.GenerateToken(context.Background(), "user1", "client1", "read")
+	result, err := provider.GenerateToken(context.Background(), "user1", "client1", "read", 0)
 	require.NoError(t, err)
 
 	parser := jwt.NewParser()
@@ -824,7 +867,7 @@ func TestLocalTokenProvider_RS256_CrossValidationFails(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	result, err := provider1.GenerateToken(context.Background(), "u", "c", "r")
+	result, err := provider1.GenerateToken(context.Background(), "u", "c", "r", 0)
 	require.NoError(t, err)
 
 	_, err = provider2.ValidateToken(context.Background(), result.TokenString)
@@ -846,7 +889,7 @@ func TestLocalTokenProvider_RS256_RefreshToken(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	refreshResult, err := provider.GenerateRefreshToken(context.Background(), "u1", "c1", "r")
+	refreshResult, err := provider.GenerateRefreshToken(context.Background(), "u1", "c1", "r", 0)
 	require.NoError(t, err)
 
 	valResult, err := provider.ValidateRefreshToken(context.Background(), refreshResult.TokenString)
@@ -855,7 +898,12 @@ func TestLocalTokenProvider_RS256_RefreshToken(t *testing.T) {
 	assert.Equal(t, "u1", valResult.UserID)
 
 	// RefreshAccessToken
-	refreshed, err := provider.RefreshAccessToken(context.Background(), refreshResult.TokenString)
+	refreshed, err := provider.RefreshAccessToken(
+		context.Background(),
+		refreshResult.TokenString,
+		0,
+		0,
+	)
 	require.NoError(t, err)
 	assert.NotNil(t, refreshed.AccessToken)
 	assert.NotNil(t, refreshed.RefreshToken, "rotation mode should produce new refresh token")
@@ -985,7 +1033,7 @@ func TestGenerateToken_WithJitter(t *testing.T) {
 
 	var expirations []time.Time
 	for range 20 {
-		result, err := provider.GenerateToken(context.Background(), "user1", "client1", "read")
+		result, err := provider.GenerateToken(context.Background(), "user1", "client1", "read", 0)
 		require.NoError(t, err)
 		assert.True(t, result.ExpiresAt.After(minExpiry) || result.ExpiresAt.Equal(minExpiry),
 			"ExpiresAt %v should be >= %v", result.ExpiresAt, minExpiry)
@@ -1015,7 +1063,7 @@ func TestGenerateToken_WithoutJitter(t *testing.T) {
 	provider, err := NewLocalTokenProvider(cfg)
 	require.NoError(t, err)
 
-	result, err := provider.GenerateToken(context.Background(), "user1", "client1", "read")
+	result, err := provider.GenerateToken(context.Background(), "user1", "client1", "read", 0)
 	require.NoError(t, err)
 	assert.WithinDuration(t, time.Now().Add(1*time.Hour), result.ExpiresAt, 5*time.Second)
 }
@@ -1031,7 +1079,13 @@ func TestGenerateRefreshToken_NotAffectedByJitter(t *testing.T) {
 	provider, err := NewLocalTokenProvider(cfg)
 	require.NoError(t, err)
 
-	result, err := provider.GenerateRefreshToken(context.Background(), "user1", "client1", "read")
+	result, err := provider.GenerateRefreshToken(
+		context.Background(),
+		"user1",
+		"client1",
+		"read",
+		0,
+	)
 	require.NoError(t, err)
 	// Refresh token should use RefreshTokenExpiration, not affected by JWTExpirationJitter
 	assert.WithinDuration(t, time.Now().Add(720*time.Hour), result.ExpiresAt, 5*time.Second)

--- a/internal/token/local_test.go
+++ b/internal/token/local_test.go
@@ -265,12 +265,14 @@ func TestLocalTokenProvider_GenerateToken_TTLOverride(t *testing.T) {
 	require.NoError(t, err)
 
 	// Explicit 15-minute TTL must be applied verbatim (no jitter, no config).
+	// Capture start before token generation so the assertion is robust on
+	// slower CI runners where time.Now() can drift between the two calls.
+	start := time.Now()
 	result, err := provider.GenerateToken(
 		context.Background(), "u", "c", "s", 15*time.Minute,
 	)
 	require.NoError(t, err)
-	expected := time.Now().Add(15 * time.Minute)
-	assert.WithinDuration(t, expected, result.ExpiresAt, 2*time.Second)
+	assert.WithinDuration(t, start.Add(15*time.Minute), result.ExpiresAt, 2*time.Second)
 }
 
 func TestLocalTokenProvider_GenerateRefreshToken_TTLOverride(t *testing.T) {
@@ -283,11 +285,12 @@ func TestLocalTokenProvider_GenerateRefreshToken_TTLOverride(t *testing.T) {
 	provider, err := NewLocalTokenProvider(cfg)
 	require.NoError(t, err)
 
+	start := time.Now()
 	result, err := provider.GenerateRefreshToken(
 		context.Background(), "u", "c", "s", 24*time.Hour,
 	)
 	require.NoError(t, err)
-	assert.WithinDuration(t, time.Now().Add(24*time.Hour), result.ExpiresAt, 2*time.Second)
+	assert.WithinDuration(t, start.Add(24*time.Hour), result.ExpiresAt, 2*time.Second)
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

- Add a `TokenProfile` field on `OAuthApplication` with three presets — `short` (15m/1d), `standard` (inherits `JWT_EXPIRATION` / `REFRESH_TOKEN_EXPIRATION`, default), and `long` (24h/90d) — selectable per client from the admin UI.
- Resolve the effective TTL at **every** user-delegated issuance (device code, authorization code, and refresh) so admin profile changes take effect on the next token issued rather than being pinned to whatever the client had when a refresh token was minted.
- `client_credentials` tokens are governed independently by `CLIENT_CREDENTIALS_TOKEN_EXPIRATION` and intentionally **ignore** `TokenProfile`; M2M tokens have a larger blast radius than user tokens and are kept short by default (`1h`). Per-client M2M TTLs would require a dedicated profile field.
- Enforce guardrails: `JWT_EXPIRATION_MAX` (default 24h) and `REFRESH_TOKEN_EXPIRATION_MAX` (default 90d) are validated at startup; any profile that exceeds them blocks boot.
- Unknown profile names on a client row (data corruption) are logged at WARNING and fall back to the standard profile's TTLs rather than silently granting base JWT lifetime.
- Profile changes are logged at `WARNING` severity in the audit log with a `previous_token_profile` field for diffability.

## Breaking change

The `core.TokenProvider` interface gained a trailing TTL parameter on its generation methods. External implementations need to update their signatures; the in-tree `LocalTokenProvider` is already updated. Passing `0` preserves the old behavior (use config default).

- `GenerateToken(ctx, userID, clientID, scopes, ttl)`
- `GenerateRefreshToken(ctx, userID, clientID, scopes, ttl)`
- `GenerateClientCredentialsToken(ctx, userID, clientID, scopes, ttl)`
- `RefreshAccessToken(ctx, refreshToken, accessTTL, refreshTTL)`

## Configuration

New env vars (all optional — sensible defaults applied):

```
JWT_EXPIRATION_MAX=24h
REFRESH_TOKEN_EXPIRATION_MAX=2160h
TOKEN_PROFILE_SHORT_ACCESS_TTL=15m
TOKEN_PROFILE_SHORT_REFRESH_TTL=24h
TOKEN_PROFILE_STANDARD_ACCESS_TTL=   # defaults to JWT_EXPIRATION
TOKEN_PROFILE_STANDARD_REFRESH_TTL=  # defaults to REFRESH_TOKEN_EXPIRATION
TOKEN_PROFILE_LONG_ACCESS_TTL=24h
TOKEN_PROFILE_LONG_REFRESH_TTL=2160h
```

## Jitter semantics

`JWT_EXPIRATION_JITTER` applies only when the resolved access-token TTL is `0` (i.e. the `standard` profile exactly mirrors the base `JWT_EXPIRATION`). Explicit `short` / `long` overrides — and a `standard` profile that has been diverged from base config — use their TTL verbatim with no jitter, so the admin's profile choice is honored precisely.

## Test plan

- [ ] `make lint` — 0 issues
- [ ] `make test` — all packages pass, including new coverage in `internal/models/oauth_application_test.go`, `internal/config/config_test.go`, `internal/token/local_test.go`, and `internal/services/token_profile_test.go`
- [ ] Create an OAuth client in the admin UI, set **Token Lifetime = Short**, complete the device code flow, confirm the issued access token expires in ~15 min
- [ ] Edit the same client to **Long**, refresh the access token, confirm the new token uses the 24h TTL (profile change takes effect on next refresh)
- [ ] Enable Client Credentials Flow on a confidential client with `TokenProfile=long`, issue a client_credentials token, confirm it still expires per `CLIENT_CREDENTIALS_TOKEN_EXPIRATION` (default 1h) — profile is ignored for M2M
- [ ] Set a profile's TTL above the cap via env var; confirm the server fails to start with the expected error
- [ ] Existing integration flows (GitHub/Gitea/Microsoft OAuth login, refresh-token rotation) remain green — covered by the service test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
